### PR TITLE
Better Check Name for Errors when Validating a VC

### DIFF
--- a/packages/learn-card-core/src/wallet/verify.ts
+++ b/packages/learn-card-core/src/wallet/verify.ts
@@ -3,6 +3,12 @@ import { format } from 'date-fns';
 
 import { LearnCardRawWallet } from 'types/LearnCard';
 
+const transformErrorCheck = (error: string, _credential: VC): string => {
+    const prefix = error.split(' error')[0];
+
+    return prefix || error;
+};
+
 const transformErrorMessage = (error: string, credential: VC): string => {
     if (error.startsWith('expiration')) {
         return credential.expirationDate
@@ -41,7 +47,7 @@ export const verifyCredential = (
         rawVerificationCheck.errors.forEach(error => {
             verificationItems.push({
                 status: VerificationStatusEnum.Failed,
-                check: 'hmm',
+                check: transformErrorCheck(error, credential),
                 details: transformErrorMessage(error, credential),
             });
         });


### PR DESCRIPTION
This PR updates the `verifyCredential` function to provide a better `check` name when there is an error. Existing behavior is just the string `hmm`. I still need to do this for warnings!

To test this, add a wallet to the window object in browser dev tools and run the following code:

```ts
const vc = await wallet.issueCredential(wallet.getTestVc());
vc.expirationDate = '2022-06-10T18:26:57.687Z';
console.log(await wallet.verifyCredential(vc));
```

Before this PR, the errors will have `check: 'hmm'`. After, those checks will have better strings (`signature`, and `expiration`)