### PR TITLE
Validate Key passed in to DID Key plugin

### DIFF
--- a/packages/learn-card-core/src/wallet/plugins/didkey/index.ts
+++ b/packages/learn-card-core/src/wallet/plugins/didkey/index.ts
@@ -9,7 +9,9 @@ const isHex = (str: string) => /^[0-9a-f]+$/i.test(str);
 export const getDidKeyPlugin = async (
     key: string
 ): Promise<Plugin<'DID Key', DidKeyPluginMethods>> => {
+    if (key.length === 0) throw new Error("Please don't use an empty string for a key!");
     if (!isHex(key)) throw new Error('Key must be a hexadecimal string!');
+    if (key.length > 64) throw new Error('Key must be less than 64 characters');
 
     const keypair = JSON.parse(generateEd25519KeyFromBytes(toUint8Array(key.padStart(64, '0'))));
     const did = keyToDID('key', JSON.stringify(keypair));


### PR DESCRIPTION
When passing in a key string to generate key material, the string needs to be a (up to) 64 character hex string! I actually didn't realize this before and thought you could pass in whatever you want (including emojis), but it turns out that anything that isn't valid hex (i.e. z, 🤔, Q, etc) was just implicitly converted into a zero. You can test this by attaching `walletFromKey` to the window object in browser dev tools and running 

```js
(await walletFromKey('z')).did === (await walletFromKey('0')).did
```

Before this PR, that will be true. After this PR, the first statement will throw an error!

I also added length validation to this PR. There was already implicit length validation coming from did kit if you passed in a string that was longer than 64 characters, but this PR adds a nicer error message for that, and also checks that you didn't just pass in an empty string!