### PR TITLE
Tighten Keypair Types

### DIFF
--- a/packages/learn-card-core/src/types/LearnCard.ts
+++ b/packages/learn-card-core/src/types/LearnCard.ts
@@ -8,7 +8,7 @@ import { InitInput } from 'didkit';
 
 import { UnlockedWallet } from 'types/wallet';
 
-// export * from '@learncard/types';
+export * from '@learncard/types';
 
 export type LearnCardRawWallet = UnlockedWallet<
     'DID Key' | 'VC' | 'IDX' | 'Expiration',
@@ -24,7 +24,7 @@ export type LearnCardWallet = {
     /** Wallet holder's did */
     did: string;
     /** Wallet holder's ed25519 key pair */
-    keypair: Record<string, string>;
+    keypair: { kty: string; crv: string; x: string; d: string };
 
     /** Signs an unsigned Verifiable Credential, returning the signed VC */
     issueCredential: (credential: UnsignedVC) => Promise<VC>;

--- a/packages/learn-card-core/src/wallet/plugins/didkey/types.ts
+++ b/packages/learn-card-core/src/wallet/plugins/didkey/types.ts
@@ -15,6 +15,6 @@ export type JWK = {
 
 export type DidKeyPluginMethods = {
     getSubjectDid: () => string;
-    getSubjectKeypair: () => Record<string, string>;
+    getSubjectKeypair: () => { kty: string; crv: string; x: string; d: string };
     getKey: () => string;
 };


### PR DESCRIPTION
This just adds a tiny change that updates the types of the wallet's keypair from a generic record object to the more specific shape that gets exposed. I also re-added exporting all the types from learn card types. I'm not sure when that got commented out 😳