### PR TITLE
feat: WE-2215 - LearnCard Discord Bot Tools

### DIFF
--- a/services/learn-card-discord-bot/README.md
+++ b/services/learn-card-discord-bot/README.md
@@ -1,18 +1,30 @@
-### LearnCard Discord Bot 
+### LearnCard Discord Bot
 
-To get started:
+For documentation on using the LearnCard Discord Bot, check out the official docs:
+https://docs.learncard.com/learncard-services/discord-bot
 
+## To run your own bot:
 
 Add a `.env` file to root of project, and include the following keys:
 
 ```
-DISCORD_TOKEN=<TOKEN>
-SEED=<WALLET SEED>
+DISCORD_TOKEN=<token>
+SEED=<wallet_seed>
+REDIS_HOST=<redis_host>
+REDIS_PORT=<redis_port>
+REDIS_PW=<redis_pw>
 ```
 
 Run:
 
 ```
 pnpm build
-pnpm start 
+pnpm start
+```
+
+Or:
+
+```
+ docker build -t learn-card-discord-bot .
+ docker run --restart unless-stopped learn-card-discord-bot
 ```

--- a/services/learn-card-discord-bot/src/commands/FinishConnectID.ts
+++ b/services/learn-card-discord-bot/src/commands/FinishConnectID.ts
@@ -61,7 +61,7 @@ export const FinishConnectIDModal = {
             return;
         }
 
-        const domain = 'discord://auth.learncard.com';
+        const domain = 'discord-bot.learncard.com';
         let vp;
 
         try {

--- a/services/learn-card-discord-bot/src/commands/StartConnectID.ts
+++ b/services/learn-card-discord-bot/src/commands/StartConnectID.ts
@@ -24,7 +24,7 @@ export const StartConnectID: Command = {
             context
         );
 
-        const authLink = `https://learncard.app/did-auth/${challenge}?domain=discord://auth.learncard.com`;
+        const authLink = `https://learncard.app/did-auth/${challenge}?domain=discord-bot.learncard.com`;
 
         if (existingDID) {
             await interaction.reply({

--- a/services/learn-card-discord-bot/src/listeners/ready.ts
+++ b/services/learn-card-discord-bot/src/listeners/ready.ts
@@ -9,9 +9,6 @@ export default async ({ client }: Context): Promise<void> => {
             return;
         }
         await client.application.commands.set(Commands);
-
-        // console.log(await constructTallyMessage(client, "944320393169215498"));
-
         console.log(`${client.user.username} is online`);
     });
 };


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1z1jVDt2yNG9zDlatcw2KHQcCrHl33U%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=rNf-hP5)
# Overview

#### 🎟 Relevant Jira Issues
[WE-2215](https://welibrary.atlassian.net/browse/WE-2215?atlOrigin=eyJpIjoiZDVjZGI1ZDkxOWI1NDMwNmI2OGVjYzkzOGU3MjY0ZWQiLCJwIjoiaiJ9)

#### 📚 What is the context and goal of this PR?

For Ed3DAO (and other use cases), we need a lightweight way to enable these communities to start issuing credentials with learn-card. Plus, this is a great demonstration of interop, and gets us to a useful e2e demonstration of issuing credentials in a community, and receiving them using learncard app (with deep links =>  https://github.com/WeLibraryOS/learncardapp/pull/17)

#### 🥴 TL; RL:

Adds a new `/services` folder with a Discord bot for issuing and receiving VCs from Discord.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

https://www.figma.com/file/GXdWuHAdQrHH5GdNS8vvGQ/LearnCard-Discord-Bot?node-id=0%3A1

**Overview of Discord bot Logic:**
<img width="1503" alt="Screen Shot 2022-07-29 at 11 33 10 AM" src="https://user-images.githubusercontent.com/2185016/181793847-eb0d7443-0a9c-4b0a-84e8-eea087b384eb.png">

The LearnCard bot has a few initial commands:

<img width="1043" alt="Screen Shot 2022-07-29 at 11 35 01 AM" src="https://user-images.githubusercontent.com/2185016/181794186-fe15793c-e9d8-4fdf-bef5-06effbec626b.png">


** How this fits with the LearnCard App:**
<img width="1527" alt="Screen Shot 2022-07-29 at 11 33 24 AM" src="https://user-images.githubusercontent.com/2185016/181793905-c39d03ec-9aaf-494d-a19b-fa5d6d6a8614.png">


#### 🛠 Important tradeoffs made:

This does not yet implement 1st class support for 3rd party interoperable wallets via vc-api & chapi.

Additionally, this PR gates permissions based on manage server, but does not take advantage of Command permissions system that discord has enabled support for granular permissions control.

https://discord.com/blog/welcome-to-the-new-era-of-discord-apps?ref=badge
https://discordjs.guide/slash-commands/permissions.html#slash-command-permissions

Also, I am having issues with the dockerfile <> pnpm <> heroku deploy with the monorepo/pnpm workspaces setup. Currently, I put the dockerfile & heroku yml in the root directory, which is not ideal.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

Create a `.env` file with the following variables (contact @Custard7 for sensitive data): 
```
DISCORD_TOKEN=<token>
SEED=<wallet_seed>
REDIS_HOST=<redis_host>
REDIS_PORT=<redis_port>
REDIS_PW=<redis_pw>
```

 `cd /services/learn-card-discord-bot`
`pnpm install`
`pnpm build`
`pnpm start`

You should see the following:

<img width="743" alt="Screen Shot 2022-07-29 at 11 38 11 AM" src="https://user-images.githubusercontent.com/2185016/181794744-47b2f722-8e8d-4fe2-aed0-7cc3b5048a66.png">

Then, go to our discord server (join here: https://discord.gg/dfWUAKTf ) and ask myself, @NTonani or @TaylorBeeston to give you the Core-Team / Contributor roles. Then go to the experimentation channel: https://discord.com/channels/992154221740822630/998986619300360374

If all is good at this point, you should be able to slash-command: `/issue-test-credential`:

<img width="1001" alt="Screen Shot 2022-07-29 at 11 43 53 AM" src="https://user-images.githubusercontent.com/2185016/181795734-881a3ffd-fa2c-4fe3-bce9-390c621af3da.png">

Meanwhile, I recommend opening a new terminal, and opening up [`learn-card-cli`](https://github.com/WeLibraryOS/LearnCard/tree/main/packages/learn-card-cli):

<img width="886" alt="Screen Shot 2022-07-29 at 11 41 13 AM" src="https://user-images.githubusercontent.com/2185016/181795241-95f89349-dd27-4cb6-9ab6-2edce3424888.png">

Call `wallet.did('key')` and copy-paste the did:key:asjdhf that you get into the following slash command back in Discord:

`/register-did` - <paste-did-here> @<your-username>

<img width="881" alt="Screen Shot 2022-07-29 at 11 42 50 AM" src="https://user-images.githubusercontent.com/2185016/181795519-54a96a25-c5c3-4f2d-bcd4-55abac80f364.png">

You should see the following message if it was successful:

<img width="464" alt="Screen Shot 2022-07-29 at 11 43 06 AM" src="https://user-images.githubusercontent.com/2185016/181795564-5c5648b0-225f-4e56-91be-4275f07f107a.png">

You should then be able to call slash-command `/add-credential` and fill out the Credential form:

<img width="445" alt="Screen Shot 2022-07-29 at 11 44 24 AM" src="https://user-images.githubusercontent.com/2185016/181795838-93d00ab0-6a81-4054-b532-43a6b647aeed.png">

Then call `/list-credentials` to see a list of credential templates you (and others) have stored:

<img width="371" alt="Screen Shot 2022-07-29 at 11 44 58 AM" src="https://user-images.githubusercontent.com/2185016/181795934-cc163b4b-8288-4482-88d7-47ccb7adc333.png">

Then call /`send-credential` @<your-username>
Then select the credential template you created:

<img width="642" alt="Screen Shot 2022-07-29 at 11 45 47 AM" src="https://user-images.githubusercontent.com/2185016/181796086-5843c281-1395-409a-82c2-965c98a8b32c.png">

You should then **receive a PERSONAL DM** like this!! 🎉 

<img width="1004" alt="Screen Shot 2022-07-29 at 11 45 59 AM" src="https://user-images.githubusercontent.com/2185016/181796126-da07d292-ef5d-44d6-9864-e53fb1760d2b.png">

Which has the ceramic `streamId`!!! That you should be able to call `wallet.addCredential({ id: streamId, title: 'My Cred'}) on! 🎉  

`https://learncard.app/claim-credential/kjzl6cwe1jw14907y2nrk9bkpmx9zq4n9npkljcobf50sx92ebhhpkuxb7k66qi`

^ @gerardopar @goblincore @TaylorBeeston this is what should deep link into LearnCard app and initiate the claim credential flow!!!! Then we are in business folks! 🎉 

#### 📱 🖥 Which devices would you like help testing on?
Any device discord runs on I suppose!

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
None yet.

# Documentation

#### 📜 Gitbook

https://app.gitbook.com/o/6uDv1QDlxaaZC7i8EaGb/s/FXvEJ9j3Vf3FW5Nc557n/~/changes/fO3QQjo3GYUMoEezOhAi/learncard-services/discord-bot

# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
