### PR TITLE
Add additional prop to job listing card to override with custom button component

### DIFF
--- a/.changeset/honest-buses-own.md
+++ b/.changeset/honest-buses-own.md
@@ -1,0 +1,5 @@
+---
+"@learncard/react": patch
+---
+
+Add additional prop to job listing card to override with custom button component

--- a/packages/react-learn-card/src/components/JobListCard/JobListCard.stories.tsx
+++ b/packages/react-learn-card/src/components/JobListCard/JobListCard.stories.tsx
@@ -25,6 +25,12 @@ const dummyQualificationDisplay = {
     },
 };
 
+const customButtonTest = (
+    <button type="button" onClick={() => console.log('custom button clicked')}>
+        BUTTON TEST{' '}
+    </button>
+);
+
 const Template: Story<JobListCardProps> = args => <JobListCard {...args} />;
 
 export const JobListCardTest = Template.bind({});

--- a/packages/react-learn-card/src/components/JobListCard/JobListCard.tsx
+++ b/packages/react-learn-card/src/components/JobListCard/JobListCard.tsx
@@ -51,6 +51,7 @@ export const JobListCard: React.FC<JobListCardProps> = ({
     qualificationDisplay,
     percentQualifiedDisplay,
     postDateDisplay,
+    customButtonComponent,
     imgThumb,
     isBookmarked,
     onBookmark,
@@ -62,15 +63,18 @@ export const JobListCard: React.FC<JobListCardProps> = ({
 
     const courseCountDisplay =
         courseReqCount &&
-        `${qualificationDisplay?.courses?.fulfilledCount ?? 0}/${qualificationDisplay?.courses?.totalRequiredCount ?? 0
+        `${qualificationDisplay?.courses?.fulfilledCount ?? 0}/${
+            qualificationDisplay?.courses?.totalRequiredCount ?? 0
         }`;
     const achievementsCountDisplay =
         achievementsReqCount &&
-        `${qualificationDisplay?.achievements?.fulfilledCount ?? 0}/${qualificationDisplay?.achievements?.totalRequiredCount ?? 0
+        `${qualificationDisplay?.achievements?.fulfilledCount ?? 0}/${
+            qualificationDisplay?.achievements?.totalRequiredCount ?? 0
         }`;
     const skillsCountDisplay =
         skillsReqCount &&
-        `${qualificationDisplay?.skills?.fulfilledCount ?? 0}/${qualificationDisplay?.skills?.totalRequiredCount ?? 0
+        `${qualificationDisplay?.skills?.fulfilledCount ?? 0}/${
+            qualificationDisplay?.skills?.totalRequiredCount ?? 0
         }`;
 
     const qualifiedText = percentQualifiedDisplay
@@ -86,6 +90,18 @@ export const JobListCard: React.FC<JobListCardProps> = ({
     if (!location && locationRequirement) locationText = locationRequirement;
     if (!locationRequirement && location) locationText = location;
     if (locationRequirement && location) locationText = `${locationRequirement} • ${location}`;
+
+    const defaultButton = (
+        <button
+            type="button"
+            onClick={onClick}
+            className="mt-[10px] bg-cyan-700 py-[15px] px-[2px] rounded-[40px] text-grayscale-50 text-[17px] font-bold"
+        >
+            {qualifiedText}
+        </button>
+    );
+
+    const buttonComponent = customButtonComponent ? customButtonComponent : defaultButton;
 
     return (
         <div
@@ -138,13 +154,7 @@ export const JobListCard: React.FC<JobListCardProps> = ({
                 </div>
             </div>
 
-            <button
-                type="button"
-                onClick={onClick}
-                className="mt-[10px] bg-cyan-700 py-[15px] px-[2px] rounded-[40px] text-grayscale-50 text-[17px] font-bold"
-            >
-                {qualifiedText}
-            </button>
+            {buttonComponent}
         </div>
     );
 };

--- a/packages/react-learn-card/src/types/index.ts
+++ b/packages/react-learn-card/src/types/index.ts
@@ -173,6 +173,7 @@ export type JobQualificationDisplay = {
 
 export type JobListCardProps = {
     title?: string;
+    customButtonComponent?: React.ReactNode;
     company?: string;
     compensation?: string;
     location?: string;


### PR DESCRIPTION
# Overview


This adds a prop `customButtonComponent` to allow to pass a React node into where the current button is to make it more customizable.

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [ ] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
