### PR TITLE
Feat: Add Draft / Live state to Boosts

### DIFF
--- a/.changeset/sour-bulldogs-sit.md
+++ b/.changeset/sour-bulldogs-sit.md
@@ -1,0 +1,25 @@
+---
+"@learncard/types": patch
+"@learncard/network-plugin": minor
+"@learncard/network-brain-service": minor
+---
+
+### Feat: Add Draft / Live state to Boosts
+
+This introduces a new `status` field on boosts, currently supporting:
+
+```
+LIVE 
+DRAFT
+```
+
+`LIVE` status indicates the boost is published and can be sent to others. Live Boosts can not be updated or deleted.
+`DRAFT` status indicates the boost is in draft state. It can not be sent to others. Draft boosts can be updated and deleted.
+
+#### Major Changes:
+
+- updateBoost (in the LCN plugin) now supports an additional `credential` field that allows you to pass through a new base credential template for the boost
+- updateBoost allows you to pass a status field in, that can flip the status of a boost from DRAFT to LIVE.
+- adds support for deleting draft boosts (and preventing deleting live boosts)
+- adds support for updating draft boosts (and preventing updating live boosts)
+- prevents sending draft boosts, or creating claim links for draft boosts

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -28,11 +28,19 @@ export const SentCredentialInfoValidator = z.object({
 });
 export type SentCredentialInfo = z.infer<typeof SentCredentialInfoValidator>;
 
+export const LCNBoostStatus = z.enum([
+    'DRAFT',
+    'LIVE',
+]);
+export type LCNBoostStatusEnum = z.infer<typeof LCNBoostStatus>;
+
+
 export const BoostValidator = z.object({
     uri: z.string(),
     name: z.string().optional(),
     type: z.string().optional(),
     category: z.string().optional(),
+    status: LCNBoostStatus.optional()
 });
 export type Boost = z.infer<typeof BoostValidator>;
 

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -319,10 +319,10 @@ export const getLearnCardNetworkPlugin = async (
 
                 return client.boost.getBoostRecipients.query({ uri, limit, skip });
             },
-            updateBoost: async (_learnCard, uri, updates) => {
+            updateBoost: async (_learnCard, uri, updates, credential) => {
                 if (!userData) throw new Error('Please make an account first!');
 
-                return client.boost.updateBoost.mutate({ uri, updates });
+                return client.boost.updateBoost.mutate({ uri, updates: { credential, ...updates } });
             },
             deleteBoost: async (_learnCard, uri) => {
                 if (!userData) throw new Error('Please make an account first!');

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -72,7 +72,7 @@ export type LearnCardNetworkPluginMethods = {
         limit?: number,
         skip?: number
     ) => Promise<BoostRecipientInfo[]>;
-    updateBoost: (uri: string, updates: Partial<Omit<Boost, 'uri'>>) => Promise<boolean>;
+    updateBoost: (uri: string, updates: Partial<Omit<Boost, 'uri'>>, credential: UnsignedVC | VC) => Promise<boolean>;
     deleteBoost: (uri: string) => Promise<boolean>;
     sendBoost: (profileId: string, boostUri: string, encrypt?: boolean) => Promise<string>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,7 +655,7 @@ importers:
       '@changesets/changelog-github': ^0.4.5
       '@changesets/cli': ^2.23.0
       '@learncard/core': 8.5.4
-      '@learncard/types': 5.2.4
+      '@learncard/types': 5.2.5
       '@rollup/plugin-json': ^4.1.0
       '@types/cors': ^2.8.12
       '@types/figlet': ^1.5.4

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/create.ts
@@ -2,7 +2,8 @@ import { UnsignedVC, VC } from '@learncard/types';
 import { v4 as uuid } from 'uuid';
 
 import { Boost, BoostInstance, ProfileInstance } from '@models';
-import { BoostType } from 'types/boost';
+import { BoostStatus, BoostType } from 'types/boost';
+import { convertCredentialToBoostTemplateJSON } from '@helpers/boost.helpers';
 
 export const createBoost = async (
     credential: UnsignedVC | VC,
@@ -11,24 +12,12 @@ export const createBoost = async (
 ): Promise<BoostInstance> => {
     const id = uuid();
 
-    const template = { ...credential };
-
-    delete template.proof;
-    template.issuer = 'did:example:123';
-
-    if (Array.isArray(template.credentialSubject)) {
-        template.credentialSubject = template.credentialSubject.map(subject => {
-            subject.id = 'did:example:123';
-
-            return subject;
-        });
-    } else {
-        template.credentialSubject.id = 'did:example:123';
-    }
+    const { status = BoostStatus.enum.LIVE } = metadata;
 
     return Boost.createOne({
         id,
-        boost: JSON.stringify(template),
+        boost: convertCredentialToBoostTemplateJSON(credential),
+        status,
         ...metadata,
         createdBy: {
             where: {

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -14,6 +14,7 @@ import { getCredentialUri } from './credential.helpers';
 import { getLearnCard } from './learnCard.helpers';
 import { issueCredentialWithSigningAuthority } from './signingAuthority.helpers';
 import { sendNotification } from './notifications.helpers';
+import { BoostStatus } from 'types/boost';
 
 export const getBoostUri = (id: string, domain: string): string =>
     constructUri('boost', id, domain);
@@ -26,6 +27,28 @@ export const isProfileBoostOwner = async (
 
     return owner?.profileId === profile.profileId;
 };
+
+export const isDraftBoost = (boost: BoostInstance): boolean => {
+    return boost.status === BoostStatus.enum.DRAFT; 
+}
+
+export const convertCredentialToBoostTemplateJSON = (credential: VC | UnsignedVC): string => {
+    const template = { ...credential };
+
+    delete template.proof;
+    template.issuer = 'did:example:123';
+
+    if (Array.isArray(template.credentialSubject)) {
+        template.credentialSubject = template.credentialSubject.map(subject => {
+            subject.id = 'did:example:123';
+
+            return subject;
+        });
+    } else {
+        template.credentialSubject.id = 'did:example:123';
+    }
+    return JSON.stringify(template);
+}
 
 export const verifyCredentialIsDerivedFromBoost = async (
     boost: BoostInstance,

--- a/services/learn-card-network/brain-service/src/models/Boost.ts
+++ b/services/learn-card-network/brain-service/src/models/Boost.ts
@@ -3,7 +3,7 @@ import { ModelFactory, ModelRelatedNodesI, NeogmaInstance } from 'neogma';
 import { neogma } from '@instance';
 
 import { Profile, ProfileInstance } from './Profile';
-import { BoostType } from 'types/boost';
+import { BoostType, BoostStatus } from 'types/boost';
 
 export type BoostRelationships = {
     createdBy: ModelRelatedNodesI<
@@ -25,6 +25,7 @@ export const Boost = ModelFactory<BoostType, BoostRelationships>(
             type: { type: 'string' },
             category: { type: 'string' },
             boost: { type: 'string', required: true },
+            status: { type: 'string', enum: BoostStatus.options }
         },
         primaryKeyField: 'id',
         relationships: {

--- a/services/learn-card-network/brain-service/src/types/boost.ts
+++ b/services/learn-card-network/brain-service/src/types/boost.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { BoostValidator as _BoostValidator, LCNBoostClaimLinkSigningAuthorityValidator, LCNBoostClaimLinkSigningAuthorityType, LCNBoostClaimLinkOptionsValidator, LCNBoostClaimLinkOptionsType } from '@learncard/types';
+import { BoostValidator as _BoostValidator, LCNBoostClaimLinkSigningAuthorityValidator, LCNBoostClaimLinkSigningAuthorityType, LCNBoostClaimLinkOptionsValidator, LCNBoostClaimLinkOptionsType, LCNBoostStatus, LCNBoostStatusEnum } from '@learncard/types';
+
+export const BoostStatus = LCNBoostStatus;
+export type BoostStatusEnum = LCNBoostStatusEnum;
 
 export const BoostValidator = _BoostValidator.omit({ uri: true }).extend({
     id: z.string(),

--- a/services/meta-mask-snap/snap.manifest.json
+++ b/services/meta-mask-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/WeLibraryOS/LearnCard.git"
   },
   "source": {
-    "shasum": "p9VamRHE3R0mNuonSsjOlOj47uaUVMG/G8NFg50xGVE=",
+    "shasum": "QFDSxjK92lky0JLaBlwha+/xxjVx8RuhFQdKE0ObigY=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

We need a clear delineation between boosts that are being created, and boosts that have been vacuum-sealed and ready to send to people!

#### 🥴 TL; RL:

This introduces a new `status` field on boosts, currently supporting:

```
LIVE 
DRAFT
```
Live status indicates the boost is published and can be sent to others. Live Boosts can not be updated or deleted.
Draft status indicates the boost is in draft state. It can not be sent to others. Draft boosts can be updated and deleted.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- updateBoost (in the LCN plugin) now supports an additional `credential` field that allows you to pass through a new base credential template for the boost
- updateBoost allows you to pass a status field in, that can flip the status of a boost from DRAFT to LIVE.
- adds support for deleting draft boosts (and preventing deleting live boosts)
- adds support for updating draft boosts (and preventing updating live boosts)
- prevents sending draft boosts, or creating claim links for draft boosts

#### 🛠 Important tradeoffs made:

I didn't make the status field required for boosts. Any boost without an explicit status, is presumed, implicitly, to be `LIVE` status.

I chose to make the status field an enum instead of a boolean, so we could support additional states in the future, such as ARCHIVED, for boosts that have been published, but the owner no longer wants to see them in their managed section (but also, not deleting them from the record). Or, possibly, a PENDING_PUBLISH status, that could be a timed release of the boost. Such future states are fully supported by enum status over binary boolean draft state.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
