### PR TITLE
Return all Boost Recipients

### DIFF
--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -43,7 +43,7 @@ export type Boost = z.infer<typeof BoostValidator>;
 export const BoostRecipientValidator = z.object({
     to: LCNProfileValidator,
     from: z.string(),
-    received: z.string(),
+    received: z.string().optional(),
 });
 
 export type BoostRecipientInfo = z.infer<typeof BoostRecipientValidator>;

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -336,10 +336,21 @@ export const getLearnCardNetworkPlugin = async (
 
                 return client.boost.getBoosts.query();
             },
-            getBoostRecipients: async (_learnCard, uri, limit = 25, skip = undefined) => {
+            getBoostRecipients: async (
+                _learnCard,
+                uri,
+                limit = 25,
+                skip = undefined,
+                includeUnacceptedBoosts = true
+            ) => {
                 if (!userData) throw new Error('Please make an account first!');
 
-                return client.boost.getBoostRecipients.query({ uri, limit, skip });
+                return client.boost.getBoostRecipients.query({
+                    uri,
+                    limit,
+                    skip,
+                    includeUnacceptedBoosts,
+                });
             },
             updateBoost: async (_learnCard, uri, updates, credential) => {
                 if (!userData) throw new Error('Please make an account first!');

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -78,7 +78,8 @@ export type LearnCardNetworkPluginMethods = {
     getBoostRecipients: (
         uri: string,
         limit?: number,
-        skip?: number
+        skip?: number,
+        includeUnacceptedBoosts?: boolean
     ) => Promise<BoostRecipientInfo[]>;
     updateBoost: (
         uri: string,

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
@@ -37,9 +37,11 @@ export const getBoostRecipients = async (
     {
         limit,
         skip,
+        includeUnacceptedBoosts = true,
     }: {
         limit: number;
         skip?: number;
+        includeUnacceptedBoosts?: boolean;
     }
 ): Promise<BoostRecipientInfo[]> => {
     const query = new QueryBuilder()
@@ -61,7 +63,7 @@ export const getBoostRecipients = async (
             ],
         })
         .match({
-            optional: true,
+            optional: includeUnacceptedBoosts,
             related: [
                 { identifier: 'credential', model: Credential },
                 {

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
@@ -9,7 +9,9 @@ import {
     Credential,
     CredentialInstance,
     CredentialRelationships,
+    ProfileRelationships,
 } from '@models';
+import { getProfilesByProfileIds } from '@accesslayer/profile/read';
 
 export const getBoostOwner = async (boost: BoostInstance): Promise<ProfileInstance | undefined> => {
     return (await boost.findRelationships({ alias: 'createdBy' }))[0]?.target;
@@ -40,40 +42,61 @@ export const getBoostRecipients = async (
         skip?: number;
     }
 ): Promise<BoostRecipientInfo[]> => {
-    const query = new QueryBuilder().match({
-        related: [
-            { identifier: 'source', model: Boost, where: { id: boost.id } },
-            {
-                ...Credential.getRelationshipByAlias('instanceOf'),
-                identifier: 'instanceOf',
-                direction: 'in',
-            },
-            { identifier: 'credential', model: Credential },
-            {
-                ...Credential.getRelationshipByAlias('credentialReceived'),
-                identifier: 'received',
-            },
-            {
-                identifier: 'recipient',
-                model: Profile,
-            },
-        ],
-    });
+    const query = new QueryBuilder()
+        .match({
+            related: [
+                { identifier: 'source', model: Boost, where: { id: boost.id } },
+                {
+                    ...Credential.getRelationshipByAlias('instanceOf'),
+                    identifier: 'instanceOf',
+                    direction: 'in',
+                },
+                { identifier: 'credential', model: Credential },
+                {
+                    ...Profile.getRelationshipByAlias('credentialSent'),
+                    identifier: 'sent',
+                    direction: 'in',
+                },
+                { identifier: 'sender', model: Profile },
+            ],
+        })
+        .match({
+            optional: true,
+            related: [
+                { identifier: 'credential', model: Credential },
+                {
+                    ...Credential.getRelationshipByAlias('credentialReceived'),
+                    identifier: 'received',
+                },
+                { identifier: 'recipient', model: Profile },
+            ],
+        });
 
     const results = convertQueryResultToPropertiesObjectArray<{
-        recipient: ProfileInstance;
-        received: CredentialRelationships['credentialReceived']['RelationshipProperties'];
+        sender: ProfileInstance;
+        sent: ProfileRelationships['credentialSent']['RelationshipProperties'];
+        recipient?: ProfileInstance;
+        received?: CredentialRelationships['credentialReceived']['RelationshipProperties'];
     }>(
         await query
-            .return('received, recipient')
+            .return('sender, sent, received')
             .limit(limit)
             .skip(skip ?? 0)
             .run()
     );
 
-    return results.map(({ received, recipient }) => ({
-        to: recipient,
-        from: received.from,
-        received: received.date,
+    const resultsWithIds = results.map(({ sender, sent, received }) => ({
+        to: sent.to,
+        from: sender.profileId,
+        received: received?.date,
     }));
+
+    const recipients = await getProfilesByProfileIds(resultsWithIds.map(result => result.to));
+
+    return resultsWithIds
+        .map(result => ({
+            ...result,
+            to: recipients.find(recipient => recipient.profileId === result.to),
+        }))
+        .filter(result => Boolean(result.to)) as BoostRecipientInfo[];
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/read.ts
@@ -11,6 +11,18 @@ export const getProfilesByProfileId = async (profileId: string): Promise<Profile
     return Profile.findMany({ where: { profileId: transformProfileId(profileId) } });
 };
 
+export const getProfilesByProfileIds = async (profileIds: string[]): Promise<ProfileType[]> => {
+    const result = await new QueryBuilder(
+        new BindParam({ profileIds: profileIds.map(transformProfileId) })
+    )
+        .match({ identifier: 'profile', model: Profile })
+        .where('profile.profileId IN $profileIds')
+        .return('profile')
+        .run();
+
+    return QueryRunner.getResultProperties<ProfileType>(result, 'profile');
+};
+
 export const getProfileByDid = async (did: string): Promise<ProfileInstance | null> => {
     return Profile.findOne({ where: { did } });
 };

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -207,18 +207,19 @@ export const boostsRouter = t.router({
                 uri: z.string(),
                 limit: z.number().optional().default(25),
                 skip: z.number().optional(),
+                includeUnacceptedBoosts: z.boolean().default(true),
             })
         )
         .output(BoostRecipientValidator.array())
         .query(async ({ input }) => {
-            const { uri, limit, skip } = input;
+            const { uri, limit, skip, includeUnacceptedBoosts } = input;
 
             const boost = await getBoostByUri(uri);
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
             //TODO: Should we restrict who can see the recipients of a boost? Maybe to Boost owner / people who have the boost?
-            return getBoostRecipients(boost, { limit, skip });
+            return getBoostRecipients(boost, { limit, skip, includeUnacceptedBoosts });
         }),
     updateBoost: profileRoute
         .meta({

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -324,6 +324,28 @@ describe('Boosts', () => {
 
             expect(await userA.clients.fullAuth.boost.getBoostRecipients({ uri })).toHaveLength(1);
         });
+
+        it("should allow not returning recipients that haven't accepted yet", async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            expect(await userA.clients.fullAuth.boost.getBoostRecipients({ uri })).toHaveLength(0);
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                uri,
+                false
+            );
+
+            expect(
+                await userA.clients.fullAuth.boost.getBoostRecipients({
+                    uri,
+                    includeUnacceptedBoosts: false,
+                })
+            ).toHaveLength(0);
+        });
     });
 
     describe('updateBoost', () => {

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -307,6 +307,23 @@ describe('Boosts', () => {
 
             expect(await userA.clients.fullAuth.boost.getBoostRecipients({ uri })).toHaveLength(1);
         });
+
+        it("should return recipients that haven't accepted yet", async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            expect(await userA.clients.fullAuth.boost.getBoostRecipients({ uri })).toHaveLength(0);
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                uri,
+                false
+            );
+
+            expect(await userA.clients.fullAuth.boost.getBoostRecipients({ uri })).toHaveLength(1);
+        });
     });
 
     describe('updateBoost', () => {


### PR DESCRIPTION
- :bug: Loosen BoostRecipientInfo type
- :bug: Return boost recipients who haven't accepted yet

# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Right now, when calling `getBoostRecipients`, only recipients who have accepted the boost are returned.

#### 🥴 TL; RL:
Adds an `includeUnacceptedBoosts` flag (defaults to true) that allows asking for all recipients, not
just those who have accepted

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- `BoostRecipientInfo` type has been loosened to allow the received date to be optional (in case it hasn't been received yet!)
- `getBoostRecipients` now takes in an `includeUnacceptedBoosts` flag

#### 🛠 Important tradeoffs made:
The Neo4j query was kind of tough to write, because the `BoostRecipientInfo` type wants a full user 
Profile and not just the ID (which is all you have if they haven't accepted the boost!), so, it actually
does two queries: One to get all the recipient/sender IDs (and received date), and another to go and
grab the full recipient profile for all recipients. I _think_ this could be optimized into one query
using the Neo4j `UNION` operator, but I'm not 100% sure, and it would heavily complicate this call,
so I left it like this for now.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the tests! Also, pop open the CLI, make a boost, send it to someone (but don't accept it), and 
call `getBoostRecipients` and make sure they show up!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote tests to make sure both cases of the flag are covered!

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
