### PR TITLE
Fix Didkit Concurrency Bug

### DIFF
--- a/.changeset/soft-oranges-report.md
+++ b/.changeset/soft-oranges-report.md
@@ -1,0 +1,5 @@
+---
+'@learncard/didkit-plugin': minor
+---
+
+Fix didkit failing to properly init when instantiating multiple LearnCards concurrently

--- a/packages/plugins/didkit/src/didkit/index.ts
+++ b/packages/plugins/didkit/src/didkit/index.ts
@@ -3,16 +3,22 @@ import _init, { InitInput } from './pkg/didkit_wasm';
 export * from './pkg/didkit_wasm';
 
 let initialized = false;
+let generating = false;
 
 export const init = async (
     arg: InitInput | Promise<InitInput> = 'https://cdn.filestackcontent.com/NXWgZbAoRVSr3oVsHXpX'
 ) => {
+    while (generating) await new Promise(res => setTimeout(res, 250));
+
     // allow calling multiple times without reinitializing
     if (initialized) return;
 
-    initialized = true;
+    generating = true;
 
-    return _init(arg);
+    await _init(arg);
+
+    generating = false;
+    initialized = true;
 };
 
 export default init;

--- a/packages/plugins/didkit/src/didkit/index.ts
+++ b/packages/plugins/didkit/src/didkit/index.ts
@@ -3,22 +3,29 @@ import _init, { InitInput } from './pkg/didkit_wasm';
 export * from './pkg/didkit_wasm';
 
 let initialized = false;
-let generating = false;
+let generating = false; // Mutex flag to allow first init call to acquire a lock
 
 export const init = async (
     arg: InitInput | Promise<InitInput> = 'https://cdn.filestackcontent.com/NXWgZbAoRVSr3oVsHXpX'
 ) => {
+    // Do not return until we are done generating!
     while (generating) await new Promise(res => setTimeout(res, 250));
 
     // allow calling multiple times without reinitializing
     if (initialized) return;
 
-    generating = true;
+    try {
+        generating = true;
 
-    await _init(arg);
+        await _init(arg);
 
-    generating = false;
-    initialized = true;
+        generating = false;
+        initialized = true;
+    } catch (error) {
+        generating = false;
+
+        throw error;
+    }
 };
 
 export default init;


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Right now, if you instantiate two LearnCards at the same time via Promise.all, it will not work and
at least one of them will totally fail!

#### 🥴 TL; RL:
Say goodbye to this error! 
![image](https://github.com/learningeconomy/LearnCard/assets/39720479/604b5026-22c9-4edd-8dc2-9ad6986823b0)


#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Prior to this change, I was preventing costly re-inits of the webassembly by keeping a variable around
to check if the init function had already been ran. This results in ~9x speedup when instantiating multiple
LearnCards. However, this check was pretty crude, and if a second LearnCard wanted to come in and initialize
while the first one was currently initializing, it would just _not_ init, and then didkit would have no access
to wasm. This PR beats this by adding a more robust `generating` variable. Using this, if a second LearnCard
comes in wanting to instantiate while the init function is running from another LC, it will now poll
every 250ms until that `generating` variable becomes false, at which point it will make sure init
ran successfully, then return as expected.

#### 🛠 Important tradeoffs made:
I just kind of arbitrarily picked 250ms as a poll time, because I think it is sane. I didn't do any kind
of benchmarking or anything, but I think it's fine

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
In the CLI code (`packages/learn-card/cli/src/index.ts`), add a `await Promise.all([initLearnCard({ seed: 'a' }), initLearnCard({ seed: 'b' })])`.
On `main`, that will error, on this branch it will not!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
