### PR TITLE
Don't Strip Status

### DIFF
--- a/.changeset/few-ears-invite.md
+++ b/.changeset/few-ears-invite.md
@@ -1,0 +1,5 @@
+---
+'@learncard/types': patch
+---
+
+Don't strip fields from credentialStatus

--- a/packages/learn-card-types/src/vc.ts
+++ b/packages/learn-card-types/src/vc.ts
@@ -101,10 +101,14 @@ export type Profile = z.infer<typeof ProfileValidator>;
 export const CredentialSubjectValidator = z.object({ id: z.string().optional() }).catchall(z.any());
 export type CredentialSubject = z.infer<typeof CredentialSubjectValidator>;
 
-export const CredentialStatusValidator = z.object({ type: z.string(), id: z.string() });
+export const CredentialStatusValidator = z
+    .object({ type: z.string(), id: z.string() })
+    .catchall(z.any());
 export type CredentialStatus = z.infer<typeof CredentialStatusValidator>;
 
-export const CredentialSchemaValidator = z.object({ id: z.string(), type: z.string() });
+export const CredentialSchemaValidator = z
+    .object({ id: z.string(), type: z.string() })
+    .catchall(z.any());
 export type CredentialSchema = z.infer<typeof CredentialSchemaValidator>;
 
 export const RefreshServiceValidator = z
@@ -151,7 +155,7 @@ export const UnsignedVPValidator = z
     .object({
         '@context': ContextValidator,
         id: z.string().optional(),
-        type: z.string().array().nonempty(),
+        type: z.string().or(z.string().array().nonempty()),
         verifiableCredential: VCValidator.or(VCValidator.array()).optional(),
         holder: z.string().optional(),
     })


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Working on the new CHAPI exchange flow, I noticed that saved credentials with `credentialStatus` were
being mutated when getting saved, and found that it's because our zod validators are too strict and
are stripping fields from `credentialStatus`!

#### 🥴 TL; RL:
Loosens the credential status type to not strip fields!

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
