### PR TITLE
Auto-Connect Boosts

### DIFF
--- a/.changeset/eleven-bikes-think.md
+++ b/.changeset/eleven-bikes-think.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': minor
+'@learncard/types': minor
+---
+
+Add autoConnectRecipients to Boost metadata

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -37,6 +37,7 @@ export const BoostValidator = z.object({
     type: z.string().optional(),
     category: z.string().optional(),
     status: LCNBoostStatus.optional(),
+    autoConnectRecipients: z.boolean().optional(),
 });
 export type Boost = z.infer<typeof BoostValidator>;
 

--- a/services/learn-card-network/brain-service/jest.config.ts
+++ b/services/learn-card-network/brain-service/jest.config.ts
@@ -192,6 +192,8 @@ const config: Config = {
 
     // Whether to use watchman for file crawling
     // watchman: true,
+
+    testTimeout: 10_000,
 };
 
 export default config;

--- a/services/learn-card-network/brain-service/src/cache/connections.ts
+++ b/services/learn-card-network/brain-service/src/cache/connections.ts
@@ -1,0 +1,29 @@
+import cache from '@cache';
+import { ProfileType } from 'types/profile';
+
+const CONNECTIONS_TTL = 60 * 60 * 24;
+
+export const getConnectionsCacheKey = (profileId: string): string => `connections:${profileId}`;
+
+export const getCachedConnectionsByProfileId = async (
+    profileId: string
+): Promise<ProfileType[] | null | undefined> => {
+    const result = await cache.get(getConnectionsCacheKey(profileId), true, CONNECTIONS_TTL);
+
+    return result && JSON.parse(result);
+};
+
+export const setCachedConnectionsForProfileId = async (
+    profileId: string,
+    connections: ProfileType[]
+) => {
+    return cache.set(
+        getConnectionsCacheKey(profileId),
+        JSON.stringify(connections),
+        CONNECTIONS_TTL
+    );
+};
+
+export const deleteCachedConnectionsForProfileId = async (profileId: string) => {
+    return cache.delete([getConnectionsCacheKey(profileId)]);
+};

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -170,10 +170,12 @@ export const issueCertifiedBoost = async (
             lcnDID = learnCard.id.did();
         }
     } catch (e) {
-        console.warn(
-            'LCN DID Document is unable to resolve while issuing Certified Boost. Reverting to did:key. Is this a test environment?',
-            lcnDID
-        );
+        if (process.env.NODE_ENV !== 'test') {
+            console.warn(
+                'LCN DID Document is unable to resolve while issuing Certified Boost. Reverting to did:key. Is this a test environment?',
+                lcnDID
+            );
+        }
         lcnDID = learnCard.id.did();
     }
 
@@ -226,7 +228,7 @@ export const sendBoost = async (
     const decryptedCredential = await decryptCredential(credential);
     let boostUri: string | undefined;
     if (decryptedCredential) {
-        console.log('🚀 sendBoost:VC Decrypted');
+        if (process.env.NODE_ENV !== 'test') console.log('🚀 sendBoost:VC Decrypted');
         const certifiedBoost = await issueCertifiedBoost(boost, decryptedCredential, domain);
         if (certifiedBoost) {
             const credentialInstance = await storeCredential(certifiedBoost);
@@ -240,7 +242,9 @@ export const sendBoost = async (
             ]);
 
             boostUri = getCredentialUri(credentialInstance.id, domain);
-            console.log('🚀 sendBoost:boost certified', boostUri);
+            if (process.env.NODE_ENV !== 'test') {
+                console.log('🚀 sendBoost:boost certified', boostUri);
+            }
         } else {
             throw new Error('Credential does not match boost template.');
         }
@@ -257,7 +261,9 @@ export const sendBoost = async (
         ]);
 
         boostUri = getCredentialUri(credentialInstance.id, domain);
-        console.log('🚀 sendBoost:boost sent uncertified', boostUri);
+        if (process.env.NODE_ENV !== 'test') {
+            console.log('🚀 sendBoost:boost sent uncertified', boostUri);
+        }
     }
 
     if (typeof boostUri === 'string') {
@@ -274,7 +280,9 @@ export const sendBoost = async (
                     vcUris: [boostUri],
                 },
             });
-            console.log('🚀 sendBoost:notification sent! ✅');
+            if (process.env.NODE_ENV !== 'test') {
+                console.log('🚀 sendBoost:notification sent! ✅');
+            }
         }
         return boostUri;
     } else {
@@ -335,7 +343,6 @@ export const issueClaimLinkBoost = async (
     to: ProfileInstance,
     signingAuthorityForUser: SigningAuthorityForUserType
 ): Promise<string> => {
-    console.log('issueClaimLinkBoost');
     const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC | VC;
     const boostId = boost?.dataValues?.id;
     const boostURI = getBoostUri(boostId, domain);
@@ -356,7 +363,6 @@ export const issueClaimLinkBoost = async (
         boostCredential.boostId = boostURI;
     }
 
-    console.log('issueCredentialWithSigningAuthority');
     const vc = await issueCredentialWithSigningAuthority(
         from,
         boostCredential,

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -19,6 +19,7 @@ import { issueCredentialWithSigningAuthority } from './signingAuthority.helpers'
 import { addNotificationToQueue } from './notifications.helpers';
 import { BoostStatus } from 'types/boost';
 import { getDidWeb } from './did.helpers';
+import { deleteCachedConnectionsForProfileId } from '@cache/connections';
 
 export const getBoostUri = (id: string, domain: string): string =>
     constructUri('boost', id, domain);
@@ -264,6 +265,13 @@ export const sendBoost = async (
         if (process.env.NODE_ENV !== 'test') {
             console.log('🚀 sendBoost:boost sent uncertified', boostUri);
         }
+    }
+
+    if (autoAcceptCredential && boost.dataValues.autoConnectRecipients) {
+        await Promise.all([
+            deleteCachedConnectionsForProfileId(from.profileId),
+            deleteCachedConnectionsForProfileId(to.profileId),
+        ]);
     }
 
     if (typeof boostUri === 'string') {

--- a/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
@@ -11,6 +11,7 @@ import {
 import { getCredentialSentToProfile } from '@accesslayer/credential/relationships/read';
 import { constructUri, getUriParts } from './uri.helpers';
 import { addNotificationToQueue } from './notifications.helpers';
+import { deleteCachedConnectionsForProfileId } from '@cache/connections';
 
 export const getCredentialUri = (id: string, domain: string): string =>
     constructUri('credential', id, domain);
@@ -63,6 +64,11 @@ export const acceptCredential = async (profile: ProfileInstance, uri: string): P
     }
 
     await createReceivedCredentialRelationship(profile, pendingVc.source, pendingVc.target);
+
+    await Promise.all([
+        deleteCachedConnectionsForProfileId(profile.profileId),
+        deleteCachedConnectionsForProfileId(pendingVc.source.profileId),
+    ]);
 
     await addNotificationToQueue({
         type: LCNNotificationTypeEnumValidator.enum.BOOST_ACCEPTED,

--- a/services/learn-card-network/brain-service/src/helpers/notifications.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/notifications.helpers.ts
@@ -43,11 +43,14 @@ export async function sendNotification(notification: LCNNotification) {
             notification.sent = new Date().toISOString();
         }
         if (typeof notificationsWebhook === 'string' && notificationsWebhook?.startsWith('http')) {
-            console.log(
-                'Sending notification!',
-                notificationsWebhook,
-                JSON.stringify(notification)
-            );
+            if (process.env.NODE_ENV !== 'test') {
+                console.log(
+                    'Sending notification!',
+                    notificationsWebhook,
+                    JSON.stringify(notification)
+                );
+            }
+
             const learnCard = await getDidWebLearnCard();
 
             const didJwt = await learnCard.invoke.getDidAuthVp({ proofFormat: 'jwt' });
@@ -84,7 +87,9 @@ export async function sendNotification(notification: LCNNotification) {
             return validationResult.data;
         }
     } catch (error) {
-        console.error('Notifications Helpers - Error While Sending:', error);
+        if (process.env.NODE_ENV !== 'test') {
+            console.error('Notifications Helpers - Error While Sending:', error);
+        }
     }
     return false;
 }

--- a/services/learn-card-network/brain-service/src/helpers/signingAuthority.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/signingAuthority.helpers.ts
@@ -24,17 +24,18 @@ export async function issueCredentialWithSigningAuthority(
     encrypt: boolean = true
 ): Promise<VC | JWE> {
     try {
-        console.log(
-            'Issuing Credential with SA',
-            JSON.stringify({
-                credential,
-                signingAuthorityForUser,
-            })
-        );
+        if (!IS_TEST_ENVIRONMENT) {
+            console.log(
+                'Issuing Credential with SA',
+                JSON.stringify({
+                    credential,
+                    signingAuthorityForUser,
+                })
+            );
+        }
 
         if (IS_TEST_ENVIRONMENT) {
-            console.log('✅ IS TEST ENVIRONMENT _mockIssueCredentialWithSigningAuthority');
-            return _mockIssueCredentialWithSigningAuthority(credential);
+            return await _mockIssueCredentialWithSigningAuthority(credential);
         }
 
         const learnCard = await getDidWebLearnCard();
@@ -42,18 +43,15 @@ export async function issueCredentialWithSigningAuthority(
         const didJwt = await learnCard.invoke.getDidAuthVp({ proofFormat: 'jwt' });
 
         const issuerEndpoint = `${signingAuthorityForUser.signingAuthority.endpoint}/credentials/issue`;
-        console.log('Issuer Endpoint: ', issuerEndpoint);
+
+        if (!IS_TEST_ENVIRONMENT) console.log('Issuer Endpoint: ', issuerEndpoint);
 
         const ownerDid = getDidWeb(
             process.env.DOMAIN_NAME ?? 'network.learncard.com',
             owner.profileId
         );
 
-        const encryption = encrypt
-            ? {
-                  recipients: [learnCard.id.did()],
-              }
-            : undefined;
+        const encryption = encrypt ? { recipients: [learnCard.id.did()] } : undefined;
 
         // Create an AbortController instance and get the signal
         const controller = new AbortController();
@@ -81,8 +79,10 @@ export async function issueCredentialWithSigningAuthority(
         });
 
         clearTimeout(timeoutId);
+
         const res = await response.json();
-        console.log('RESPONSE: ', res);
+
+        if (!IS_TEST_ENVIRONMENT) console.log('RESPONSE: ', res);
 
         if (!res || res?.code === 'INTERNAL_SERVER_ERROR') {
             throw new Error(res);

--- a/services/learn-card-network/brain-service/src/models/Boost.ts
+++ b/services/learn-card-network/brain-service/src/models/Boost.ts
@@ -24,6 +24,7 @@ export const Boost = ModelFactory<BoostType, BoostRelationships>(
             name: { type: 'string' },
             type: { type: 'string' },
             category: { type: 'string' },
+            autoConnectRecipients: { type: 'boolean' },
             boost: { type: 'string', required: true },
             status: { type: 'string', enum: BoostStatus.options },
         },

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -63,10 +63,14 @@ export const boostsRouter = t.router({
         .mutation(async ({ ctx, input }) => {
             const { profile } = ctx.user;
             const { profileId, credential, uri } = input;
-            console.log('🚀 BEGIN - Send Boost', JSON.stringify(input));
+
+            if (process.env.NODE_ENV !== 'test') {
+                console.log('🚀 BEGIN - Send Boost', JSON.stringify(input));
+            }
 
             const targetProfile = await getProfileByProfileId(profileId);
             const isBlocked = await isRelationshipBlocked(profile, targetProfile);
+
             if (!targetProfile || isBlocked) {
                 throw new TRPCError({
                     code: 'NOT_FOUND',

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -402,6 +402,7 @@ export const boostsRouter = t.router({
                 getClaimLinkSAInfoForBoost(boostUri, challenge),
                 getBoostByUri(boostUri),
             ]);
+
             if (!claimLinkSA) {
                 throw new TRPCError({
                     code: 'NOT_FOUND',
@@ -411,19 +412,23 @@ export const boostsRouter = t.router({
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
             const boostOwner = await getBoostOwner(boost);
-            if (!boostOwner)
+
+            if (!boostOwner) {
                 throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost owner' });
+            }
 
             const signingAuthority = await getSigningAuthorityForUserByName(
                 boostOwner,
                 claimLinkSA.endpoint,
                 claimLinkSA.name
             );
-            if (!signingAuthority)
+
+            if (!signingAuthority) {
                 throw new TRPCError({
                     code: 'NOT_FOUND',
                     message: 'Could not find signing authority for boost',
                 });
+            }
 
             try {
                 const sentBoostUri = await issueClaimLinkBoost(

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -973,12 +973,16 @@ describe('Profiles', () => {
 
     describe('connections', () => {
         beforeEach(async () => {
+            await Boost.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
             await Profile.delete({ detach: true, where: {} });
             await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
             await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
         });
 
         afterAll(async () => {
+            await Boost.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
             await Profile.delete({ detach: true, where: {} });
         });
 
@@ -1005,6 +1009,76 @@ describe('Profiles', () => {
 
             expect(oneConnection).toHaveLength(1);
             expect(oneConnection[0]!.profileId).toEqual('userb');
+        });
+
+        it('should show connections from auto-connect boosts', async () => {
+            await expect(userA.clients.fullAuth.profile.connections()).resolves.not.toThrow();
+
+            const noConnections = await userA.clients.fullAuth.profile.connections();
+
+            expect(noConnections).toHaveLength(0);
+
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                autoConnectRecipients: true,
+            });
+            const userBProfile = await userB.clients.fullAuth.profile.getProfile();
+
+            const credential = await userA.learnCard.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: userA.learnCard.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: userA.learnCard.id.did(),
+                },
+                boostId: uri,
+            });
+
+            const credentialUri = await userA.clients.fullAuth.boost.sendBoost({
+                profileId: userBProfile.profileId,
+                uri,
+                credential,
+            });
+            await userB.clients.fullAuth.credential.acceptCredential({ uri: credentialUri });
+
+            const oneConnection = await userA.clients.fullAuth.profile.connections();
+
+            expect(oneConnection).toHaveLength(1);
+            expect(oneConnection[0]!.profileId).toEqual('userb');
+        });
+
+        it('should not show connections from non-auto-connect boosts', async () => {
+            await expect(userA.clients.fullAuth.profile.connections()).resolves.not.toThrow();
+
+            const noConnections = await userA.clients.fullAuth.profile.connections();
+
+            expect(noConnections).toHaveLength(0);
+
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+            const userBProfile = await userB.clients.fullAuth.profile.getProfile();
+
+            const credential = await userA.learnCard.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: userA.learnCard.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: userA.learnCard.id.did(),
+                },
+                boostId: uri,
+            });
+
+            const credentialUri = await userA.clients.fullAuth.boost.sendBoost({
+                profileId: userBProfile.profileId,
+                uri,
+                credential,
+            });
+            await userB.clients.fullAuth.credential.acceptCredential({ uri: credentialUri });
+
+            const stillNoConnections = await userA.clients.fullAuth.profile.connections();
+
+            expect(stillNoConnections).toHaveLength(0);
         });
     });
 

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -973,6 +973,7 @@ describe('Profiles', () => {
 
     describe('connections', () => {
         beforeEach(async () => {
+            await cache.node.flushall();
             await Boost.delete({ detach: true, where: {} });
             await Credential.delete({ detach: true, where: {} });
             await Profile.delete({ detach: true, where: {} });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-111] Setting to "Auto-Connect" Members

#### 📚 What is the context and goal of this PR?
We want to be able to automatically connect profiles if they share a boost!

#### 🥴 TL; RL:
Adds an `autoConnectRecipients` field to Boost metadata

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- Boost type updated to include `autoConnectRecipients`
- `getConnections` logic updated to also search for users that share an auto-connect boost with you
    - Also accounts for the case where you only have created the boost and have not actually received it!

#### 🛠 Important tradeoffs made:
The `getConnections` query is pretty intense right now and is definitely more in favor of a write-heavy
workload rather than a read-heavy workload, which we are more likely to see. A way past this in the future
may be to actually create an intermediary relationship directly between two profiles pointing to the
boost that connects them every single time a Boost is received, however that will greatly lengthen
the time it takes to receive a boost, and introduces tons of complexity in having to manage that all
those extra relationships! So, I want to try it like this first and see just how slow this query actually
gets

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the test suite! Additionally, if you want you can spin up LCN locally, connect to it via the CLI,
make a boost that auto-connects, then make another wallet connected your local LCN, send a boost from
first wallet to second, then see if the two wallets are connected! (This is what the test suite does tho)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
Wrote tests that do the above

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
