### PR TITLE
[LC-113] Allow Adding Additional Boost Admins

### DIFF
--- a/.changeset/quiet-buckets-clean.md
+++ b/.changeset/quiet-buckets-clean.md
@@ -1,0 +1,34 @@
+---
+'@learncard/learn-cloud-service': patch
+'@learncard/network-brain-service': patch
+'@learncard/network-brain-client': patch
+'@learncard/learn-cloud-client': patch
+'@learncard/network-plugin': patch
+'@learncard/create-http-bridge': patch
+'@learncard/did-web-plugin': patch
+'@learncard/dynamic-loader-plugin': patch
+'learn-card-discord-bot': patch
+'@learncard/vc-templates-plugin': patch
+'@learncard/learn-cloud-plugin': patch
+'@learncard/helpers': patch
+'@learncard/expiration-plugin': patch
+'@learncard/learn-card-plugin': patch
+'@learncard/types': patch
+'@learncard/ethereum-plugin': patch
+'@learncard/react': patch
+'@learncard/core': patch
+'@learncard/init': patch
+'@learncard/ceramic-plugin': patch
+'@learncard/cli': patch
+'@learncard/crypto-plugin': patch
+'@learncard/didkey-plugin': patch
+'@learncard/didkit-plugin': patch
+'@learncard/vc-api-plugin': patch
+'@learncard/meta-mask-snap': patch
+'@learncard/chapi-plugin': patch
+'@learncard/vpqr-plugin': patch
+'@learncard/idx-plugin': patch
+'@learncard/vc-plugin': patch
+---
+
+Emit declarationMap

--- a/.changeset/three-guests-share.md
+++ b/.changeset/three-guests-share.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-service': minor
+---
+
+Allow setting additional admins for Boosts

--- a/packages/learn-card-bridge-http/tsconfig.json
+++ b/packages/learn-card-bridge-http/tsconfig.json
@@ -23,6 +23,7 @@
         "target": "es2017",
         "outDir": "dist",
         "declaration": true,
+        "declarationMap": true,
         "sourceMap": true,
         "baseUrl": ".",
 

--- a/packages/learn-card-cli/tsconfig.json
+++ b/packages/learn-card-cli/tsconfig.json
@@ -23,6 +23,7 @@
         "target": "es2017",
         "outDir": "dist",
         "declaration": true,
+        "declarationMap": true,
         "sourceMap": true,
         "baseUrl": ".",
 

--- a/packages/learn-card-core/tsconfig.json
+++ b/packages/learn-card-core/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/learn-card-helpers/tsconfig.json
+++ b/packages/learn-card-helpers/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "module": "ES2015",
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
     "strict": true,

--- a/packages/learn-card-init/tsconfig.json
+++ b/packages/learn-card-init/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/learn-card-network/brain-client/tsconfig.json
+++ b/packages/learn-card-network/brain-client/tsconfig.json
@@ -23,6 +23,7 @@
         "outDir": "dist",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "sourceMap": true,
 

--- a/packages/learn-card-network/cloud-client/tsconfig.json
+++ b/packages/learn-card-network/cloud-client/tsconfig.json
@@ -23,6 +23,7 @@
         "outDir": "dist",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "sourceMap": true,
 

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { PaginationResponseValidator } from './mongo';
+
 export const LCNProfileValidator = z.object({
     profileId: z.string().min(3).max(40),
     displayName: z.string().default(''),
@@ -10,6 +12,11 @@ export const LCNProfileValidator = z.object({
     notificationsWebhook: z.string().url().startsWith('https://').optional(),
 });
 export type LCNProfile = z.infer<typeof LCNProfileValidator>;
+
+export const PaginatedLCNProfilesValidator = PaginationResponseValidator.extend({
+    records: LCNProfileValidator.array(),
+});
+export type PaginatedLCNProfiles = z.infer<typeof PaginatedLCNProfilesValidator>;
 
 export const LCNProfileConnectionStatusEnum = z.enum([
     'CONNECTED',

--- a/packages/learn-card-types/tsconfig.json
+++ b/packages/learn-card-types/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "es6",
         "module": "ES2015",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/ceramic/tsconfig.json
+++ b/packages/plugins/ceramic/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/chapi/tsconfig.json
+++ b/packages/plugins/chapi/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/crypto/tsconfig.json
+++ b/packages/plugins/crypto/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/did-web-plugin/tsconfig.json
+++ b/packages/plugins/did-web-plugin/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/didkey/tsconfig.json
+++ b/packages/plugins/didkey/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/didkit/tsconfig.json
+++ b/packages/plugins/didkit/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/dynamic-loader/tsconfig.json
+++ b/packages/plugins/dynamic-loader/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/ethereum/tsconfig.json
+++ b/packages/plugins/ethereum/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/expiration/tsconfig.json
+++ b/packages/plugins/expiration/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/idx/tsconfig.json
+++ b/packages/plugins/idx/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -366,6 +366,21 @@ export const getLearnCardNetworkPlugin = async (
                     updates: { credential, ...updates },
                 });
             },
+            getBoostAdmins: async (_learnCard, uri, options = {}) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.boost.getBoostAdmins.query({ uri, ...options });
+            },
+            addBoostAdmin: async (_learnCard, uri, profileId) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.boost.addBoostAdmin.mutate({ uri, profileId });
+            },
+            removeBoostAdmin: async (_learnCard, uri, profileId) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.boost.removeBoostAdmin.mutate({ uri, profileId });
+            },
             deleteBoost: async (_learnCard, uri) => {
                 if (!userData) throw new Error('Please make an account first!');
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -11,6 +11,8 @@ import {
     LCNSigningAuthorityForUserType,
     LCNBoostClaimLinkSigningAuthorityType,
     LCNBoostClaimLinkOptionsType,
+    PaginationOptionsType,
+    PaginatedLCNProfiles,
 } from '@learncard/types';
 import { Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
@@ -92,6 +94,12 @@ export type LearnCardNetworkPluginMethods = {
         credential: UnsignedVC | VC
     ) => Promise<boolean>;
     deleteBoost: (uri: string) => Promise<boolean>;
+    getBoostAdmins: (
+        uri: string,
+        options?: Partial<PaginationOptionsType> & { includeSelf?: boolean }
+    ) => Promise<PaginatedLCNProfiles>;
+    addBoostAdmin: (uri: string, profileId: string) => Promise<boolean>;
+    removeBoostAdmin: (uri: string, profileId: string) => Promise<boolean>;
     sendBoost: (profileId: string, boostUri: string, encrypt?: boolean) => Promise<string>;
 
     registerSigningAuthority: (endpoint: string, name: string, did: string) => Promise<boolean>;

--- a/packages/plugins/learn-card-network/tsconfig.json
+++ b/packages/plugins/learn-card-network/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/learn-card/tsconfig.json
+++ b/packages/plugins/learn-card/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/learn-cloud/tsconfig.json
+++ b/packages/plugins/learn-cloud/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/vc-api/tsconfig.json
+++ b/packages/plugins/vc-api/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/vc-templates/tsconfig.json
+++ b/packages/plugins/vc-templates/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/vc/tsconfig.json
+++ b/packages/plugins/vc/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/plugins/vpqr/tsconfig.json
+++ b/packages/plugins/vpqr/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "ESNext",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "outDir": "dist",
         "strict": true,

--- a/packages/react-learn-card/tsconfig.json
+++ b/packages/react-learn-card/tsconfig.json
@@ -43,7 +43,7 @@
 
         /* Emit */
         // "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-        // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+        "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
         // "emitDeclarationOnly": true,                         /* Only output d.ts files and not JavaScript files. */
         "sourceMap": true /* Create source map files for emitted JavaScript files. */,
         // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */

--- a/services/learn-card-discord-bot/tsconfig.json
+++ b/services/learn-card-discord-bot/tsconfig.json
@@ -23,6 +23,7 @@
         "target": "es2017",
         "outDir": "dist",
         "declaration": true,
+        "declarationMap": true,
         "sourceMap": true,
         "baseUrl": ".",
 

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
@@ -10,16 +10,3 @@ export const getBoostByUri = async (uri: string): Promise<BoostInstance | null> 
 
     return Boost.findOne({ where: { id } });
 };
-
-export const getBoostsForProfile = async (
-    profile: ProfileInstance,
-    { limit }: { limit: number }
-): Promise<BoostInstance[]> => {
-    const results = await Boost.findRelationships({
-        alias: 'createdBy',
-        where: { target: { profileId: profile.profileId } },
-        limit,
-    });
-
-    return results.map(result => result.source);
-};

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
@@ -1,5 +1,5 @@
 import { getIdFromUri } from '@helpers/uri.helpers';
-import { Boost, BoostInstance, ProfileInstance } from '@models';
+import { Boost, BoostInstance } from '@models';
 
 export const getBoostById = async (id: string): Promise<BoostInstance | null> => {
     return Boost.findOne({ where: { id } });

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/create.ts
@@ -18,3 +18,13 @@ export const createReceivedCredentialRelationship = async (
         properties: { from: from.profileId, date: new Date().toISOString() },
     });
 };
+
+export const setProfileAsBoostAdmin = async (
+    profile: ProfileInstance,
+    boost: BoostInstance
+): Promise<void> => {
+    await profile.relateTo({
+        alias: 'adminOf',
+        where: { id: boost.id },
+    });
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/delete.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/delete.ts
@@ -1,0 +1,11 @@
+import { ProfileInstance, BoostInstance, Profile } from '@models';
+
+export const removeProfileAsBoostAdmin = async (
+    profile: ProfileInstance,
+    boost: BoostInstance
+): Promise<void> => {
+    await Profile.deleteRelationships({
+        alias: 'adminOf',
+        where: { source: { profileId: profile.profileId }, target: { id: boost.id } },
+    });
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
@@ -13,6 +13,7 @@ import {
 } from '@models';
 import { getProfilesByProfileIds } from '@accesslayer/profile/read';
 import { ProfileType } from 'types/profile';
+import { BoostType } from 'types/boost';
 
 export const getBoostOwner = async (boost: BoostInstance): Promise<ProfileInstance | undefined> => {
     return (await boost.findRelationships({ alias: 'createdBy' }))[0]?.target;
@@ -145,4 +146,24 @@ export const isProfileBoostAdmin = async (profile: ProfileInstance, boost: Boost
     const result = await query.return('count(profile) AS count').run();
 
     return Number(result.records[0]?.get('count') ?? 0) > 0;
+};
+
+export const getBoostsForProfile = async (
+    profile: ProfileInstance,
+    { limit }: { limit: number }
+): Promise<BoostType[]> => {
+    const query = new QueryBuilder().match({
+        related: [
+            { identifier: 'boost', model: Boost },
+            `-[:${Profile.getRelationshipByAlias('adminOf').name}|${Boost.getRelationshipByAlias('createdBy').name
+            }]-`,
+            { model: Profile, where: { profileId: profile.profileId } },
+        ],
+    });
+
+    const results = convertQueryResultToPropertiesObjectArray<{
+        boost: BoostType;
+    }>(await query.return('DISTINCT boost').limit(limit).run());
+
+    return results.map(({ boost }) => boost);
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
@@ -1,4 +1,4 @@
-import { QueryBuilder } from 'neogma';
+import { BindParam, Op, QueryBuilder, Where } from 'neogma';
 import { convertQueryResultToPropertiesObjectArray } from '@helpers/neo4j.helpers';
 import { BoostRecipientInfo } from '@learncard/types';
 import {
@@ -12,6 +12,7 @@ import {
     ProfileRelationships,
 } from '@models';
 import { getProfilesByProfileIds } from '@accesslayer/profile/read';
+import { ProfileType } from 'types/profile';
 
 export const getBoostOwner = async (boost: BoostInstance): Promise<ProfileInstance | undefined> => {
     return (await boost.findRelationships({ alias: 'createdBy' }))[0]?.target;
@@ -101,4 +102,47 @@ export const getBoostRecipients = async (
             to: recipients.find(recipient => recipient.profileId === result.to),
         }))
         .filter(result => Boolean(result.to)) as BoostRecipientInfo[];
+};
+
+export const getBoostAdmins = async (
+    boost: BoostInstance,
+    { limit, cursor, blacklist = [] }: { limit: number; cursor?: string; blacklist?: string[] }
+): Promise<ProfileType[]> => {
+    const _query = new QueryBuilder(new BindParam({ blacklist }))
+        .match({
+            related: [
+                { identifier: 'source', model: Boost, where: { id: boost.id } },
+                `-[:${Profile.getRelationshipByAlias('adminOf').name}|${Boost.getRelationshipByAlias('createdBy').name
+                }]-`,
+                { identifier: 'admin', model: Profile },
+            ],
+        })
+        .where('NOT admin.profileId IN $blacklist');
+
+    const query = cursor
+        ? _query.where(
+            new Where({ admin: { profileId: { [Op.gt]: cursor } } }, _query.getBindParam())
+        )
+        : _query;
+
+    const results = convertQueryResultToPropertiesObjectArray<{
+        admin: ProfileType;
+    }>(await query.return('admin').orderBy('admin.profileId').limit(limit).run());
+
+    return results.map(({ admin }) => admin);
+};
+
+export const isProfileBoostAdmin = async (profile: ProfileInstance, boost: BoostInstance) => {
+    const query = new QueryBuilder().match({
+        related: [
+            { model: Boost, where: { id: boost.id } },
+            `-[:${Profile.getRelationshipByAlias('adminOf').name}|${Boost.getRelationshipByAlias('createdBy').name
+            }]-`,
+            { identifier: 'profile', model: Profile, where: { profileId: profile.profileId } },
+        ],
+    });
+
+    const result = await query.return('count(profile) AS count').run();
+
+    return Number(result.records[0]?.get('count') ?? 0) > 0;
 };

--- a/services/learn-card-network/brain-service/src/models/Profile.ts
+++ b/services/learn-card-network/brain-service/src/models/Profile.ts
@@ -8,11 +8,13 @@ import { SigningAuthority } from './SigningAuthority';
 import { transformProfileId } from '@helpers/profile.helpers';
 import { ProfileType } from 'types/profile';
 import { SigningAuthorityInstance } from './SigningAuthority';
+import { Boost, BoostInstance } from './Boost';
 
 export type ProfileRelationships = {
     connectionRequested: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
     connectedWith: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
     blocked: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
+    adminOf: ModelRelatedNodesI<typeof Boost, BoostInstance>;
     credentialSent: ModelRelatedNodesI<
         typeof Credential,
         CredentialInstance,

--- a/services/learn-card-network/brain-service/src/models/index.ts
+++ b/services/learn-card-network/brain-service/src/models/index.ts
@@ -3,6 +3,8 @@ import { Profile } from './Profile';
 import { Credential } from './Credential';
 import { Presentation } from './Presentation';
 
+Profile.addRelationships({ adminOf: { model: Boost, direction: 'out', name: 'ADMIN_OF' } });
+
 Credential.addRelationships({
     credentialReceived: {
         model: Profile,

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -315,7 +315,7 @@ export const boostsRouter = t.router({
             })
         )
         .output(PaginatedLCNProfilesValidator)
-        .mutation(async ({ input, ctx }) => {
+        .query(async ({ input, ctx }) => {
             const { uri, limit, cursor, includeSelf } = input;
 
             const boost = await getBoostByUri(uri);

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -86,7 +86,7 @@ export const boostsRouter = t.router({
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
-            if (!(await isProfileBoostOwner(profile, boost))) {
+            if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'Profile does not own boost',
@@ -163,7 +163,7 @@ export const boostsRouter = t.router({
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
-            if (!(await isProfileBoostOwner(profile, boost))) {
+            if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'Profile does not own boost',
@@ -263,7 +263,7 @@ export const boostsRouter = t.router({
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
-            if (!(await isProfileBoostOwner(profile, boost))) {
+            if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'Profile does not own boost',
@@ -382,7 +382,7 @@ export const boostsRouter = t.router({
             if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
-                    message: 'Profile does not own boost',
+                    message: 'Profile does not have admin rights over boost',
                 });
             }
 
@@ -477,7 +477,7 @@ export const boostsRouter = t.router({
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
-            if (!(await isProfileBoostOwner(profile, boost))) {
+            if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'Profile does not own boost',
@@ -519,7 +519,7 @@ export const boostsRouter = t.router({
 
             if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
 
-            if (!(await isProfileBoostOwner(profile, boost))) {
+            if (!(await isProfileBoostAdmin(profile, boost))) {
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'Profile does not own boost',

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -310,7 +310,7 @@ export const boostsRouter = t.router({
         .input(
             PaginationOptionsValidator.extend({
                 limit: PaginationOptionsValidator.shape.limit.default(25),
-                includeSelf: z.boolean().default(false),
+                includeSelf: z.boolean().default(true),
                 uri: z.string(),
             })
         )

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -13,11 +13,12 @@ import {
 
 import { t, profileRoute } from '@routes';
 
-import { getBoostByUri, getBoostsForProfile } from '@accesslayer/boost/read';
+import { getBoostByUri } from '@accesslayer/boost/read';
 import {
     getBoostAdmins,
     getBoostRecipients,
     isProfileBoostAdmin,
+    getBoostsForProfile,
 } from '@accesslayer/boost/relationships/read';
 
 import { deleteStorageForUri, setStorageForUri } from '@cache/storage';
@@ -195,7 +196,7 @@ export const boostsRouter = t.router({
             const boosts = await getBoostsForProfile(profile, { limit: 50 });
 
             return boosts.map(boost => {
-                const { id, boost: _boost, ...remaining } = boost.dataValues;
+                const { id, boost: _boost, ...remaining } = boost;
                 return {
                     ...remaining,
                     uri: getBoostUri(id, ctx.domain),

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -145,6 +145,18 @@ describe('Boosts', () => {
 
             expect(boosts).toHaveLength(1);
         });
+
+        it('should get boosts you are admin of, not just created', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({ credential: testVc });
+
+            await userA.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userb' });
+
+            await expect(userB.clients.fullAuth.boost.getBoosts()).resolves.not.toThrow();
+
+            const boosts = await userB.clients.fullAuth.boost.getBoosts();
+
+            expect(boosts).toHaveLength(1);
+        });
     });
 
     describe('sendBoost', () => {

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -714,31 +714,31 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
 
             await userA.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userb' });
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
         });
 
-        it('should allow including self in boost admins', async () => {
+        it('should allow discluding self in boost admins', async () => {
             const uri = await userA.clients.fullAuth.boost.createBoost({
                 credential: testUnsignedBoost,
             });
 
             expect(
-                (await userA.clients.fullAuth.boost.getBoostAdmins({ uri, includeSelf: true }))
+                (await userA.clients.fullAuth.boost.getBoostAdmins({ uri, includeSelf: false }))
                     .records
-            ).toHaveLength(1);
+            ).toHaveLength(0);
 
             await userA.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userb' });
 
             expect(
-                (await userA.clients.fullAuth.boost.getBoostAdmins({ uri, includeSelf: true }))
+                (await userA.clients.fullAuth.boost.getBoostAdmins({ uri, includeSelf: false }))
                     .records
-            ).toHaveLength(2);
+            ).toHaveLength(1);
         });
 
         it('should allow anyone to see boost admins', async () => {
@@ -747,8 +747,7 @@ describe('Boosts', () => {
             });
 
             expect(
-                (await userB.clients.fullAuth.boost.getBoostAdmins({ uri, includeSelf: true }))
-                    .records
+                (await userB.clients.fullAuth.boost.getBoostAdmins({ uri })).records
             ).toHaveLength(1);
         });
     });
@@ -790,7 +789,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
 
             await expect(
                 userA.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userb' })
@@ -798,7 +797,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
         });
 
         it('should allow admins to add more admins', async () => {
@@ -812,7 +811,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
 
             await expect(
                 userB.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userc' })
@@ -820,7 +819,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(2);
+            ).toHaveLength(3);
         });
 
         it('should not allow non-admins to add more admins', async () => {
@@ -832,7 +831,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
 
             await expect(
                 userB.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userc' })
@@ -840,7 +839,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
         });
     });
 
@@ -881,7 +880,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
 
             await expect(
                 userA.clients.fullAuth.boost.removeBoostAdmin({ uri, profileId: 'userb' })
@@ -889,7 +888,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
         });
 
         it('should only allow admins to remove admins', async () => {
@@ -903,7 +902,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
 
             await expect(
                 userC.clients.fullAuth.boost.removeBoostAdmin({ uri, profileId: 'userb' })
@@ -911,7 +910,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
         });
 
         it('should not allow removing boost creator', async () => {
@@ -923,7 +922,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
 
             await expect(
                 userB.clients.fullAuth.boost.removeBoostAdmin({ uri, profileId: 'usera' })
@@ -935,7 +934,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
         });
 
         it('should allow admins to remove themselves', async () => {
@@ -947,7 +946,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(1);
+            ).toHaveLength(2);
 
             await expect(
                 userB.clients.fullAuth.boost.removeBoostAdmin({ uri, profileId: 'userb' })
@@ -955,7 +954,7 @@ describe('Boosts', () => {
 
             expect(
                 (await userA.clients.fullAuth.boost.getBoostAdmins({ uri })).records
-            ).toHaveLength(0);
+            ).toHaveLength(1);
         });
     });
 

--- a/services/learn-card-network/brain-service/tsconfig.json
+++ b/services/learn-card-network/brain-service/tsconfig.json
@@ -22,6 +22,7 @@
         "target": "es2022",
         "outDir": "dist",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "sourceMap": true,
         "rootDir": ".",

--- a/services/learn-card-network/learn-cloud-service/tsconfig.json
+++ b/services/learn-card-network/learn-cloud-service/tsconfig.json
@@ -22,6 +22,7 @@
         "target": "es2022",
         "outDir": "dist",
         "declaration": true,
+        "declarationMap": true,
         "emitDeclarationOnly": true,
         "sourceMap": true,
         "rootDir": ".",

--- a/services/meta-mask-snap/tsconfig.json
+++ b/services/meta-mask-snap/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true,
+        "declarationMap": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "useUnknownInCatchVariables": false,


### PR DESCRIPTION
- :hammer: Emit declarationMaps
- :sparkles: Add basic CRUD for Boost Admins
- :sparkles: Update permissions to allow admins to actually do things!
- :sparkles: Return boosts you are admin of in getBoosts
- :bookmark: Changeset
- :sparkles: Add new methods to plugin

# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-113] Assign additional admins to Boosts

#### 📚 What is the context and goal of this PR?
Right now, only the creator of a boost can send or edit it. That is sad =(

#### 🥴 TL; RL:
Allows adding additional Boost admins who may then send and edit boosts!

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- I added `declarationMap: true` to all tsconfigs to allow jumping straight to ts files in your editor!
- Add three new routes: `getBoostAdmins`, `addBoostAdmin`, `removeBoostAdmin`, they just do what they say on the tin
- There is a new relationship between profiles and Boosts called `ADMIN_OF`
- All relevant boost queries have been updated to check for both `CREATED_BY` and `ADMIN_OF` relationships
- Admins are allowed to add more admins
- Admins are allowed to remove themselves as admins
- The Boost creator is _not_ allowed to be removed as an admin
- Anyone is allowed to view a Boost's admins list

#### 🛠 Important tradeoffs made:
I'm not 100% sure that we want to allow everyone to view a Boost's admin list, but it seems right to me.
Also, to address potential Boost orphans and to limit malicious behavior, I have set it so that the
Boost creator is kind of like a super admin in that they cannot be removed as an admin. In the future,
we may want to flesh this out a bit better and instead be able to allow more fine-grained permissions
to boost admins so that potentially untrusted admins can be allowed to send a boost but _not_ be able
to just remove other admins at will.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the test suite!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote lots of new tests to cover all the new behavior =)

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
