### PR TITLE
Fix [LC-21] Expiration for add profile link

### DIFF
--- a/.changeset/many-fireants-enjoy.md
+++ b/.changeset/many-fireants-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': minor
+'@learncard/network-plugin': minor
+---
+
+"expiration" added to profile invite

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -216,10 +216,14 @@ export const getLearnCardNetworkPlugin = async (
 
                 return client.profile.connectionRequests.query();
             },
-            generateInvite: async (_learnCard, challenge) => {
+
+            generateInvite: async (_learnCard, challenge: string, expiration: number) => {
                 if (!userData) throw new Error('Please make an account first!');
 
-                return client.profile.generateInvite.mutate({ challenge });
+                // Assuming mutate only returns profileId and challenge, you need to include expiration manually
+                const result = await client.profile.generateInvite.mutate({ challenge, expiration });
+                // Make sure the result includes expiration, or manually add it if necessary
+                return { ...result, expiration };
             },
 
             blockProfile: async (_learnCard, profileId) => {

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -219,8 +219,7 @@ export const getLearnCardNetworkPlugin = async (
 
             generateInvite: async (_learnCard, challenge, expiration) => {
                 if (!userData) throw new Error('Please make an account first!');
-                const result = await client.profile.generateInvite.mutate({ challenge, expiration });
-                return result
+                return client.profile.generateInvite.mutate({ challenge, expiration });
             },
 
             blockProfile: async (_learnCard, profileId) => {

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -217,13 +217,10 @@ export const getLearnCardNetworkPlugin = async (
                 return client.profile.connectionRequests.query();
             },
 
-            generateInvite: async (_learnCard, challenge: string, expiration: number) => {
+            generateInvite: async (_learnCard, challenge, expiration) => {
                 if (!userData) throw new Error('Please make an account first!');
-
-                // Assuming mutate only returns profileId and challenge, you need to include expiration manually
                 const result = await client.profile.generateInvite.mutate({ challenge, expiration });
-                // Make sure the result includes expiration, or manually add it if necessary
-                return { ...result, expiration };
+                return result
             },
 
             blockProfile: async (_learnCard, profileId) => {
@@ -470,6 +467,7 @@ export const getLearnCardNetworkPlugin = async (
                     challenge,
                 });
             },
+            
             claimBoostWithLink: async (_learnCard, boostUri, challenge) => {
                 if (!userData) throw new Error('Please make an account first!');
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -49,14 +49,14 @@ export type LearnCardNetworkPluginMethods = {
         }
     ) => Promise<LCNProfile[]>;
     connectWith: (profileId: string) => Promise<boolean>;
-    connectWithInvite: (profileId: string, challenge: string) => Promise<boolean>;
+    connectWithInvite: (profileId: string, challenge: string, expiration: number) => Promise<boolean>;
     cancelConnectionRequest: (profileId: string) => Promise<boolean>;
     disconnectWith: (profileId: string) => Promise<boolean>;
     acceptConnectionRequest: (id: string) => Promise<boolean>;
     getConnections: () => Promise<LCNProfile[]>;
     getPendingConnections: () => Promise<LCNProfile[]>;
     getConnectionRequests: () => Promise<LCNProfile[]>;
-    generateInvite: (challenge?: string) => Promise<{ profileId: string; challenge: string }>;
+    generateInvite: (challenge?: string, expiration?: number) => Promise<{ profileId: string; challenge: string; expiration: number }>;
 
     blockProfile: (profileId: string) => Promise<boolean>;
     unblockProfile: (profileId: string) => Promise<boolean>;
@@ -117,8 +117,9 @@ export type LearnCardNetworkPluginMethods = {
         boostUri: string,
         claimLinkSA: LCNBoostClaimLinkSigningAuthorityType,
         options?: LCNBoostClaimLinkOptionsType,
-        challenge?: string
-    ) => Promise<{ boostUri: string; challenge: string }>;
+        challenge?: string,
+        expiration?: number
+    ) => Promise<{ boostUri: string; challenge: string; expiration: number }>;
     claimBoostWithLink: (boostUri: string, challenge: string) => Promise<string>;
 
     resolveFromLCN: (uri: string) => Promise<VC | UnsignedVC | VP | JWE>;

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -49,7 +49,7 @@ export type LearnCardNetworkPluginMethods = {
         }
     ) => Promise<LCNProfile[]>;
     connectWith: (profileId: string) => Promise<boolean>;
-    connectWithInvite: (profileId: string, challenge: string, expiration: number) => Promise<boolean>;
+    connectWithInvite: (profileId: string, challenge: string) => Promise<boolean>;
     cancelConnectionRequest: (profileId: string) => Promise<boolean>;
     disconnectWith: (profileId: string) => Promise<boolean>;
     acceptConnectionRequest: (id: string) => Promise<boolean>;

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -56,7 +56,7 @@ export type LearnCardNetworkPluginMethods = {
     getConnections: () => Promise<LCNProfile[]>;
     getPendingConnections: () => Promise<LCNProfile[]>;
     getConnectionRequests: () => Promise<LCNProfile[]>;
-    generateInvite: (challenge?: string, expiration?: number) => Promise<{ profileId: string; challenge: string; expiration: number }>;
+    generateInvite: (challenge?: string, expiration?: number) => Promise<{ profileId: string; challenge: string}>;
 
     blockProfile: (profileId: string) => Promise<boolean>;
     unblockProfile: (profileId: string) => Promise<boolean>;
@@ -119,7 +119,7 @@ export type LearnCardNetworkPluginMethods = {
         options?: LCNBoostClaimLinkOptionsType,
         challenge?: string,
         expiration?: number
-    ) => Promise<{ boostUri: string; challenge: string; expiration: number }>;
+    ) => Promise<{ boostUri: string; challenge: string }>;
     claimBoostWithLink: (boostUri: string, challenge: string) => Promise<string>;
 
     resolveFromLCN: (uri: string) => Promise<VC | UnsignedVC | VP | JWE>;

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -117,8 +117,7 @@ export type LearnCardNetworkPluginMethods = {
         boostUri: string,
         claimLinkSA: LCNBoostClaimLinkSigningAuthorityType,
         options?: LCNBoostClaimLinkOptionsType,
-        challenge?: string,
-        expiration?: number
+        challenge?: string
     ) => Promise<{ boostUri: string; challenge: string }>;
     claimBoostWithLink: (boostUri: string, challenge: string) => Promise<string>;
 

--- a/services/learn-card-network/brain-service/src/cache/invites.ts
+++ b/services/learn-card-network/brain-service/src/cache/invites.ts
@@ -1,32 +1,35 @@
 import cache from '@cache';
+import exp from 'node:constants';
 
-export const getInviteCacheKey = (profileId: string, challenge: string): string =>
-    `inviteChallenge:${profileId}:${challenge}`;
+export const getInviteCacheKey = (profileId: string, challenge: string, expiration: number): string =>
+    `inviteChallenge:${profileId}:${challenge}:${expiration}`;
 
 export const VALID = 'valid';
 
 export const isInviteValidForProfile = async (
     profileId: string,
-    challenge: string
+    challenge: string,
+    expiration: number
 ): Promise<typeof VALID | null | undefined> => {
-    const result = await cache.get(getInviteCacheKey(profileId, challenge));
+    const result = await cache.get(getInviteCacheKey(profileId, challenge, expiration));
 
     return result === VALID ? result : undefined;
 };
 
 export const isInviteAlreadySetForProfile = async (
     profileId: string,
-    challenge: string
+    challenge: string,
+    expiration: number
 ): Promise<boolean> => {
-    const result = await cache.get(getInviteCacheKey(profileId, challenge));
+    const result = await cache.get(getInviteCacheKey(profileId, challenge, expiration));
 
     return Boolean(result);
 };
 
-export const setValidInviteForProfile = async (profileId: string, challenge: string) => {
-    return cache.set(getInviteCacheKey(profileId, challenge), VALID);
+export const setValidInviteForProfile = async (profileId: string, challenge: string, expiration: number) => {
+    return cache.set(getInviteCacheKey(profileId, challenge, expiration), VALID);
 };
 
-export const invalidateInviteForProfile = async (profileId: string, challenge: string) => {
-    return cache.delete([getInviteCacheKey(profileId, challenge)]);
+export const invalidateInviteForProfile = async (profileId: string, challenge: string, expiration: number) => {
+    return cache.delete([getInviteCacheKey(profileId, challenge, expiration)]);
 };

--- a/services/learn-card-network/brain-service/src/cache/invites.ts
+++ b/services/learn-card-network/brain-service/src/cache/invites.ts
@@ -1,17 +1,15 @@
 import cache from '@cache';
-import exp from 'node:constants';
 
-export const getInviteCacheKey = (profileId: string, challenge: string, expiration: number): string =>
-    `inviteChallenge:${profileId}:${challenge}:${expiration}`;
+export const getInviteCacheKey = (profileId: string, challenge: string): string =>
+    `inviteChallenge:${profileId}:${challenge}`;
 
 export const VALID = 'valid';
 
 export const isInviteValidForProfile = async (
     profileId: string,
     challenge: string,
-    expiration: number
 ): Promise<typeof VALID | null | undefined> => {
-    const result = await cache.get(getInviteCacheKey(profileId, challenge, expiration));
+    const result = await cache.get(getInviteCacheKey(profileId, challenge));
 
     return result === VALID ? result : undefined;
 };
@@ -19,17 +17,16 @@ export const isInviteValidForProfile = async (
 export const isInviteAlreadySetForProfile = async (
     profileId: string,
     challenge: string,
-    expiration: number
 ): Promise<boolean> => {
-    const result = await cache.get(getInviteCacheKey(profileId, challenge, expiration));
+    const result = await cache.get(getInviteCacheKey(profileId, challenge));
 
     return Boolean(result);
 };
 
-export const setValidInviteForProfile = async (profileId: string, challenge: string, expiration: number) => {
-    return cache.set(getInviteCacheKey(profileId, challenge, expiration), VALID);
+export const setValidInviteForProfile = async (profileId: string, challenge: string, expiration?: number) => {
+    return cache.set(getInviteCacheKey(profileId, challenge), VALID, expiration);
 };
 
-export const invalidateInviteForProfile = async (profileId: string, challenge: string, expiration: number) => {
-    return cache.delete([getInviteCacheKey(profileId, challenge, expiration)]);
+export const invalidateInviteForProfile = async (profileId: string, challenge: string) => {
+    return cache.delete([getInviteCacheKey(profileId, challenge)]);
 };

--- a/services/learn-card-network/brain-service/src/routes/profiles.ts
+++ b/services/learn-card-network/brain-service/src/routes/profiles.ts
@@ -576,7 +576,7 @@ export const profilesRouter = t.router({
                     'This route creates a one-time challenge that an unknown profile can use to connect with this account',
             },
         })
-        .input(z.object({ challenge: z.string().optional(), expiration: z.number().default(3600) }).optional(),)
+        .input(z.object({ challenge: z.string().optional(), expiration: z.number().default(3600 * 24 * 30) }).optional(),)
         .output(z.object({ profileId: z.string(), challenge: z.string() }))
         .mutation(async ({ ctx, input }) => {
             const { profile } = ctx.user;

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -1416,7 +1416,7 @@ describe('Profiles', () => {
 
             await userA.clients.fullAuth.profile.generateInvite({
                 challenge: 'nice',
-                expiration: new Date('02-06-2025').getTime(),
+                expiration: 60 * 60 * 24 * 7 * 52 *3, // 3 Years
             });
 
             jest.setSystemTime(new Date('02-06-2025'));

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -1432,6 +1432,8 @@ describe('Profiles', () => {
         });
 
         it('allows connections with challenges before they expire', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
+
             await userA.clients.fullAuth.profile.generateInvite({
                 challenge: 'validChallenge',
                 expiration: 60 * 60 * 24 * 7, // Expires in 1 week
@@ -1447,6 +1449,30 @@ describe('Profiles', () => {
                     profileId: 'usera',
                 })
             ).resolves.not.toThrow();
+
+            jest.useRealTimers();
+        });
+
+        it('does not allow connections with challenges after they expire', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
+
+            await userA.clients.fullAuth.profile.generateInvite({
+                challenge: 'validChallenge',
+                expiration: 60 * 60 * 24 * 7, // Expires in 1 week
+            });
+
+            // Fast-forward time by 3 weeks
+            jest.advanceTimersByTime(3 * 7 * 60 * 60 * 24 * 1000);
+
+            // Attempt to connect with the challenge before it expires
+            await expect(
+                userB.clients.fullAuth.profile.connectWithInvite({
+                    challenge: 'validChallenge',
+                    profileId: 'usera',
+                })
+            ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+            jest.useRealTimers();
         });
     });
 

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -1416,7 +1416,7 @@ describe('Profiles', () => {
 
             await userA.clients.fullAuth.profile.generateInvite({
                 challenge: 'nice',
-                expiration: 60 * 60 * 24 * 7 * 52 *3, // 3 Years
+                expiration: 60 * 60 * 24 * 7 * 52 * 3, // 3 Years
             });
 
             jest.setSystemTime(new Date('02-06-2025'));
@@ -1429,26 +1429,24 @@ describe('Profiles', () => {
             ).resolves.not.toThrow();
 
             jest.useRealTimers();
-        });  
+        });
 
-        it('the generation date cannot be updated after creation', async () => {
-            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
-
+        it('allows connections with challenges before they expire', async () => {
             await userA.clients.fullAuth.profile.generateInvite({
-                challenge: 'nice',
-                expiration: new Date('02-06-2025').getTime(),
+                challenge: 'validChallenge',
+                expiration: 60 * 60 * 24 * 7, // Expires in 1 week
             });
 
-            jest.setSystemTime(new Date('02-06-2025'));
+            // Fast-forward time by 3 days
+            jest.advanceTimersByTime(60 * 60 * 24 * 1000 * 3);
 
+            // Attempt to connect with the challenge before it expires
             await expect(
                 userB.clients.fullAuth.profile.connectWithInvite({
-                    challenge: 'nice',
+                    challenge: 'validChallenge',
                     profileId: 'usera',
                 })
             ).resolves.not.toThrow();
-
-            jest.useRealTimers();
         });
     });
 

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -1411,26 +1411,6 @@ describe('Profiles', () => {
             jest.useRealTimers();
         });
 
-        it('allows setting the expiration length', async () => {
-            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
-
-            await userA.clients.fullAuth.profile.generateInvite({
-                challenge: 'nice',
-                expiration: 1000 * 60 * 60 * 24 * 365,
-            });
-
-            jest.setSystemTime(new Date('02-06-2024'));
-
-            await expect(
-                userB.clients.fullAuth.profile.connectWithInvite({
-                    challenge: 'nice',
-                    profileId: 'usera',
-                })
-            ).resolves.not.toThrow();
-
-            jest.useRealTimers();
-        });
-
         it('allows setting the expiration date', async () => {
             jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
 

--- a/services/learn-card-network/brain-service/test/profiles.spec.ts
+++ b/services/learn-card-network/brain-service/test/profiles.spec.ts
@@ -1410,6 +1410,66 @@ describe('Profiles', () => {
 
             jest.useRealTimers();
         });
+
+        it('allows setting the expiration length', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
+
+            await userA.clients.fullAuth.profile.generateInvite({
+                challenge: 'nice',
+                expiration: 1000 * 60 * 60 * 24 * 365,
+            });
+
+            jest.setSystemTime(new Date('02-06-2024'));
+
+            await expect(
+                userB.clients.fullAuth.profile.connectWithInvite({
+                    challenge: 'nice',
+                    profileId: 'usera',
+                })
+            ).resolves.not.toThrow();
+
+            jest.useRealTimers();
+        });
+
+        it('allows setting the expiration date', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
+
+            await userA.clients.fullAuth.profile.generateInvite({
+                challenge: 'nice',
+                expiration: new Date('02-06-2025').getTime(),
+            });
+
+            jest.setSystemTime(new Date('02-06-2025'));
+
+            await expect(
+                userB.clients.fullAuth.profile.connectWithInvite({
+                    challenge: 'nice',
+                    profileId: 'usera',
+                })
+            ).resolves.not.toThrow();
+
+            jest.useRealTimers();
+        });  
+
+        it('the generation date cannot be updated after creation', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('02-06-2023'));
+
+            await userA.clients.fullAuth.profile.generateInvite({
+                challenge: 'nice',
+                expiration: new Date('02-06-2025').getTime(),
+            });
+
+            jest.setSystemTime(new Date('02-06-2025'));
+
+            await expect(
+                userB.clients.fullAuth.profile.connectWithInvite({
+                    challenge: 'nice',
+                    profileId: 'usera',
+                })
+            ).resolves.not.toThrow();
+
+            jest.useRealTimers();
+        });
     });
 
     describe('registerSigningAuthority', () => {


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
https://welibrary.atlassian.net/browse/LC-21

Lets set the expiration for the add profile link to 30 Days vs 1 hour. 

Stretch Goal: Add selector to choose 24 hours, 7 days, 1 mo, never expire

#### 📚 What is the context and goal of this PR?
Allows users to set the expiration for the add profile link to 30 Days vs 1 hour. 

#### 🥴 TL; RL:
The "generateInvite" function now has an `expiration` parameter and the "generateInvite: profileRoute" endpoint now takes an `expiration` as an input. 
![image](https://github.com/learningeconomy/LearnCard/assets/52934303/6b7c84fc-035a-492a-bf33-e5c42ebd69f5)

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing
Yes in "LearnCard/services/learn-card-network/brain-service/test/profiles.spec.ts" two new tests:
- allows setting the expiration length
- the generation date cannot be updated after creation

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Running jest unit tests *OR* edit the default expiration pictured above to a very short amount of time to watch the invite fail. 

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
Jest unit tests and QA. 


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [ ] There is **not** a "Do Not Merge" label on this PR
- [ ] I have thoughtfully considered the security implications of this change.
- [ ] This change does not expose new public facing endpoints that do not have authentication
