### PR TITLE
LearnCard ConsentFlow 2.2 Iterations

### DIFF
--- a/.changeset/angry-comics-divide.md
+++ b/.changeset/angry-comics-divide.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Allow getting all data for consented contracts

--- a/.changeset/chilly-experts-count.md
+++ b/.changeset/chilly-experts-count.md
@@ -1,0 +1,8 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+'@learncard/types': patch
+'@learncard/init': patch
+---
+
+Add more fields to LCN Profiles

--- a/.changeset/eighty-berries-film.md
+++ b/.changeset/eighty-berries-film.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Allow querying when getting a specific contract's data

--- a/.changeset/khaki-bottles-rule.md
+++ b/.changeset/khaki-bottles-rule.md
@@ -1,0 +1,7 @@
+---
+'@learncard/types': patch
+'@learncard/didkit-plugin': patch
+'@learncard/vc-plugin': patch
+---
+
+Add DidDocument type

--- a/.changeset/nice-ties-shout.md
+++ b/.changeset/nice-ties-shout.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-service': patch
+---
+
+Send notifications when a new Transaction is made

--- a/.changeset/purple-parents-cry.md
+++ b/.changeset/purple-parents-cry.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Allow managing service profiles

--- a/.changeset/silly-ears-joke.md
+++ b/.changeset/silly-ears-joke.md
@@ -1,0 +1,5 @@
+---
+'@learncard/vc-plugin': patch
+---
+
+Better default verificationMethod logic

--- a/.changeset/twelve-eyes-look.md
+++ b/.changeset/twelve-eyes-look.md
@@ -1,0 +1,5 @@
+---
+'@learncard/init': patch
+---
+
+Add DidWebNetworkLearnCard target

--- a/packages/learn-card-init/src/init.ts
+++ b/packages/learn-card-init/src/init.ts
@@ -3,6 +3,7 @@ import { emptyLearnCard } from './initializers/emptyLearnCard';
 import { learnCardFromSeed } from './initializers/learnCardFromSeed';
 import { networkLearnCardFromSeed } from './initializers/networkLearnCardFromSeed';
 import { didWebLearnCardFromSeed } from './initializers/didWebLearnCardFromSeed';
+import { didWebNetworkLearnCardFromSeed } from './initializers/didWebNetworkLearnCardFromSeed';
 import { learnCardFromApiUrl } from './initializers/apiLearnCard';
 
 import {
@@ -13,6 +14,7 @@ import {
     CustomLearnCard,
     NetworkLearnCardFromSeed,
     DidWebLearnCardFromSeed,
+    DidWebNetworkLearnCardFromSeed,
 } from 'types/LearnCard';
 
 export * from './initializers/customLearnCard';
@@ -20,6 +22,7 @@ export * from './initializers/emptyLearnCard';
 export * from './initializers/learnCardFromSeed';
 export * from './initializers/networkLearnCardFromSeed';
 export * from './initializers/didWebLearnCardFromSeed';
+export * from './initializers/didWebNetworkLearnCardFromSeed';
 export * from './initializers/apiLearnCard';
 
 // Overloads (Unfortunately necessary boilerplate 😢)
@@ -59,6 +62,15 @@ export function initLearnCard(
 export function initLearnCard(
     config: NetworkLearnCardFromSeed['args']
 ): Promise<NetworkLearnCardFromSeed['returnValue']>;
+
+/**
+ * Generates a full wallet with access to LearnCard Network from a 32 byte seed using a different did:web
+ *
+ * @group Init Functions
+ */
+export function initLearnCard(
+    config: DidWebNetworkLearnCardFromSeed['args']
+): Promise<DidWebNetworkLearnCardFromSeed['returnValue']>;
 
 /**
  * Generates a wallet that can sign VCs/VPs from a VC API
@@ -101,7 +113,11 @@ export async function initLearnCard(
     }
 
     if ('seed' in config) {
-        if ('network' in config) return networkLearnCardFromSeed(config);
+        if ('network' in config) {
+            if ('didWeb' in config) return didWebNetworkLearnCardFromSeed(config);
+
+            return networkLearnCardFromSeed(config);
+        }
 
         if ('didWeb' in config) return didWebLearnCardFromSeed(config);
 

--- a/packages/learn-card-init/src/initializers/didWebNetworkLearnCardFromSeed.ts
+++ b/packages/learn-card-init/src/initializers/didWebNetworkLearnCardFromSeed.ts
@@ -1,0 +1,87 @@
+import { generateLearnCard } from '@learncard/core';
+import { DynamicLoaderPlugin } from '@learncard/dynamic-loader-plugin';
+import { CryptoPlugin } from '@learncard/crypto-plugin';
+import { DidMethod, getDidKitPlugin } from '@learncard/didkit-plugin';
+import { getDidKeyPlugin } from '@learncard/didkey-plugin';
+import { getVCPlugin } from '@learncard/vc-plugin';
+import { getVCTemplatesPlugin } from '@learncard/vc-templates-plugin';
+import { getCeramicPlugin } from '@learncard/ceramic-plugin';
+import { getLearnCloudPlugin } from '@learncard/learn-cloud-plugin';
+import { getIDXPlugin } from '@learncard/idx-plugin';
+import { expirationPlugin } from '@learncard/expiration-plugin';
+import { getEthereumPlugin } from '@learncard/ethereum-plugin';
+import { getVpqrPlugin } from '@learncard/vpqr-plugin';
+import { getCHAPIPlugin } from '@learncard/chapi-plugin';
+import { getVerifyBoostPlugin, getLearnCardNetworkPlugin } from '@learncard/network-plugin';
+import { getLearnCardPlugin } from '@learncard/learn-card-plugin';
+import { getDidWebPlugin } from '@learncard/did-web-plugin';
+
+import { DidWebNetworkLearnCardFromSeed } from 'types/LearnCard';
+import { defaultCeramicIDXArgs, defaultEthereumArgs } from '../defaults';
+
+/**
+ * Generates a Network LearnCard Wallet with a custom did:web did from a 64 character seed string
+ *
+ * @group Init Functions
+ */
+export const didWebNetworkLearnCardFromSeed = async ({
+    seed,
+    didWeb,
+    network: _network,
+    trustedBoostRegistry,
+
+    cloud: {
+        url = 'https://cloud.learncard.com/trpc',
+        unencryptedFields = [],
+        unencryptedCustomFields = [],
+    } = {},
+    ceramicIdx = defaultCeramicIDXArgs,
+    didkit,
+    allowRemoteContexts = false,
+    ethereumConfig = defaultEthereumArgs,
+    debug,
+}: DidWebNetworkLearnCardFromSeed['args']): Promise<
+    DidWebNetworkLearnCardFromSeed['returnValue']
+> => {
+    const network = typeof _network === 'boolean' ? 'https://network.learncard.com/trpc' : _network;
+
+    const dynamicLc = await (await generateLearnCard({ debug })).addPlugin(DynamicLoaderPlugin);
+
+    const cryptoLc = await dynamicLc.addPlugin(CryptoPlugin);
+
+    const didkitLc = await cryptoLc.addPlugin(await getDidKitPlugin(didkit, allowRemoteContexts));
+
+    const didkeyLc = await didkitLc.addPlugin(
+        await getDidKeyPlugin<DidMethod>(didkitLc, seed, 'key')
+    );
+
+    const didkeyAndVCLc = await didkeyLc.addPlugin(getVCPlugin(didkeyLc));
+
+    const templateLc = await didkeyAndVCLc.addPlugin(getVCTemplatesPlugin());
+
+    const ceramicLc = await templateLc.addPlugin(await getCeramicPlugin(templateLc, ceramicIdx));
+
+    const cloudLc = await ceramicLc.addPlugin(
+        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields)
+    );
+
+    const idxLc = await cloudLc.addPlugin(await getIDXPlugin(cloudLc, ceramicIdx));
+
+    const expirationLc = await idxLc.addPlugin(expirationPlugin(idxLc));
+
+    const ethLc = await expirationLc.addPlugin(getEthereumPlugin(expirationLc, ethereumConfig));
+
+    const vpqrLc = await ethLc.addPlugin(getVpqrPlugin(ethLc));
+
+    const chapiLc = await vpqrLc.addPlugin(await getCHAPIPlugin());
+
+    const boostVerificationLc = await chapiLc.addPlugin(
+        await getVerifyBoostPlugin(chapiLc, trustedBoostRegistry)
+    );
+
+    const lcLc = await boostVerificationLc.addPlugin(getLearnCardPlugin(boostVerificationLc));
+
+    const didWebLc = await lcLc.addPlugin(await getDidWebPlugin(lcLc, didWeb));
+
+    return didWebLc.addPlugin(await getLearnCardNetworkPlugin(didWebLc, network));
+};

--- a/packages/learn-card-init/src/types/LearnCard.ts
+++ b/packages/learn-card-init/src/types/LearnCard.ts
@@ -124,6 +124,33 @@ export type DidWebLearnCardFromSeed = InitFunction<
 >;
 
 /** @group Init Functions */
+export type DidWebNetworkLearnCardFromSeed = InitFunction<
+    { seed: string; network: true | string; didWeb: string; trustedBoostRegistry?: string },
+    keyof LearnCardConfig,
+    LearnCard<
+        [
+            DynamicLoaderPluginType,
+            CryptoPluginType,
+            DIDKitPlugin,
+            DidKeyPlugin<DidMethod>,
+            VCPlugin,
+            VCTemplatePlugin,
+            CeramicPlugin,
+            LearnCloudPlugin,
+            IDXPlugin,
+            ExpirationPlugin,
+            EthereumPlugin,
+            VpqrPlugin,
+            CHAPIPlugin,
+            VerifyBoostPlugin,
+            LearnCardPlugin,
+            DidWebPlugin,
+            LearnCardNetworkPlugin
+        ]
+    >
+>;
+
+/** @group Init Functions */
 export type LearnCardFromVcApi = InitFunction<
     { vcApi: true | string; did?: string },
     'debug',
@@ -149,6 +176,7 @@ export type InitLearnCard = GenericInitFunction<
         LearnCardFromSeed,
         NetworkLearnCardFromSeed,
         DidWebLearnCardFromSeed,
+        DidWebNetworkLearnCardFromSeed,
         LearnCardFromVcApi,
         CustomLearnCard
     ]

--- a/packages/learn-card-types/src/did.ts
+++ b/packages/learn-card-types/src/did.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { ContextValidator, ProofValidator } from './vc';
+import { JWKValidator } from './crypto';
+
+export const VerificationMethodValidator = z.string().or(
+    z
+        .object({
+            '@context': ContextValidator.optional(),
+            id: z.string(),
+            type: z.string(),
+            controller: z.string(),
+            publicKeyJwk: JWKValidator.optional(),
+            publicKeyBase58: z.string().optional(),
+            blockChainAccountId: z.string().optional(),
+        })
+        .catchall(z.any())
+);
+export type VerificationMethod = z.infer<typeof VerificationMethodValidator>;
+
+export const ServiceValidator = z
+    .object({
+        id: z.string(),
+        type: z.string().or(z.string().array().nonempty()),
+        serviceEndpoint: z.any().or(z.any().array().nonempty()),
+    })
+    .catchall(z.any());
+export type Service = z.infer<typeof ServiceValidator>;
+
+export const DidDocumentValidator = z
+    .object({
+        '@context': ContextValidator,
+        id: z.string(),
+        alsoKnownAs: z.string().optional(),
+        controller: z.string().or(z.string().array().nonempty()).optional(),
+        verificationMethod: VerificationMethodValidator.array().optional(),
+        authentication: VerificationMethodValidator.array().optional(),
+        assertionMethod: VerificationMethodValidator.array().optional(),
+        keyAgreement: VerificationMethodValidator.array().optional(),
+        capabilityInvocation: VerificationMethodValidator.array().optional(),
+        capabilityDelegation: VerificationMethodValidator.array().optional(),
+        publicKey: VerificationMethodValidator.array().optional(),
+        service: ServiceValidator.array().optional(),
+        proof: ProofValidator.or(ProofValidator.array()).optional(),
+    })
+    .catchall(z.any());
+export type DidDocument = z.infer<typeof DidDocumentValidator>;

--- a/packages/learn-card-types/src/index.ts
+++ b/packages/learn-card-types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './vc';
+export * from './did';
 export * from './obv3';
 export * from './learncard';
 export * from './learncloud';

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -5,11 +5,15 @@ import { PaginationResponseValidator } from './mongo';
 export const LCNProfileValidator = z.object({
     profileId: z.string().min(3).max(40),
     displayName: z.string().default(''),
+    shortBio: z.string().default(''),
     bio: z.string().default(''),
     did: z.string(),
     email: z.string().optional(),
     image: z.string().optional(),
+    heroImage: z.string().optional(),
+    websiteLink: z.string().optional(),
     isServiceProfile: z.boolean().default(false).optional(),
+    type: z.string().optional(),
     notificationsWebhook: z.string().url().startsWith('https://').optional(),
 });
 export type LCNProfile = z.infer<typeof LCNProfileValidator>;

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -61,44 +61,6 @@ export const BoostRecipientValidator = z.object({
 
 export type BoostRecipientInfo = z.infer<typeof BoostRecipientValidator>;
 
-export const LCNNotificationTypeEnumValidator = z.enum([
-    'CONNECTION_REQUEST',
-    'CONNECTION_ACCEPTED',
-    'CREDENTIAL_RECEIVED',
-    'CREDENTIAL_ACCEPTED',
-    'BOOST_RECEIVED',
-    'BOOST_ACCEPTED',
-    'PRESENTATION_REQUEST',
-    'PRESENTATION_RECEIVED',
-]);
-
-export type LCNNotificationTypeEnum = z.infer<typeof LCNNotificationTypeEnumValidator>;
-
-export const LCNNotificationMessageValidator = z.object({
-    title: z.string().optional(),
-    body: z.string().optional(),
-});
-
-export type LCNNotificationMessage = z.infer<typeof LCNNotificationMessageValidator>;
-
-export const LCNNotificationDataValidator = z.object({
-    vcUris: z.array(z.string()).optional(),
-    vpUris: z.array(z.string()).optional(),
-});
-
-export type LCNNotificationData = z.infer<typeof LCNNotificationDataValidator>;
-
-export const LCNNotificationValidator = z.object({
-    type: LCNNotificationTypeEnumValidator,
-    to: LCNProfileValidator.partial().and(z.object({ did: z.string() })),
-    from: LCNProfileValidator.partial().and(z.object({ did: z.string() })),
-    message: LCNNotificationMessageValidator.optional(),
-    data: LCNNotificationDataValidator.optional(),
-    sent: z.string().datetime().optional(),
-});
-
-export type LCNNotification = z.infer<typeof LCNNotificationValidator>;
-
 export const LCNBoostClaimLinkSigningAuthorityValidator = z.object({
     endpoint: z.string(),
     name: z.string(),
@@ -353,3 +315,43 @@ export const PaginatedConsentFlowTransactionsValidator = PaginationResponseValid
 export type PaginatedConsentFlowTransactions = z.infer<
     typeof PaginatedConsentFlowTransactionsValidator
 >;
+
+export const LCNNotificationTypeEnumValidator = z.enum([
+    'CONNECTION_REQUEST',
+    'CONNECTION_ACCEPTED',
+    'CREDENTIAL_RECEIVED',
+    'CREDENTIAL_ACCEPTED',
+    'BOOST_RECEIVED',
+    'BOOST_ACCEPTED',
+    'PRESENTATION_REQUEST',
+    'PRESENTATION_RECEIVED',
+    'CONSENT_FLOW_TRANSACTION',
+]);
+
+export type LCNNotificationTypeEnum = z.infer<typeof LCNNotificationTypeEnumValidator>;
+
+export const LCNNotificationMessageValidator = z.object({
+    title: z.string().optional(),
+    body: z.string().optional(),
+});
+
+export type LCNNotificationMessage = z.infer<typeof LCNNotificationMessageValidator>;
+
+export const LCNNotificationDataValidator = z.object({
+    vcUris: z.array(z.string()).optional(),
+    vpUris: z.array(z.string()).optional(),
+    transaction: ConsentFlowTransactionValidator.optional(),
+});
+
+export type LCNNotificationData = z.infer<typeof LCNNotificationDataValidator>;
+
+export const LCNNotificationValidator = z.object({
+    type: LCNNotificationTypeEnumValidator,
+    to: LCNProfileValidator.partial().and(z.object({ did: z.string() })),
+    from: LCNProfileValidator.partial().and(z.object({ did: z.string() })),
+    message: LCNNotificationMessageValidator.optional(),
+    data: LCNNotificationDataValidator.optional(),
+    sent: z.string().datetime().optional(),
+});
+
+export type LCNNotification = z.infer<typeof LCNNotificationValidator>;

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -265,6 +265,14 @@ export const ConsentFlowContractQueryValidator = z.object({
 export type ConsentFlowContractQuery = z.infer<typeof ConsentFlowContractQueryValidator>;
 export type ConsentFlowContractQueryInput = z.input<typeof ConsentFlowContractQueryValidator>;
 
+export const ConsentFlowDataQueryValidator = z.object({
+    anonymize: z.boolean().optional(),
+    credentials: z.object({ categories: z.record(z.boolean()).optional() }).optional(),
+    personal: z.record(z.boolean()).optional(),
+});
+export type ConsentFlowDataQuery = z.infer<typeof ConsentFlowDataQueryValidator>;
+export type ConsentFlowDataQueryInput = z.input<typeof ConsentFlowDataQueryValidator>;
+
 export const ConsentFlowTermsQueryValidator = z.object({
     read: z
         .object({

--- a/packages/plugins/didkit/src/types.ts
+++ b/packages/plugins/didkit/src/types.ts
@@ -1,4 +1,12 @@
-import { JWK, UnsignedVC, UnsignedVP, VC, VP, VerificationCheck } from '@learncard/types';
+import {
+    JWK,
+    UnsignedVC,
+    UnsignedVP,
+    VC,
+    VP,
+    VerificationCheck,
+    DidDocument,
+} from '@learncard/types';
 import type { DIDResolutionResult } from 'dids';
 import { Plugin } from '@learncard/core';
 
@@ -60,7 +68,7 @@ export type DidkitPluginMethods = {
         options?: ProofOptions
     ) => Promise<VerificationCheck>;
     contextLoader: (url: string) => Promise<Record<string, any>>;
-    resolveDid: (did: string, inputMetadata?: InputMetadata) => Promise<Record<string, any>>;
+    resolveDid: (did: string, inputMetadata?: InputMetadata) => Promise<DidDocument>;
     didResolver: (did: string, inputMetadata?: InputMetadata) => Promise<DIDResolutionResult>;
 };
 

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -130,6 +130,8 @@ export const getLearnCardNetworkPlugin = async (
                 return newDid;
             },
             createManagedServiceProfile: async (_learnCard, profile) => {
+                if (!userData) throw new Error('Please make an account first!');
+
                 const newDid = await client.profile.createManagedServiceProfile.mutate(profile);
 
                 return newDid;

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -507,10 +507,16 @@ export const getLearnCardNetworkPlugin = async (
                 return client.contracts.deleteConsentFlowContract.mutate({ uri });
             },
 
-            getConsentFlowData: async (_learnCard, uri, options) => {
+            getConsentFlowData: async (_learnCard, uri, options = {}) => {
                 if (!userData) throw new Error('Please make an account first!');
 
                 return client.contracts.getConsentedDataForContract.query({ uri, ...options });
+            },
+
+            getAllConsentFlowData: async (_learnCard, query = {}, options = {}) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.contracts.getConsentedData.query({ query, ...options });
             },
 
             consentToContract: async (_learnCard, contractUri, { terms, expiresAt, oneTime }) => {

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -129,6 +129,16 @@ export const getLearnCardNetworkPlugin = async (
 
                 return newDid;
             },
+            createManagedServiceProfile: async (_learnCard, profile) => {
+                const newDid = await client.profile.createManagedServiceProfile.mutate(profile);
+
+                return newDid;
+            },
+            getManagedServiceProfiles: async (_learnCard, options = {}) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.profile.getManagedServiceProfiles.query(options);
+            },
             updateProfile: async (_learnCard, profile) => {
                 if (!userData) throw new Error('Please make an account first!');
 
@@ -468,7 +478,7 @@ export const getLearnCardNetworkPlugin = async (
                     challenge,
                 });
             },
-            
+
             claimBoostWithLink: async (_learnCard, boostUri, challenge) => {
                 if (!userData) throw new Error('Please make an account first!');
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -24,7 +24,7 @@ import {
     ConsentFlowTransactionsQuery,
     PaginatedConsentFlowData,
 } from '@learncard/types';
-import { Plugin } from '@learncard/core';
+import { LearnCard, Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
 import { VerifyExtension } from '@learncard/vc-plugin';
 
@@ -44,6 +44,12 @@ export type LearnCardNetworkPluginMethods = {
     createServiceProfile: (
         profile: Omit<LCNProfile, 'did' | 'isServiceProfile'>
     ) => Promise<string>;
+    createManagedServiceProfile: (
+        profile: Omit<LCNProfile, 'did' | 'isServiceProfile'>
+    ) => Promise<string>;
+    getManagedServiceProfiles: (
+        options: Partial<PaginationOptionsType> & { id?: string }
+    ) => Promise<PaginatedLCNProfiles>;
     updateProfile: (
         profile: Partial<Omit<LCNProfile, 'did' | 'isServiceProfile'>>
     ) => Promise<boolean>;
@@ -66,7 +72,10 @@ export type LearnCardNetworkPluginMethods = {
     getConnections: () => Promise<LCNProfile[]>;
     getPendingConnections: () => Promise<LCNProfile[]>;
     getConnectionRequests: () => Promise<LCNProfile[]>;
-    generateInvite: (challenge?: string, expiration?: number) => Promise<{ profileId: string; challenge: string}>;
+    generateInvite: (
+        challenge?: string,
+        expiration?: number
+    ) => Promise<{ profileId: string; challenge: string }>;
 
     blockProfile: (profileId: string) => Promise<boolean>;
     unblockProfile: (profileId: string) => Promise<boolean>;

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -156,7 +156,7 @@ export type LearnCardNetworkPluginMethods = {
     deleteContract: (uri: string) => Promise<boolean>;
     getConsentFlowData: (
         uri: string,
-        options?: Partial<PaginationOptionsType>
+        options?: Partial<PaginationOptionsType> & { query?: ConsentFlowDataQuery }
     ) => Promise<PaginatedConsentFlowData>;
     getAllConsentFlowData: (
         query?: ConsentFlowDataQuery,

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -23,6 +23,7 @@ import {
     PaginatedConsentFlowTransactions,
     ConsentFlowTransactionsQuery,
     PaginatedConsentFlowData,
+    ConsentFlowDataQuery,
 } from '@learncard/types';
 import { LearnCard, Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
@@ -155,6 +156,10 @@ export type LearnCardNetworkPluginMethods = {
     deleteContract: (uri: string) => Promise<boolean>;
     getConsentFlowData: (
         uri: string,
+        options?: Partial<PaginationOptionsType>
+    ) => Promise<PaginatedConsentFlowData>;
+    getAllConsentFlowData: (
+        query?: ConsentFlowDataQuery,
         options?: Partial<PaginationOptionsType>
     ) => Promise<PaginatedConsentFlowData>;
     consentToContract: (

--- a/packages/plugins/vc/src/helpers.ts
+++ b/packages/plugins/vc/src/helpers.ts
@@ -1,0 +1,31 @@
+import { VCImplicitLearnCard } from './types';
+
+/**
+ * Determines the default verification method to use for a given did by resolving it and looking
+ * for a keypair that matches the default keypair for the LearnCard
+ */
+export const getDefaultVerificationMethod = async (
+    learnCard: VCImplicitLearnCard,
+    issuerDid: string
+) => {
+    const kp = learnCard.id.keypair();
+
+    if (!kp) {
+        throw new Error('Cannot get default verification method: unable to get subject keypair');
+    }
+
+    const issuerDidDoc = await learnCard.invoke.resolveDid(issuerDid);
+
+    const verificationMethodEntry =
+        typeof issuerDidDoc === 'string'
+            ? undefined
+            : issuerDidDoc?.verificationMethod?.find(entry =>
+                typeof entry === 'string' ? false : entry?.publicKeyJwk?.x === kp.x
+            );
+
+    const verificationMethod =
+        (typeof verificationMethodEntry !== 'string' && verificationMethodEntry?.id) ||
+        (await learnCard.invoke.didToVerificationMethod(issuerDid));
+
+    return verificationMethod;
+};

--- a/packages/plugins/vc/src/issueCredential.ts
+++ b/packages/plugins/vc/src/issueCredential.ts
@@ -13,16 +13,40 @@ export const issueCredential = (initLearnCard: VCDependentLearnCard) => {
 
         if (!kp) throw new Error('Cannot issue credential: Could not get subject keypair');
 
-        const verificationMethod = await learnCard.invoke.didToVerificationMethod(
-            typeof credential.issuer === 'string' ? credential.issuer : credential.issuer.id!
-        );
-
         const options = {
-            verificationMethod,
             proofPurpose: 'assertionMethod',
             type: 'Ed25519Signature2020',
             ...signingOptions,
         };
+
+        if (!('verificationMethod' in options)) {
+            const issuerDid = await learnCard.invoke.resolveDid(
+                typeof credential.issuer === 'string' ? credential.issuer : credential.issuer.id!
+            );
+
+            const verificationMethodEntry =
+                typeof issuerDid === 'string'
+                    ? undefined
+                    : issuerDid?.verificationMethod?.find(entry =>
+                        typeof entry === 'string' ? false : entry?.publicKeyJwk?.x === kp.x
+                    );
+
+            const verificationMethod =
+                (typeof verificationMethodEntry !== 'string' && verificationMethodEntry?.id) ||
+                (await learnCard.invoke.didToVerificationMethod(
+                    typeof credential.issuer === 'string'
+                        ? credential.issuer
+                        : credential.issuer.id!
+                ));
+
+            options.verificationMethod = verificationMethod;
+        }
+
+        learnCard.debug?.('Signing with these options', {
+            credential,
+            options,
+            kp,
+        });
 
         return initLearnCard.invoke.issueCredential(credential, options, kp);
     };

--- a/packages/plugins/vc/src/issueCredential.ts
+++ b/packages/plugins/vc/src/issueCredential.ts
@@ -2,6 +2,7 @@ import { UnsignedVC } from '@learncard/types';
 
 import { ProofOptions } from '@learncard/didkit-plugin';
 import { VCDependentLearnCard, VCImplicitLearnCard } from './types';
+import { getDefaultVerificationMethod } from './helpers';
 
 export const issueCredential = (initLearnCard: VCDependentLearnCard) => {
     return async (
@@ -20,26 +21,10 @@ export const issueCredential = (initLearnCard: VCDependentLearnCard) => {
         };
 
         if (!('verificationMethod' in options)) {
-            const issuerDid = await learnCard.invoke.resolveDid(
-                typeof credential.issuer === 'string' ? credential.issuer : credential.issuer.id!
-            );
+            const issuerDid =
+                typeof credential.issuer === 'string' ? credential.issuer : credential.issuer.id!;
 
-            const verificationMethodEntry =
-                typeof issuerDid === 'string'
-                    ? undefined
-                    : issuerDid?.verificationMethod?.find(entry =>
-                        typeof entry === 'string' ? false : entry?.publicKeyJwk?.x === kp.x
-                    );
-
-            const verificationMethod =
-                (typeof verificationMethodEntry !== 'string' && verificationMethodEntry?.id) ||
-                (await learnCard.invoke.didToVerificationMethod(
-                    typeof credential.issuer === 'string'
-                        ? credential.issuer
-                        : credential.issuer.id!
-                ));
-
-            options.verificationMethod = verificationMethod;
+            options.verificationMethod = await getDefaultVerificationMethod(learnCard, issuerDid);
         }
 
         learnCard.debug?.('Signing with these options', {

--- a/packages/plugins/vc/src/issuePresentation.ts
+++ b/packages/plugins/vc/src/issuePresentation.ts
@@ -2,6 +2,7 @@ import { UnsignedVP } from '@learncard/types';
 
 import { ProofOptions } from '@learncard/didkit-plugin';
 import { VCDependentLearnCard, VCImplicitLearnCard } from './types';
+import { getDefaultVerificationMethod } from './helpers';
 
 export const issuePresentation = (initLearnCard: VCDependentLearnCard) => {
     return async (
@@ -21,20 +22,10 @@ export const issuePresentation = (initLearnCard: VCDependentLearnCard) => {
         };
 
         if (!('verificationMethod' in options)) {
-            const issuerDid = await learnCard.invoke.resolveDid(learnCard.id.did());
-
-            const verificationMethodEntry =
-                typeof issuerDid === 'string'
-                    ? undefined
-                    : issuerDid?.verificationMethod?.find(entry =>
-                        typeof entry === 'string' ? false : entry?.publicKeyJwk?.x === kp.x
-                    );
-
-            const verificationMethod =
-                (typeof verificationMethodEntry !== 'string' && verificationMethodEntry?.id) ||
-                (await learnCard.invoke.didToVerificationMethod(learnCard.id.did()));
-
-            options.verificationMethod = verificationMethod;
+            options.verificationMethod = await getDefaultVerificationMethod(
+                learnCard,
+                learnCard.id.did()
+            );
         }
 
         return initLearnCard.invoke.issuePresentation(presentation, options, kp);

--- a/packages/plugins/vc/src/types.ts
+++ b/packages/plugins/vc/src/types.ts
@@ -1,4 +1,12 @@
-import { JWK, UnsignedVC, VC, UnsignedVP, VP, VerificationCheck } from '@learncard/types';
+import {
+    JWK,
+    UnsignedVC,
+    VC,
+    UnsignedVP,
+    VP,
+    VerificationCheck,
+    DidDocument,
+} from '@learncard/types';
 import { Plugin, LearnCard } from '@learncard/core';
 import { ProofOptions, InputMetadata } from '@learncard/didkit-plugin';
 
@@ -19,7 +27,7 @@ export type VCPluginDependentMethods = {
         presentation: VP | string,
         options?: ProofOptions
     ) => Promise<VerificationCheck>;
-    resolveDid: (did: string, inputMetadata?: InputMetadata) => Promise<Record<string, any>>;
+    resolveDid: (did: string, inputMetadata?: InputMetadata) => Promise<DidDocument>;
 };
 
 /** @group VC Plugin */

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
@@ -131,11 +131,13 @@ export const getContractTermsById = async (
     terms: DbTermsType;
     consenter: LCNProfile;
     contract: DbContractType;
+    contractOwner: LCNProfile;
 } | null> => {
     const result = convertQueryResultToPropertiesObjectArray<{
         consenter: LCNProfile;
         terms: FlatDbTermsType;
         contract: FlatDbContractType;
+        contractOwner: LCNProfile;
     }>(
         await new QueryBuilder()
             .match({
@@ -145,9 +147,11 @@ export const getContractTermsById = async (
                     { model: ConsentFlowTerms, identifier: 'terms', where: { id } },
                     ConsentFlowTerms.getRelationshipByAlias('consentsTo'),
                     { model: ConsentFlowContract, identifier: 'contract' },
+                    `-[:${ConsentFlowContract.getRelationshipByAlias('createdBy').name}]-`,
+                    { identifier: 'contractOwner', model: Profile },
                 ],
             })
-            .return('consenter, terms, contract')
+            .return('consenter, terms, contract, contractOwner')
             .run()
     );
 
@@ -156,6 +160,7 @@ export const getContractTermsById = async (
             consenter: result[0]!.consenter,
             terms: inflateObject(result[0]!.terms),
             contract: inflateObject(result[0]!.contract),
+            contractOwner: result[0]!.contractOwner,
         }
         : null;
 };
@@ -166,6 +171,7 @@ export const getContractTermsByUri = async (
     terms: DbTermsType;
     consenter: LCNProfile;
     contract: DbContractType;
+    contractOwner: LCNProfile;
 } | null> => {
     return getContractTermsById(getIdFromUri(uri));
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
@@ -157,11 +157,11 @@ export const getContractTermsById = async (
 
     return result.length > 0
         ? {
-            consenter: result[0]!.consenter,
-            terms: inflateObject(result[0]!.terms),
-            contract: inflateObject(result[0]!.contract),
-            contractOwner: result[0]!.contractOwner,
-        }
+              consenter: result[0]!.consenter,
+              terms: inflateObject(result[0]!.terms),
+              contract: inflateObject(result[0]!.contract),
+              contractOwner: result[0]!.contractOwner,
+          }
         : null;
 };
 
@@ -276,6 +276,10 @@ export const getConsentedDataForProfile = async (
             ConsentFlowContract.getRelationshipByAlias('createdBy'),
             { model: Profile, where: { profileId } },
         ],
+        // The following is custom Cypher logic that has the following behavior:
+        // If query key is true, ensure all resulting terms have that key
+        // If query key is false, ensure no resulting terms have that key
+        // If query key is not present, return all terms whether they have it or not
     }).where(`
 all(key IN keys($params) WHERE 
     CASE $params[key]
@@ -320,6 +324,10 @@ export const getConsentedDataForContract = async (
             ConsentFlowTerms.getRelationshipByAlias('consentsTo'),
             { model: ConsentFlowContract, where: { id: id } },
         ],
+        // The following is custom Cypher logic that has the following behavior:
+        // If query key is true, ensure all resulting terms have that key
+        // If query key is false, ensure no resulting terms have that key
+        // If query key is not present, return all terms whether they have it or not
     }).where(`
 all(key IN keys($params) WHERE 
     CASE $params[key]

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/read.ts
@@ -1,0 +1,33 @@
+import { Op, QueryBuilder, Where } from 'neogma';
+import { convertQueryResultToPropertiesObjectArray } from '@helpers/neo4j.helpers';
+import { Profile } from '@models';
+import { ProfileType } from 'types/profile';
+
+export const getManagedServiceProfiles = async (
+    profileId: string,
+    { limit, cursor, targetId }: { limit: number; cursor?: string; targetId?: string }
+): Promise<ProfileType[]> => {
+    const _query = new QueryBuilder().match({
+        related: [
+            {
+                identifier: 'managed',
+                model: Profile,
+                ...(targetId && { where: { profileId: targetId } }),
+            },
+            Profile.getRelationshipByAlias('managedBy'),
+            { identifier: 'manager', model: Profile, where: { profileId: profileId } },
+        ],
+    });
+
+    const query = cursor
+        ? _query.where(
+            new Where({ managed: { profileId: { [Op.gt]: cursor } } }, _query.getBindParam())
+        )
+        : _query;
+
+    const results = convertQueryResultToPropertiesObjectArray<{
+        managed: ProfileType;
+    }>(await query.return('managed').orderBy('managed.profileId').limit(limit).run());
+
+    return results.map(({ managed }) => managed);
+};

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import { v4 as uuid } from 'uuid';
 import _sodium from 'libsodium-wrappers';
 import { base64url } from 'multiformats/bases/base64';
 import { base58btc } from 'multiformats/bases/base58';

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -193,6 +193,7 @@ app.get(
                     const { target } = managedRelationship;
 
                     const targetDid = target.did;
+                    const targetKey = target.did.split(':')[2];
 
                     const targetDidDoc = await learnCard.invoke.resolveDid(targetDid);
                     const targetJwk = (targetDidDoc.verificationMethod?.[0] as any)
@@ -202,7 +203,7 @@ app.get(
                     const _x25519PublicKeyBytes =
                         sodium.crypto_sign_ed25519_pk_to_curve25519(_decodedJwk);
 
-                    const id = `${did}#${uuid()}`;
+                    const id = `${did}#${targetKey}`;
 
                     finalDoc.verificationMethod.unshift({
                         id,

--- a/services/learn-card-network/brain-service/src/helpers/contract.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/contract.helpers.ts
@@ -1,4 +1,9 @@
-import { ConsentFlowContractInput, ConsentFlowTermsInput } from '@learncard/types';
+import {
+    ConsentFlowContractInput,
+    ConsentFlowDataQuery,
+    ConsentFlowTermsInput,
+} from '@learncard/types';
+import cloneDeep from 'lodash/cloneDeep';
 
 export const areTermsValid = (terms: ConsentFlowTermsInput, contract: ConsentFlowContractInput) => {
     const contractPersonalReadKeys = Object.keys(contract.read?.personal ?? {});
@@ -44,4 +49,16 @@ export const areTermsValid = (terms: ConsentFlowTermsInput, contract: ConsentFlo
     }
 
     return true;
+};
+
+export const convertDataQueryToNeo4jQuery = (_query: ConsentFlowDataQuery) => {
+    const query = cloneDeep(_query);
+
+    Object.keys(query.credentials?.categories ?? {}).forEach(category => {
+        query.credentials!.categories![category] = {
+            shared: query.credentials!.categories![category],
+        } as any;
+    });
+
+    return { read: query };
 };

--- a/services/learn-card-network/brain-service/src/models/Profile.ts
+++ b/services/learn-card-network/brain-service/src/models/Profile.ts
@@ -14,6 +14,7 @@ export type ProfileRelationships = {
     connectionRequested: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
     connectedWith: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
     blocked: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
+    managedBy: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
     adminOf: ModelRelatedNodesI<typeof Boost, BoostInstance>;
     credentialSent: ModelRelatedNodesI<
         typeof Credential,
@@ -62,6 +63,7 @@ export const Profile = ModelFactory<ProfileType, ProfileRelationships>(
             connectionRequested: { model: 'self', direction: 'out', name: 'CONNECTION_REQUESTED' },
             connectedWith: { model: 'self', direction: 'out', name: 'CONNECTED_WITH' },
             blocked: { model: 'self', direction: 'out', name: 'BLOCKED' },
+            managedBy: { model: 'self', direction: 'out', name: 'MANAGED_BY' },
             credentialSent: {
                 model: Credential,
                 direction: 'out',

--- a/services/learn-card-network/brain-service/src/models/Profile.ts
+++ b/services/learn-card-network/brain-service/src/models/Profile.ts
@@ -43,11 +43,15 @@ export const Profile = ModelFactory<ProfileType, ProfileRelationships>(
         schema: {
             profileId: { type: 'string', required: true, uniqueItems: true },
             displayName: { type: 'string', required: false },
+            shortBio: { type: 'string', required: false },
             bio: { type: 'string', required: false },
             did: { type: 'string', required: true, uniqueItems: true },
             email: { type: 'string', required: false, uniqueItems: true },
             image: { type: 'string', required: false },
+            heroImage: { type: 'string', required: false },
+            websiteLink: { type: 'string', required: false },
             isServiceProfile: { type: 'boolean', required: false },
+            type: { type: 'string', required: false },
             notificationsWebhook: {
                 type: 'string',
                 required: false,

--- a/services/learn-card-network/brain-service/src/routes/contracts.ts
+++ b/services/learn-card-network/brain-service/src/routes/contracts.ts
@@ -225,6 +225,7 @@ export const contractsRouter = t.router({
         .input(
             PaginationOptionsValidator.extend({
                 uri: z.string(),
+                query: ConsentFlowDataQueryValidator.default({}),
                 limit: PaginationOptionsValidator.shape.limit.default(25),
             })
         )
@@ -232,7 +233,7 @@ export const contractsRouter = t.router({
         .query(async ({ ctx, input }) => {
             const { profile } = ctx.user;
 
-            const { uri, limit, cursor } = input;
+            const { uri, query, limit, cursor } = input;
 
             const contract = await getContractByUri(uri);
 
@@ -250,6 +251,7 @@ export const contractsRouter = t.router({
             const contractId = getIdFromUri(uri);
 
             const results = await getConsentedDataForContract(contractId, {
+                query,
                 limit: limit + 1,
                 cursor,
             });

--- a/services/learn-card-network/brain-service/test/consentflow.spec.ts
+++ b/services/learn-card-network/brain-service/test/consentflow.spec.ts
@@ -5,6 +5,11 @@ import {
     minimalTerms,
     noTerms,
     predatoryContract,
+    normalContract,
+    normalFullTerms,
+    normalAchievementOnlyTerms,
+    normalIDOnlyTerms,
+    normalNoTerms,
 } from './helpers/contract';
 import { getClient, getUser } from './helpers/getClient';
 import { Profile, ConsentFlowContract, ConsentFlowTransaction, ConsentFlowTerms } from '@models';
@@ -389,6 +394,212 @@ describe('Consent Flow Contracts', () => {
             await expect(
                 userB.clients.fullAuth.contracts.getConsentedDataForContract({ uri })
             ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+    });
+
+    describe('getConsentedData', () => {
+        let uri: string;
+
+        beforeEach(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await ConsentFlowContract.delete({ detach: true, where: {} });
+            await ConsentFlowTerms.delete({ detach: true, where: {} });
+            await ConsentFlowTransaction.delete({ detach: true, where: {} });
+            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+            uri = await userA.clients.fullAuth.contracts.createConsentFlowContract({
+                contract: normalContract,
+                name: 'a',
+            });
+            await userB.clients.fullAuth.contracts.consentToContract({
+                contractUri: uri,
+                terms: normalFullTerms,
+            });
+
+            await Promise.all(
+                Array(12)
+                    .fill(0)
+                    .map(async (_, index) => {
+                        const client = await getClient({
+                            did: `did:test:${index + 1}`,
+                            isChallengeValid: true,
+                        });
+                        await client.profile.createProfile({
+                            profileId: `user${index}`,
+                        });
+
+                        let terms = normalFullTerms;
+                        if (index % 4 === 0) terms = normalAchievementOnlyTerms;
+                        else if (index % 4 === 1) terms = normalIDOnlyTerms;
+                        else if (index % 4 === 2) terms = normalNoTerms;
+
+                        await client.contracts.consentToContract({
+                            contractUri: uri,
+                            terms,
+                        });
+                    })
+            );
+        });
+
+        afterAll(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await ConsentFlowContract.delete({ detach: true, where: {} });
+            await ConsentFlowTerms.delete({ detach: true, where: {} });
+            await ConsentFlowTransaction.delete({ detach: true, where: {} });
+        });
+
+        it('should not allow you to get data without full auth', async () => {
+            await expect(noAuthClient.contracts.getConsentedData()).rejects.toMatchObject({
+                code: 'UNAUTHORIZED',
+            });
+            await expect(
+                userA.clients.partialAuth.contracts.getConsentedData()
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        it('should allow you to get data for contracts you own', async () => {
+            await expect(
+                userA.clients.fullAuth.contracts.getConsentedData()
+            ).resolves.not.toThrow();
+
+            const data = await userA.clients.fullAuth.contracts.getConsentedData();
+
+            expect(data.records).toHaveLength(13);
+        });
+
+        it("should not get data for someone else's contracts", async () => {
+            const data = await userB.clients.fullAuth.contracts.getConsentedData();
+
+            expect(data.records).toHaveLength(0);
+        });
+
+        describe('should allow you to query the data', () => {
+            it('should get all data with empty query', async () => {
+                const allData = await userA.clients.fullAuth.contracts.getConsentedData();
+
+                expect(allData.records).toHaveLength(13);
+            });
+
+            it('should allow inclusive queries', async () => {
+                const achievementsData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { Achievement: true } } },
+                });
+
+                expect(achievementsData.records).toHaveLength(7);
+                expect(
+                    achievementsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+
+                const idsData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { ID: true } } },
+                });
+
+                expect(idsData.records).toHaveLength(7);
+                expect(
+                    idsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining inclusive queries', async () => {
+                const achievementsAndIdsData =
+                    await userA.clients.fullAuth.contracts.getConsentedData({
+                        query: { credentials: { categories: { Achievement: true, ID: true } } },
+                    });
+
+                expect(achievementsAndIdsData.records).toHaveLength(4);
+                expect(
+                    achievementsAndIdsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    achievementsAndIdsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow exclusive queries', async () => {
+                const noAchievementsData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { Achievement: false } } },
+                });
+
+                expect(noAchievementsData.records).toHaveLength(6);
+                expect(
+                    noAchievementsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+
+                const noIdsData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { ID: false } } },
+                });
+
+                expect(noIdsData.records).toHaveLength(6);
+                expect(
+                    noIdsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining exclusive queries', async () => {
+                const noData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { ID: false, Achievement: false } } },
+                });
+
+                expect(noData.records).toHaveLength(3);
+                expect(
+                    noData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    noData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining inclusive/exclusive queries', async () => {
+                const achievementsOnlyData =
+                    await userA.clients.fullAuth.contracts.getConsentedData({
+                        query: { credentials: { categories: { ID: false, Achievement: true } } },
+                    });
+
+                expect(achievementsOnlyData.records).toHaveLength(3);
+                expect(
+                    achievementsOnlyData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    achievementsOnlyData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+
+                const idsOnlyData = await userA.clients.fullAuth.contracts.getConsentedData({
+                    query: { credentials: { categories: { ID: true, Achievement: false } } },
+                });
+
+                expect(idsOnlyData.records).toHaveLength(3);
+                expect(
+                    idsOnlyData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    idsOnlyData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
         });
     });
 

--- a/services/learn-card-network/brain-service/test/consentflow.spec.ts
+++ b/services/learn-card-network/brain-service/test/consentflow.spec.ts
@@ -349,13 +349,37 @@ describe('Consent Flow Contracts', () => {
             await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
 
             uri = await userA.clients.fullAuth.contracts.createConsentFlowContract({
-                contract: minimalContract,
+                contract: normalContract,
                 name: 'a',
             });
             await userB.clients.fullAuth.contracts.consentToContract({
                 contractUri: uri,
-                terms: minimalTerms,
+                terms: normalFullTerms,
             });
+
+            await Promise.all(
+                Array(12)
+                    .fill(0)
+                    .map(async (_, index) => {
+                        const client = await getClient({
+                            did: `did:test:${index + 1}`,
+                            isChallengeValid: true,
+                        });
+                        await client.profile.createProfile({
+                            profileId: `user${index}`,
+                        });
+
+                        let terms = normalFullTerms;
+                        if (index % 4 === 0) terms = normalAchievementOnlyTerms;
+                        else if (index % 4 === 1) terms = normalIDOnlyTerms;
+                        else if (index % 4 === 2) terms = normalNoTerms;
+
+                        await client.contracts.consentToContract({
+                            contractUri: uri,
+                            terms,
+                        });
+                    })
+            );
         });
 
         afterAll(async () => {
@@ -385,15 +409,155 @@ describe('Consent Flow Contracts', () => {
                 uri,
             });
 
-            expect(data.records).toHaveLength(1);
-            expect(data.records[0]!.personal.name).toEqual('Name lol');
-            expect(data.records[0]!.credentials.categories).toEqual({});
+            expect(data.records).toHaveLength(13);
         });
 
         it("should not allow you to get data for someone else's contracts", async () => {
             await expect(
                 userB.clients.fullAuth.contracts.getConsentedDataForContract({ uri })
             ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        describe('should allow you to query the data', () => {
+            it('should get all data with empty query', async () => {
+                const allData = await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                    uri,
+                });
+
+                expect(allData.records).toHaveLength(13);
+            });
+
+            it('should allow inclusive queries', async () => {
+                const achievementsData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { Achievement: true } } },
+                    });
+
+                expect(achievementsData.records).toHaveLength(7);
+                expect(
+                    achievementsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+
+                const idsData = await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                    uri,
+                    query: { credentials: { categories: { ID: true } } },
+                });
+
+                expect(idsData.records).toHaveLength(7);
+                expect(
+                    idsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining inclusive queries', async () => {
+                const achievementsAndIdsData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { Achievement: true, ID: true } } },
+                    });
+
+                expect(achievementsAndIdsData.records).toHaveLength(4);
+                expect(
+                    achievementsAndIdsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    achievementsAndIdsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow exclusive queries', async () => {
+                const noAchievementsData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { Achievement: false } } },
+                    });
+
+                expect(noAchievementsData.records).toHaveLength(6);
+                expect(
+                    noAchievementsData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+
+                const noIdsData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { ID: false } } },
+                    });
+
+                expect(noIdsData.records).toHaveLength(6);
+                expect(
+                    noIdsData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining exclusive queries', async () => {
+                const noData = await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                    uri,
+                    query: { credentials: { categories: { ID: false, Achievement: false } } },
+                });
+
+                expect(noData.records).toHaveLength(3);
+                expect(
+                    noData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    noData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
+
+            it('should allow combining inclusive/exclusive queries', async () => {
+                const achievementsOnlyData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { ID: false, Achievement: true } } },
+                    });
+
+                expect(achievementsOnlyData.records).toHaveLength(3);
+                expect(
+                    achievementsOnlyData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    achievementsOnlyData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+
+                const idsOnlyData =
+                    await userA.clients.fullAuth.contracts.getConsentedDataForContract({
+                        uri,
+                        query: { credentials: { categories: { ID: true, Achievement: false } } },
+                    });
+
+                expect(idsOnlyData.records).toHaveLength(3);
+                expect(
+                    idsOnlyData.records.every(
+                        record => (record.credentials.categories.ID?.length ?? 0) > 0
+                    )
+                ).toBeTruthy();
+                expect(
+                    idsOnlyData.records.every(
+                        record => (record.credentials.categories.Achievement?.length ?? 0) === 0
+                    )
+                ).toBeTruthy();
+            });
         });
     });
 

--- a/services/learn-card-network/brain-service/test/helpers/contract.ts
+++ b/services/learn-card-network/brain-service/test/helpers/contract.ts
@@ -15,6 +15,27 @@ export const minimalContract: ConsentFlowContract = {
     },
 };
 
+export const normalContract: ConsentFlowContract = {
+    read: {
+        personal: { name: { required: false } },
+        credentials: {
+            categories: {
+                Achievement: { required: false },
+                ID: { required: false },
+            },
+        },
+    },
+    write: {
+        personal: { name: { required: false } },
+        credentials: {
+            categories: {
+                Achievement: { required: false },
+                ID: { required: false },
+            },
+        },
+    },
+};
+
 export const predatoryContract: ConsentFlowContract = {
     read: {
         personal: {
@@ -83,6 +104,98 @@ export const noTerms: ConsentFlowTerms = {
     write: {
         personal: {},
         credentials: { categories: {} },
+    },
+};
+
+export const normalFullTerms: ConsentFlowTerms = {
+    read: {
+        personal: { name: 'Full Fullerson' },
+        credentials: {
+            shareAll: true,
+            sharing: true,
+            categories: {
+                Achievement: {
+                    shareAll: true,
+                    sharing: true,
+                    shared: ['achievement1', 'achievement2'],
+                },
+                ID: { shareAll: true, sharing: true, shared: ['id1', 'id2'] },
+            },
+        },
+    },
+    write: {
+        personal: { name: true },
+        credentials: { categories: { Achievement: true, ID: true } },
+    },
+};
+
+export const normalAchievementOnlyTerms: ConsentFlowTerms = {
+    read: {
+        personal: { name: 'Full Fullerson Only Achievements' },
+        credentials: {
+            shareAll: false,
+            sharing: true,
+            categories: {
+                Achievement: {
+                    shareAll: true,
+                    sharing: true,
+                    shared: ['achievement1', 'achievement2'],
+                },
+                ID: {
+                    shareAll: false,
+                    sharing: false,
+                    shared: [],
+                },
+            },
+        },
+    },
+    write: {
+        personal: { name: true },
+        credentials: { categories: { Achievement: true, ID: false } },
+    },
+};
+
+export const normalIDOnlyTerms: ConsentFlowTerms = {
+    read: {
+        personal: { name: 'Full Fullerson Only IDs' },
+        credentials: {
+            shareAll: false,
+            sharing: true,
+            categories: {
+                Achievement: {
+                    shareAll: false,
+                    sharing: false,
+                    shared: [],
+                },
+                ID: { shareAll: true, sharing: true, shared: ['id1', 'id2'] },
+            },
+        },
+    },
+    write: {
+        personal: { name: true },
+        credentials: { categories: { Achievement: false, ID: true } },
+    },
+};
+
+export const normalNoTerms: ConsentFlowTerms = {
+    read: {
+        personal: {},
+        credentials: {
+            shareAll: false,
+            sharing: false,
+            categories: {
+                Achievement: {
+                    shareAll: false,
+                    sharing: false,
+                    shared: [],
+                },
+                ID: { shareAll: false, sharing: false, shared: [] },
+            },
+        },
+    },
+    write: {
+        personal: { name: false },
+        credentials: { categories: { Achievement: false, ID: false } },
     },
 };
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
All the iterations spelled out in the Quest Doc

#### 🥴 TL; RL:
Added the ability to manage service profiles, expanded data model for profiles, made it easier to get/view consented data, and added notifications for consent flow transactions!

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- New `DidDocument` type in `@learncard/types`
    - Follows spec/didkit types for a Resolved Did Doc
- Better default `verificationMethod` logic
    - Basically, when issuing a VC/VP, we select a `verificationMethod` to use by default if none is passed in. This logic now better accounts for if you are issuing as a managed service profile
- More LCN Profile fields
    - `shortBio`: `string`, used as like a headline
    - `heroImage`: `string`, used for a nice bg image for a profile
    - `websiteLink`: `string`, link to a website for the profile
    - `type`: `string`, future-proofing to allow profiles/service profiles to tag themselves with some kind of custom type
- Allow managing service profiles
    - `createManagedServiceProfile`
        - Same API as `createProfile`, but will create a new profile with a thrown-away seed and return its did
        - You can then use this profile by using your same seed and passing its did to the did:web plugin
            - E.g. `initLearnCard({ seed: YOUR_SEED, network: true, didWeb: NEW_DID })`
    - `getManagedServiceProfiles`
        - Returns a paginated list of your managed service profiles
    - New relationship: `managedBy`
        - `Profile`->`Profile`
        - When this exists, did resolution works differently to allow the manager to issue on behalf of the managed profile
        - There is also logic when verifying DID Auth to allow the manager to perform DID Auth on behalf of the managed profile
- New Init function: `DidWebNetworkLearnCard`
    - This just allows you to use a custom did:web while being connected to LCN. This is what allows you to actually _use_ your managed profiles
- `getAllConsentFlowData`
    - Grabs _all_ consent flow data across all of your contracts
    - Allows you to query this data to only get what you care about
- `getConsentFlowData` has been updated to allow you to query for data
- Notifications for Consent Flow Transactions
    - Notifications are now sent when consenting, reconsenting, updating, and withdrawing consent
    - The transaction is sent along with the notification

#### 🛠 Important tradeoffs made:
I really wanted to make a plugin method that would just return a new `LearnCard` for a managed service profile,
but it would be impossible without a non-trivial rewrite of some of the main types so for now you just have
to use the init function again =(

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
There's a lot to test here, and some of it is kind of tricky!

First, just run the test suite (`pnpm test`). This will test out the new endpoints, as well as testing
the ability to query consent flow data.

To test managed profiles, you'll need to run the brain service locally, then open the CLI and make a profile on it:
```js
let test = await initLearnCard({ seed: 'a', network: 'http://localhost:3000/trpc' });
await test.invoke.createProfile({ profileId: 'test' });
```

Then, make a managed profile:
```js
let managedDid = await test.invoke.createManagedServiceProfile({ profileId: 'managed' });
```

Then, make a LC object for it:
```js
let managed = await initLearnCard({ seed: 'a', network: 'http://localhost:3000/trpc', didWeb: managedDid });
```

Then, you should be able to issue creds/interact with the LCN using your managed profile!
```js
let uvc = managed.invoke.getTestVc(learnCard.id.did());
let vc = await managed.invoke.issueCredential(uvc);
await learnCard.invoke.verifyCredential(vc);
await managed.updateProfile({ displayName: 'Nice!!' });
await test.invoke.getProfile('managed');
```

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->
There is documentation now for all notifications!

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
