### PR TITLE
TS 5.5 Update and Send Boost Fix

### DIFF
--- a/.changeset/bright-shrimps-learn.md
+++ b/.changeset/bright-shrimps-learn.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-client': patch
+---
+
+Expose Client type

--- a/.changeset/healthy-rivers-kiss.md
+++ b/.changeset/healthy-rivers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-plugin': patch
+---
+
+Allow overriding a boost VC before sending it

--- a/.changeset/odd-otters-watch.md
+++ b/.changeset/odd-otters-watch.md
@@ -1,0 +1,5 @@
+---
+'@learncard/core': minor
+---
+
+Update to TS 5.5.2

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "vitest": "^1.4.0"
     },
     "dependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.5.2"
     },
     "pnpm": {
         "overrides": {

--- a/packages/learn-card-core/src/types/utilities.ts
+++ b/packages/learn-card-core/src/types/utilities.ts
@@ -35,3 +35,5 @@ export type DeepPartial<T> = T extends object
         [P in keyof T]?: DeepPartial<T[P]>;
     }
     : T;
+
+export type IsAnyOrNever<T> = [T] extends [1 & T] ? true : false;

--- a/packages/learn-card-core/src/types/wallet.ts
+++ b/packages/learn-card-core/src/types/wallet.ts
@@ -14,7 +14,7 @@ import {
     LearnCardIdPlane,
     LearnCardContextPlane,
 } from './planes';
-import { UnionToIntersection, MergeObjects } from './utilities';
+import { UnionToIntersection, MergeObjects, IsAnyOrNever } from './utilities';
 
 export type GenerateLearnCard<
     NewControlPlanes extends ControlPlane = never,
@@ -23,11 +23,11 @@ export type GenerateLearnCard<
     Methods extends Record<string, (...args: any[]) => any> = Record<never, never>
 > = LearnCard<
     any,
-    [ControlPlanes] extends [1 & ControlPlanes]
-        ? NewControlPlanes
-        : [NewControlPlanes] extends [1 & NewControlPlanes]
-        ? ControlPlanes
-        : ControlPlanes | NewControlPlanes,
+    IsAnyOrNever<ControlPlanes> extends true
+    ? NewControlPlanes
+    : IsAnyOrNever<NewControlPlanes> extends true
+    ? ControlPlanes
+    : ControlPlanes | NewControlPlanes,
     NewMethods & Methods
 >;
 
@@ -38,27 +38,27 @@ export type AddImplicitLearnCardArgument<
     DependentControlPlanes extends ControlPlane = never,
     DependentMethods extends Record<string, (...args: any[]) => any> = Record<never, never>
 > = {
-    [Key in keyof Functions]: <
-        T extends GenerateLearnCard<
-            ControlPlanes,
-            Methods,
-            DependentControlPlanes,
-            DependentMethods
-        >
-    >(
-        learnCard: T,
-        ...args: Parameters<Functions[Key]>
-    ) => ReturnType<Functions[Key]>;
-};
+        [Key in keyof Functions]: <
+            T extends GenerateLearnCard<
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >
+        >(
+            learnCard: T,
+            ...args: Parameters<Functions[Key]>
+        ) => ReturnType<Functions[Key]>;
+    };
 
 /** @group Universal Wallets */
 export type GetPluginMethods<Plugins extends Plugin[]> = undefined extends Plugins[1]
     ? NonNullable<Plugins[0]['_methods']>
     : UnionToIntersection<
-          NonNullable<
-              MergeObjects<{ [Key in keyof Plugins]: NonNullable<Plugins[Key]['_methods']> }>
-          >
-      >;
+        NonNullable<
+            MergeObjects<{ [Key in keyof Plugins]: NonNullable<Plugins[Key]['_methods']> }>
+        >
+    >;
 
 /** @group Universal Wallets */
 export type Plugin<
@@ -85,74 +85,74 @@ export type Plugin<
     cache?: {};
     id?: {};
     context?: {};
-} & ([ControlPlanes] extends [1 & ControlPlanes] // Check for any/never and prevent it from requiring all planes
+} & (IsAnyOrNever<ControlPlanes> extends true
     ? {}
     : ('read' extends ControlPlanes
-          ? {
-                read: AddImplicitLearnCardArgument<
-                    PluginReadPlane,
-                    ControlPlanes,
-                    Methods,
-                    DependentControlPlanes,
-                    DependentMethods
-                >;
-            }
-          : {}) &
-          ('store' extends ControlPlanes
-              ? {
-                    store: AddImplicitLearnCardArgument<
-                        PluginStorePlane,
-                        ControlPlanes,
-                        Methods,
-                        DependentControlPlanes,
-                        DependentMethods
-                    >;
-                }
-              : {}) &
-          ('index' extends ControlPlanes
-              ? {
-                    index: AddImplicitLearnCardArgument<
-                        PluginIndexPlane,
-                        ControlPlanes,
-                        Methods,
-                        DependentControlPlanes,
-                        DependentMethods
-                    >;
-                }
-              : {}) &
-          ('cache' extends ControlPlanes
-              ? {
-                    cache: AddImplicitLearnCardArgument<
-                        PluginCachePlane,
-                        ControlPlanes,
-                        Methods,
-                        DependentControlPlanes,
-                        DependentMethods
-                    >;
-                }
-              : {}) &
-          ('id' extends ControlPlanes
-              ? {
-                    id: AddImplicitLearnCardArgument<
-                        PluginIdPlane,
-                        ControlPlanes,
-                        Methods,
-                        DependentControlPlanes,
-                        DependentMethods
-                    >;
-                }
-              : {}) &
-          ('context' extends ControlPlanes
-              ? {
-                    context: AddImplicitLearnCardArgument<
-                        PluginContextPlane,
-                        ControlPlanes,
-                        Methods,
-                        DependentControlPlanes,
-                        DependentMethods
-                    >;
-                }
-              : {}));
+        ? {
+            read: AddImplicitLearnCardArgument<
+                PluginReadPlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}) &
+    ('store' extends ControlPlanes
+        ? {
+            store: AddImplicitLearnCardArgument<
+                PluginStorePlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}) &
+    ('index' extends ControlPlanes
+        ? {
+            index: AddImplicitLearnCardArgument<
+                PluginIndexPlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}) &
+    ('cache' extends ControlPlanes
+        ? {
+            cache: AddImplicitLearnCardArgument<
+                PluginCachePlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}) &
+    ('id' extends ControlPlanes
+        ? {
+            id: AddImplicitLearnCardArgument<
+                PluginIdPlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}) &
+    ('context' extends ControlPlanes
+        ? {
+            context: AddImplicitLearnCardArgument<
+                PluginContextPlane,
+                ControlPlanes,
+                Methods,
+                DependentControlPlanes,
+                DependentMethods
+            >;
+        }
+        : {}));
 
 /** @group Universal Wallets */
 export type LearnCard<
@@ -166,11 +166,11 @@ export type LearnCard<
         plugin: NewPlugin
     ) => Promise<LearnCard<[...Plugins, NewPlugin]>>;
     debug?: typeof console.log;
-} & ([ControlPlanes] extends [1 & ControlPlanes] // Check for any/never and prevent it from requiring all planes
+} & (IsAnyOrNever<ControlPlanes> extends true
     ? {}
     : ('read' extends ControlPlanes ? { read: LearnCardReadPlane<Plugins> } : {}) &
-          ('store' extends ControlPlanes ? { store: LearnCardStorePlane<Plugins> } : {}) &
-          ('index' extends ControlPlanes ? { index: LearnCardIndexPlane<Plugins> } : {}) &
-          ('cache' extends ControlPlanes ? { cache: LearnCardCachePlane<Plugins> } : {}) &
-          ('id' extends ControlPlanes ? { id: LearnCardIdPlane<Plugins> } : {}) &
-          ('context' extends ControlPlanes ? { context: LearnCardContextPlane<Plugins> } : {}));
+    ('store' extends ControlPlanes ? { store: LearnCardStorePlane<Plugins> } : {}) &
+    ('index' extends ControlPlanes ? { index: LearnCardIndexPlane<Plugins> } : {}) &
+    ('cache' extends ControlPlanes ? { cache: LearnCardCachePlane<Plugins> } : {}) &
+    ('id' extends ControlPlanes ? { id: LearnCardIdPlane<Plugins> } : {}) &
+    ('context' extends ControlPlanes ? { context: LearnCardContextPlane<Plugins> } : {}));

--- a/packages/learn-card-network/brain-client/src/index.ts
+++ b/packages/learn-card-network/brain-client/src/index.ts
@@ -9,7 +9,7 @@ type Inputs = inferRouterInputs<AppRouter>;
 
 type Client = CreateTRPCProxyClient<AppRouter>;
 
-type OverriddenClient = Omit<Client, 'storage' | 'boost'> & {
+export type LCNClient = Omit<Client, 'storage' | 'boost'> & {
     storage: Client['storage'] & {
         resolve: {
             query: (args: Inputs['storage']['resolve']) => Promise<VC | UnsignedVC | VP | JWE>;
@@ -32,7 +32,7 @@ export const getClient = async (
         links: [
             httpBatchLink({ url, headers: { Authorization: `Bearer ${await didAuthFunction()}` } }),
         ],
-    }) as OverriddenClient;
+    }) as LCNClient;
 
     const getChallenges = async (
         amount = 95 + Math.round((Math.random() - 0.5) * 5)
@@ -56,7 +56,7 @@ export const getClient = async (
                 },
             }),
         ],
-    }) as OverriddenClient;
+    }) as LCNClient;
 
     return trpc;
 };

--- a/packages/plugins/chapi/src/types.ts
+++ b/packages/plugins/chapi/src/types.ts
@@ -100,7 +100,9 @@ export type CHAPIPluginMethods = {
         | { success: true }
         | { success: false; reason: 'did not auth' | 'auth failed verification' | 'did not store' }
     >;
-    storePresentationViaChapi: (presentation: UnsignedVP | VP) => Promise<Credential | undefined>;
+    storePresentationViaChapi: (
+        presentation: UnsignedVP | VP
+    ) => Promise<Credential | undefined | void>;
 };
 
 /** @group CHAPI Plugin */

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -1,4 +1,5 @@
 import type { DID } from 'dids';
+import type { LCNClient } from '@learncard/network-brain-client';
 import {
     LCNProfile,
     UnsignedVC,
@@ -120,7 +121,11 @@ export type LearnCardNetworkPluginMethods = {
     ) => Promise<PaginatedLCNProfiles>;
     addBoostAdmin: (uri: string, profileId: string) => Promise<boolean>;
     removeBoostAdmin: (uri: string, profileId: string) => Promise<boolean>;
-    sendBoost: (profileId: string, boostUri: string, encrypt?: boolean) => Promise<string>;
+    sendBoost: (
+        profileId: string,
+        boostUri: string,
+        options?: boolean | { encrypt?: boolean; overideFn?: (boost: UnsignedVC) => UnsignedVC }
+    ) => Promise<string>;
 
     registerSigningAuthority: (endpoint: string, name: string, did: string) => Promise<boolean>;
     getRegisteredSigningAuthorities: (
@@ -191,6 +196,8 @@ export type LearnCardNetworkPluginMethods = {
     resolveFromLCN: (
         uri: string
     ) => Promise<VC | UnsignedVC | VP | JWE | ConsentFlowContract | ConsentFlowTerms>;
+
+    getLCNClient: () => LCNClient;
 };
 
 /** @group LearnCardNetwork Plugin */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     dependencies:
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.5.2
+        version: 5.5.2
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.4.8
@@ -26,10 +26,10 @@ importers:
         version: 2.26.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.54.0
-        version: 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4)
+        version: 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^5.54.0
-        version: 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+        version: 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       esbuild-jest:
         specifier: ^0.5.0
         version: 0.5.0(esbuild@0.20.2)
@@ -38,13 +38,13 @@ importers:
         version: 8.35.0
       eslint-config-airbnb-typescript:
         specifier: ^17.0.0
-        version: 17.0.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0)
+        version: 17.0.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0)
       eslint-import-resolver-typescript:
         specifier: ^2.7.1
         version: 2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0)
       eslint-plugin-import:
         specifier: ^2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
+        version: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.4)
@@ -53,7 +53,7 @@ importers:
         version: 7.32.2(eslint@8.35.0)
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.5.0
@@ -71,13 +71,13 @@ importers:
         version: 0.5.5
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.20.2)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.20.2)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.0.4)(vite@5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1))
+        version: 4.3.2(typescript@5.5.2)(vite@5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1))
       vitest:
         specifier: ^1.4.0
         version: 1.4.0(@types/node@18.16.18)(happy-dom@14.5.1)(jsdom@20.0.3)(less@4.1.3)(terser@5.18.1)
@@ -135,7 +135,7 @@ importers:
         version: 3.3.1(@types/react-dom@18.2.6)(@types/react@17.0.62)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1))
       '@astrojs/tailwind':
         specifier: ^5.1.0
-        version: 5.1.0(astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.0.4))(tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 5.1.0(astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.5.2))(tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       '@learncard/chapi-plugin':
         specifier: workspace:^
         version: link:../../packages/plugins/chapi
@@ -159,7 +159,7 @@ importers:
         version: 0.2.0(nanostores@0.5.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       astro:
         specifier: ^4.7.0
-        version: 4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.0.4)
+        version: 4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.5.2)
       nanostores:
         specifier: ^0.5.13
         version: 0.5.13
@@ -171,7 +171,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
@@ -193,7 +193,7 @@ importers:
         version: 1.1.3(react-dom@18.0.0(react@18.2.0))(react@18.2.0)
       '@astrojs/tailwind':
         specifier: ^2.0.1
-        version: 2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))
+        version: 2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))
       '@learncard/core':
         specifier: workspace:*
         version: link:../../packages/learn-card-core
@@ -220,7 +220,7 @@ importers:
         version: 0.2.0(nanostores@0.5.13)(react-dom@18.0.0(react@18.2.0))(react@18.2.0)
       astro:
         specifier: ^1.2.8
-        version: 1.2.8(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 1.2.8(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       nanostores:
         specifier: ^0.5.13
         version: 0.5.13
@@ -232,7 +232,7 @@ importers:
         version: 18.0.0(react@18.2.0)
       tailwindcss:
         specifier: ^3.0.24
-        version: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.1.1
@@ -276,7 +276,7 @@ importers:
         version: 1.1.3(react-dom@18.0.0(react@18.2.0))(react@18.2.0)
       '@astrojs/tailwind':
         specifier: ^2.0.1
-        version: 2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))
+        version: 2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))
       '@learncard/types':
         specifier: workspace:*
         version: link:../../packages/learn-card-types
@@ -288,7 +288,7 @@ importers:
         version: 17.0.2
       astro:
         specifier: 1.2.7
-        version: 1.2.7(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 1.2.7(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       concurrently:
         specifier: ^7.3.0
         version: 7.3.0
@@ -303,7 +303,7 @@ importers:
         version: 18.0.0(react@18.2.0)
       tailwindcss:
         specifier: ^3.0.24
-        version: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+        version: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
 
   packages/learn-card-bridge-http:
     dependencies:
@@ -562,7 +562,7 @@ importers:
         version: 18.7.19
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@18.7.19)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@18.7.19)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       dts-bundle-generator:
         specifier: ^6.10.0
         version: 6.10.0
@@ -574,7 +574,7 @@ importers:
         version: 0.5.0(esbuild@0.14.38)
       jest:
         specifier: ^28.1.3
-        version: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+        version: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-environment-jsdom:
         specifier: ^28.1.3
         version: 28.1.3
@@ -583,7 +583,7 @@ importers:
         version: 0.3.4
       ts-jest:
         specifier: ^28.0.5
-        version: 28.0.5(@babel/core@7.22.5)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 28.0.5(@babel/core@7.22.5)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/learn-card-init:
     dependencies:
@@ -656,7 +656,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -683,7 +683,7 @@ importers:
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.7.4)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.7.4)
       tsc-alias:
         specifier: ^1.6.9
         version: 1.6.9
@@ -752,7 +752,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       esbuild:
         specifier: ^0.17.17
         version: 0.17.17
@@ -822,7 +822,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -834,13 +834,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/chapi:
     dependencies:
@@ -868,7 +868,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -880,13 +880,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/crypto:
     dependencies:
@@ -895,7 +895,7 @@ importers:
         version: link:../../learn-card-core
       isomorphic-webcrypto:
         specifier: ^2.3.8
-        version: 2.3.8(expo@48.0.19(@babel/core@7.22.5))(react-native@0.72.0(@babel/core@7.22.5)(@babel/preset-env@7.22.5(@babel/core@7.22.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))
+        version: 2.3.8(expo@48.0.19(@babel/core@7.24.5))(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))
     devDependencies:
       '@types/jest':
         specifier: ^29.2.2
@@ -905,7 +905,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -917,13 +917,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/did-web-plugin:
     dependencies:
@@ -966,7 +966,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       dids:
         specifier: ^3.2.0
         version: 3.2.0
@@ -981,13 +981,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/didkey:
     dependencies:
@@ -1012,7 +1012,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1024,13 +1024,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/didkit:
     dependencies:
@@ -1049,7 +1049,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       dids:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1064,13 +1064,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/dynamic-loader:
     dependencies:
@@ -1086,7 +1086,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.54
@@ -1098,13 +1098,13 @@ importers:
         version: 1.6.0(esbuild@0.14.54)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.54)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.54)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/ethereum:
     dependencies:
@@ -1126,7 +1126,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1138,13 +1138,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/expiration:
     dependencies:
@@ -1166,7 +1166,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1178,13 +1178,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/idx:
     dependencies:
@@ -1218,7 +1218,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1230,13 +1230,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/learn-card:
     dependencies:
@@ -1261,7 +1261,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1273,13 +1273,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/learn-card-network:
     dependencies:
@@ -1313,7 +1313,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       dids:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1328,13 +1328,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/learn-cloud:
     dependencies:
@@ -1377,7 +1377,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       dids:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1392,13 +1392,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/vc:
     dependencies:
@@ -1420,7 +1420,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1432,13 +1432,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/vc-api:
     dependencies:
@@ -1457,7 +1457,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1469,13 +1469,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/vc-templates:
     dependencies:
@@ -1494,7 +1494,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1506,13 +1506,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/plugins/vpqr:
     dependencies:
@@ -1534,7 +1534,7 @@ importers:
         version: 17.0.38
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       esbuild:
         specifier: ^0.14.38
         version: 0.14.38
@@ -1546,13 +1546,13 @@ importers:
         version: 1.6.0(esbuild@0.14.38)
       jest:
         specifier: ^29.3.0
-        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+        version: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       shx:
         specifier: ^0.3.4
         version: 0.3.4
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/react-learn-card:
     dependencies:
@@ -2160,13 +2160,13 @@ importers:
         version: 2.5.0
       '@metamask/eslint-config':
         specifier: ^10.0.0
-        version: 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
+        version: 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
       '@metamask/eslint-config-jest':
         specifier: ^10.0.0
-        version: 10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4))(eslint@8.35.0)
+        version: 10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2))(eslint@8.35.0)
       '@metamask/eslint-config-nodejs':
         specifier: ^8.0.0
-        version: 8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.35.0))(eslint@8.35.0)
+        version: 8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.35.0))(eslint@8.35.0)
       '@metamask/providers':
         specifier: ^9.1.0
         version: 9.1.0
@@ -2212,7 +2212,7 @@ importers:
     devDependencies:
       '@nrwl/devkit':
         specifier: ^15.6.3
-        version: 15.6.3(nx@16.1.4)(typescript@5.0.4)
+        version: 15.6.3(nx@16.1.4)(typescript@5.5.2)
       esbuild:
         specifier: ^0.17.5
         version: 0.17.17
@@ -18426,9 +18426,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ua-parser-js@1.0.35:
@@ -19730,20 +19730,20 @@ snapshots:
       - supports-color
       - vite
 
-  '@astrojs/tailwind@2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))':
+  '@astrojs/tailwind@2.0.1(tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))':
     dependencies:
       '@proload/core': 0.3.3
       autoprefixer: 10.4.7(postcss@8.4.24)
       postcss: 8.4.24
-      tailwindcss: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      tailwindcss: 3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
 
-  '@astrojs/tailwind@5.1.0(astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.0.4))(tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))':
+  '@astrojs/tailwind@5.1.0(astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.5.2))(tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))':
     dependencies:
-      astro: 4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.0.4)
+      astro: 4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.5.2)
       autoprefixer: 10.4.19(postcss@8.4.36)
       postcss: 8.4.36
-      postcss-load-config: 4.0.2(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
-      tailwindcss: 3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      postcss-load-config: 4.0.2(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      tailwindcss: 3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
     transitivePeerDependencies:
       - ts-node
 
@@ -20923,7 +20923,6 @@ snapshots:
       browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.0
-    optional: true
 
   '@babel/helper-compilation-targets@7.23.6':
     dependencies:
@@ -20977,7 +20976,6 @@ snapshots:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-create-regexp-features-plugin@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -20999,7 +20997,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.0
-    optional: true
 
   '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.8)':
     dependencies:
@@ -21036,7 +21033,6 @@ snapshots:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-environment-visitor@7.22.20': {}
 
@@ -21129,7 +21125,6 @@ snapshots:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-replace-supers@7.22.5':
     dependencies:
@@ -21234,6 +21229,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21247,6 +21247,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.22.5(@babel/core@7.22.5)
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-transform-optional-chaining': 7.22.5(@babel/core@7.24.5)
 
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.21.8)':
     dependencies:
@@ -21322,6 +21329,18 @@ snapshots:
       '@babel/helper-replace-supers': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@babel/plugin-proposal-decorators@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/helper-replace-supers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -21492,6 +21511,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.22.5
 
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+
   '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21514,6 +21537,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21528,12 +21557,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.8)':
     dependencies:
@@ -21549,7 +21583,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.21.8)':
     dependencies:
@@ -21561,9 +21594,20 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.5
+    optional: true
+
+  '@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
     optional: true
 
@@ -21581,7 +21625,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-export-default-from@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -21605,6 +21648,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
@@ -21626,9 +21674,19 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.21.8)':
@@ -21641,6 +21699,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21651,6 +21714,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9)':
     dependencies:
       '@babel/core': 7.12.9
@@ -21659,6 +21727,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.22.5)':
@@ -21682,6 +21755,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21696,7 +21774,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.8)':
     dependencies:
@@ -21712,7 +21789,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9)':
     dependencies:
@@ -21733,7 +21809,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.8)':
     dependencies:
@@ -21749,7 +21824,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.8)':
     dependencies:
@@ -21765,7 +21839,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.21.8)':
     dependencies:
@@ -21777,6 +21850,11 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21785,6 +21863,11 @@ snapshots:
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.5)':
@@ -21804,6 +21887,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -21818,7 +21907,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-async-generator-functions@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -21827,6 +21915,16 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-generator-functions@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -21856,7 +21954,6 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.22.5(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -21872,7 +21969,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -21888,12 +21984,19 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -21904,6 +22007,15 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -21951,7 +22063,6 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -21970,7 +22081,6 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -21986,7 +22096,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22000,6 +22109,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -22010,11 +22125,22 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22028,11 +22154,23 @@ snapshots:
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -22061,7 +22199,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-function-name@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22083,13 +22220,18 @@ snapshots:
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-literals@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22105,13 +22247,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
 
   '@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22127,7 +22274,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22140,6 +22286,14 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-module-transforms': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
@@ -22171,7 +22325,6 @@ snapshots:
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22186,6 +22339,16 @@ snapshots:
   '@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
@@ -22209,6 +22372,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -22226,7 +22397,6 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-new-target@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22238,17 +22408,34 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-new-target@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.5)
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+
   '@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
 
   '@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -22258,6 +22445,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
       '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/compat-data': 7.22.5
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.24.5)
 
   '@babel/plugin-transform-object-super@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22282,13 +22478,18 @@ snapshots:
       '@babel/helper-replace-supers': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-optional-chaining@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22303,6 +22504,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-optional-chaining@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-parameters@7.22.5(@babel/core@7.12.9)':
     dependencies:
@@ -22323,12 +22531,19 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -22340,6 +22555,16 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -22357,7 +22582,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-react-constant-elements@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -22373,12 +22597,16 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.5)
+
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.24.5)
 
   '@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -22421,6 +22649,15 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.5)
       '@babel/types': 7.22.5
 
+  '@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.5)
+      '@babel/types': 7.22.5
+
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
@@ -22446,6 +22683,12 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -22458,6 +22701,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.1
 
+  '@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      regenerator-transform: 0.15.1
+
   '@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.21.8)':
     dependencies:
       '@babel/core': 7.21.8
@@ -22466,6 +22715,11 @@ snapshots:
   '@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-runtime@7.22.5(@babel/core@7.22.5)':
@@ -22507,7 +22761,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-spread@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22526,7 +22779,6 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22542,7 +22794,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22558,7 +22809,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -22568,6 +22818,11 @@ snapshots:
   '@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.5)':
@@ -22601,10 +22856,21 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.21.8)':
@@ -22624,12 +22890,17 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/preset-env@7.21.5(@babel/core@7.21.8)':
@@ -22800,6 +23071,92 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-env@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/compat-data': 7.22.5
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-generator-functions': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-classes': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-optional-chaining': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/preset-modules': 0.1.5(@babel/core@7.24.5)
+      '@babel/types': 7.22.5
+      babel-plugin-polyfill-corejs2: 0.4.3(@babel/core@7.24.5)
+      babel-plugin-polyfill-corejs3: 0.8.1(@babel/core@7.24.5)
+      babel-plugin-polyfill-regenerator: 0.5.0(@babel/core@7.24.5)
+      core-js-compat: 3.31.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-flow@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
@@ -22825,6 +23182,15 @@ snapshots:
       '@babel/types': 7.22.5
       esutils: 2.0.3
 
+  '@babel/preset-modules@0.1.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/types': 7.22.5
+      esutils: 2.0.3
+
   '@babel/preset-react@7.22.5(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
@@ -22834,6 +23200,16 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.22.5)
+
+  '@babel/preset-react@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.24.5)
 
   '@babel/preset-typescript@7.22.5(@babel/core@7.22.5)':
     dependencies:
@@ -25451,7 +25827,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))':
+  '@jest/core@28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))':
     dependencies:
       '@jest/console': 28.1.3
       '@jest/reporters': 28.1.3
@@ -25465,7 +25841,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-config: 28.1.3(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -25520,7 +25896,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))':
+  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))':
     dependencies:
       '@jest/console': 29.5.0
       '@jest/reporters': 29.5.0
@@ -25534,7 +25910,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -25554,7 +25930,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))':
+  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))':
     dependencies:
       '@jest/console': 29.5.0
       '@jest/reporters': 29.5.0
@@ -25568,7 +25944,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -25588,7 +25964,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))':
+  '@jest/core@29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))':
     dependencies:
       '@jest/console': 29.5.0
       '@jest/reporters': 29.5.0
@@ -25602,7 +25978,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -26273,23 +26649,23 @@ snapshots:
 
   '@metamask/detect-provider@1.2.0': {}
 
-  '@metamask/eslint-config-jest@10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4))(eslint@8.35.0)':
+  '@metamask/eslint-config-jest@10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2))(eslint@8.35.0)':
     dependencies:
-      '@metamask/eslint-config': 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
+      '@metamask/eslint-config': 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
       eslint: 8.35.0
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4)
+      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2)
 
-  '@metamask/eslint-config-nodejs@8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.35.0))(eslint@8.35.0)':
+  '@metamask/eslint-config-nodejs@8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.35.0))(eslint@8.35.0)':
     dependencies:
-      '@metamask/eslint-config': 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
+      '@metamask/eslint-config': 10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)
       eslint: 8.35.0
       eslint-plugin-node: 11.1.0(eslint@8.35.0)
 
-  '@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)':
+  '@metamask/eslint-config@10.0.0(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0))(eslint-plugin-jsdoc@39.9.1(eslint@8.35.0))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8))(eslint@8.35.0)(prettier@2.8.8)':
     dependencies:
       eslint: 8.35.0
       eslint-config-prettier: 8.8.0(eslint@8.35.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
       eslint-plugin-jsdoc: 39.9.1(eslint@8.35.0)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.8)
       prettier: 2.8.8
@@ -26447,9 +26823,9 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
-  '@nrwl/devkit@15.6.3(nx@16.1.4)(typescript@5.0.4)':
+  '@nrwl/devkit@15.6.3(nx@16.1.4)(typescript@5.5.2)':
     dependencies:
-      '@phenomnomnominal/tsquery': 4.1.1(typescript@5.0.4)
+      '@phenomnomnominal/tsquery': 4.1.1(typescript@5.5.2)
       ejs: 3.1.9
       ignore: 5.2.4
       nx: 16.1.4
@@ -26618,10 +26994,10 @@ snapshots:
       tslib: 2.5.3
       webcrypto-core: 1.7.7
 
-  '@phenomnomnominal/tsquery@4.1.1(typescript@5.0.4)':
+  '@phenomnomnominal/tsquery@4.1.1(typescript@5.5.2)':
     dependencies:
       esquery: 1.5.0
-      typescript: 5.0.4
+      typescript: 5.5.2
 
   '@pkgr/utils@2.4.1':
     dependencies:
@@ -26805,6 +27181,27 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  '@react-native-community/cli-plugin-metro@11.3.2(@babel/core@7.24.5)':
+    dependencies:
+      '@react-native-community/cli-server-api': 11.3.2
+      '@react-native-community/cli-tools': 11.3.2
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.76.5
+      metro-config: 0.76.5
+      metro-core: 0.76.5
+      metro-react-native-babel-transformer: 0.76.5(@babel/core@7.24.5)
+      metro-resolver: 0.76.5
+      metro-runtime: 0.76.5
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   '@react-native-community/cli-server-api@11.3.2':
     dependencies:
       '@react-native-community/cli-debugger-ui': 11.3.2
@@ -26870,6 +27267,33 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  '@react-native-community/cli@11.3.2(@babel/core@7.24.5)':
+    dependencies:
+      '@react-native-community/cli-clean': 11.3.2
+      '@react-native-community/cli-config': 11.3.2
+      '@react-native-community/cli-debugger-ui': 11.3.2
+      '@react-native-community/cli-doctor': 11.3.2
+      '@react-native-community/cli-hermes': 11.3.2
+      '@react-native-community/cli-plugin-metro': 11.3.2(@babel/core@7.24.5)
+      '@react-native-community/cli-server-api': 11.3.2
+      '@react-native-community/cli-tools': 11.3.2
+      '@react-native-community/cli-types': 11.3.2
+      chalk: 4.1.2
+      commander: 9.5.0
+      execa: 5.1.1
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+      graceful-fs: 4.2.11
+      prompts: 2.4.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   '@react-native/assets-registry@0.72.0':
     optional: true
 
@@ -26879,6 +27303,17 @@ snapshots:
       '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
       flow-parser: 0.206.0
       jscodeshift: 0.14.0(@babel/preset-env@7.22.5(@babel/core@7.22.5))
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@react-native/codegen@0.72.6(@babel/preset-env@7.22.5(@babel/core@7.24.5))':
+    dependencies:
+      '@babel/parser': 7.24.5
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      flow-parser: 0.206.0
+      jscodeshift: 0.14.0(@babel/preset-env@7.22.5(@babel/core@7.24.5))
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -26901,6 +27336,14 @@ snapshots:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react-native: 0.72.0(@babel/core@7.22.5)(@babel/preset-env@7.22.5(@babel/core@7.22.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
+      react-test-renderer: 18.2.0(react@18.3.1)
+    optional: true
+
+  '@react-native/virtualized-lists@0.72.5(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
       react-test-renderer: 18.2.0(react@18.3.1)
     optional: true
 
@@ -29191,12 +29634,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4)':
+  '@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/type-utils': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
       grapheme-splitter: 1.0.4
@@ -29204,9 +29647,9 @@ snapshots:
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -29226,7 +29669,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
     optionalDependencies:
@@ -29234,15 +29677,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4)':
+  '@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.5.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -29280,15 +29723,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.54.0(eslint@8.35.0)(typescript@5.0.4)':
+  '@typescript-eslint/type-utils@5.54.0(eslint@8.35.0)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.5.2)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -29324,7 +29767,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.54.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@5.54.0(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
@@ -29332,13 +29775,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.60.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@5.60.0(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 5.60.0
       '@typescript-eslint/visitor-keys': 5.60.0
@@ -29346,9 +29789,9 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.0
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -29382,13 +29825,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.54.0(eslint@8.35.0)(typescript@5.0.4)':
+  '@typescript-eslint/utils@5.54.0(eslint@8.35.0)(typescript@5.5.2)':
     dependencies:
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.5.2)
       eslint: 8.35.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.35.0)
@@ -29397,14 +29840,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.60.0(eslint@8.35.0)(typescript@5.0.4)':
+  '@typescript-eslint/utils@5.60.0(eslint@8.35.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.35.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.60.0
       '@typescript-eslint/types': 5.60.0
-      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.5.2)
       eslint: 8.35.0
       eslint-scope: 5.1.1
       semver: 7.6.0
@@ -29893,7 +30336,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  aqu@0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)):
+  aqu@0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@18.7.19)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
       '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
       '@babel/preset-react': 7.22.5(@babel/core@7.22.5)
@@ -29913,13 +30356,13 @@ snapshots:
       fs-extra: 10.1.0
       github-username: 6.0.0
       inquirer: 7.3.3
-      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
-      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))
+      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
+      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)))
       lodash: 4.17.21
       ora: 5.4.1
       prettier: 2.8.4
       rimraf: 3.0.2
-      ts-jest: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
+      ts-jest: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)))(typescript@4.9.5)
       typescript: 4.9.5
       webpack-merge: 5.9.0
       yup: 0.32.11
@@ -29933,10 +30376,10 @@ snapshots:
       - supports-color
       - ts-node
 
-  aqu@0.4.3(@babel/core@7.22.5)(@jest/types@29.5.0)(@types/node@18.7.19)(babel-jest@29.5.0(@babel/core@7.22.5))(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  aqu@0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)):
     dependencies:
-      '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
-      '@babel/preset-react': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      '@babel/preset-react': 7.22.5(@babel/core@7.24.5)
       '@esbuild-plugins/node-resolve': 0.1.4(esbuild@0.15.18)
       '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.9.5))(eslint@8.35.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
@@ -29953,13 +30396,93 @@ snapshots:
       fs-extra: 10.1.0
       github-username: 6.0.0
       inquirer: 7.3.3
-      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
-      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)))
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4))
+      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))
       lodash: 4.17.21
       ora: 5.4.1
       prettier: 2.8.4
       rimraf: 3.0.2
-      ts-jest: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)))(typescript@4.9.5)
+      ts-jest: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.9.5)
+      typescript: 4.9.5
+      webpack-merge: 5.9.0
+      yup: 0.32.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@jest/types'
+      - '@types/node'
+      - babel-jest
+      - encoding
+      - node-notifier
+      - supports-color
+      - ts-node
+
+  aqu@0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)):
+    dependencies:
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      '@babel/preset-react': 7.22.5(@babel/core@7.24.5)
+      '@esbuild-plugins/node-resolve': 0.1.4(esbuild@0.15.18)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.9.5))(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      commander: 9.5.0
+      dts-bundle-generator: 6.13.0
+      esbuild: 0.15.18
+      eslint: 8.35.0
+      eslint-config-prettier: 8.8.0(eslint@8.35.0)
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.4)
+      eslint-plugin-simple-import-sort: 8.0.0(eslint@8.35.0)
+      execa: 4.1.0
+      fs-extra: 10.1.0
+      github-username: 6.0.0
+      inquirer: 7.3.3
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
+      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))
+      lodash: 4.17.21
+      ora: 5.4.1
+      prettier: 2.8.4
+      rimraf: 3.0.2
+      ts-jest: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@4.9.5)
+      typescript: 4.9.5
+      webpack-merge: 5.9.0
+      yup: 0.32.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@jest/types'
+      - '@types/node'
+      - babel-jest
+      - encoding
+      - node-notifier
+      - supports-color
+      - ts-node
+
+  aqu@0.4.3(@babel/core@7.24.5)(@jest/types@29.5.0)(@types/node@17.0.38)(babel-jest@29.5.0(@babel/core@7.24.5))(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
+    dependencies:
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      '@babel/preset-react': 7.22.5(@babel/core@7.24.5)
+      '@esbuild-plugins/node-resolve': 0.1.4(esbuild@0.15.18)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.9.5))(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      commander: 9.5.0
+      dts-bundle-generator: 6.13.0
+      esbuild: 0.15.18
+      eslint: 8.35.0
+      eslint-config-prettier: 8.8.0(eslint@8.35.0)
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.35.0))(eslint@8.35.0)(prettier@2.8.4)
+      eslint-plugin-simple-import-sort: 8.0.0(eslint@8.35.0)
+      execa: 4.1.0
+      fs-extra: 10.1.0
+      github-username: 6.0.0
+      inquirer: 7.3.3
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      jest-watch-typeahead: 2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))
+      lodash: 4.17.21
+      ora: 5.4.1
+      prettier: 2.8.4
+      rimraf: 3.0.2
+      ts-jest: 29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@4.9.5)
       typescript: 4.9.5
       webpack-merge: 5.9.0
       yup: 0.32.11
@@ -30155,7 +30678,7 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  astro@1.2.7(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  astro@1.2.7(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       '@astrojs/compiler': 0.24.0
       '@astrojs/language-server': 0.23.3
@@ -30194,7 +30717,7 @@ snapshots:
       path-browserify: 1.0.1
       path-to-regexp: 6.2.1
       postcss: 8.4.24
-      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       preferred-pm: 3.0.3
       prompts: 2.4.2
       recast: 0.20.5
@@ -30222,7 +30745,7 @@ snapshots:
       - terser
       - ts-node
 
-  astro@1.2.8(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  astro@1.2.8(less@4.1.3)(terser@5.18.1)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       '@astrojs/compiler': 0.24.0
       '@astrojs/language-server': 0.23.3
@@ -30261,7 +30784,7 @@ snapshots:
       path-browserify: 1.0.1
       path-to-regexp: 6.2.1
       postcss: 8.4.24
-      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       preferred-pm: 3.0.3
       prompts: 2.4.2
       recast: 0.20.5
@@ -30289,7 +30812,7 @@ snapshots:
       - terser
       - ts-node
 
-  astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.0.4):
+  astro@4.7.0(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)(typescript@5.5.2):
     dependencies:
       '@astrojs/compiler': 2.7.1
       '@astrojs/internal-helpers': 0.4.0
@@ -30345,7 +30868,7 @@ snapshots:
       shiki: 1.3.0
       string-width: 7.1.0
       strip-ansi: 7.1.0
-      tsconfck: 3.0.3(typescript@5.0.4)
+      tsconfck: 3.0.3(typescript@5.5.2)
       unist-util-visit: 5.0.0
       vfile: 6.0.1
       vite: 5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)
@@ -30543,6 +31066,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.5.0(@babel/core@7.24.5):
+    dependencies:
+      '@babel/core': 7.24.5
+      '@jest/transform': 29.5.0
+      '@types/babel__core': 7.20.1
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.5.0(@babel/core@7.24.5)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-loader@8.3.0(@babel/core@7.22.5)(webpack@5.88.0(esbuild@0.20.2)):
     dependencies:
       '@babel/core': 7.22.5
@@ -30632,7 +31169,6 @@ snapshots:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.8):
     dependencies:
@@ -30657,7 +31193,6 @@ snapshots:
       core-js-compat: 3.31.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.8):
     dependencies:
@@ -30679,7 +31214,6 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   babel-plugin-react-native-web@0.18.12:
     optional: true
@@ -30717,6 +31251,23 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.5)
 
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.5):
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
+    optional: true
+
   babel-preset-expo@9.3.2(@babel/core@7.22.5):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.22.5(@babel/core@7.22.5)
@@ -30726,6 +31277,20 @@ snapshots:
       babel-plugin-module-resolver: 4.1.0
       babel-plugin-react-native-web: 0.18.12
       metro-react-native-babel-preset: 0.73.9(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    optional: true
+
+  babel-preset-expo@9.3.2(@babel/core@7.24.5):
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      babel-plugin-module-resolver: 4.1.0
+      babel-plugin-react-native-web: 0.18.12
+      metro-react-native-babel-preset: 0.73.9(@babel/core@7.24.5)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -30816,6 +31381,13 @@ snapshots:
       '@babel/core': 7.22.5
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.22.5)
+
+  babel-preset-jest@29.5.0(@babel/core@7.24.5):
+    dependencies:
+      '@babel/core': 7.24.5
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.5)
+    optional: true
 
   babelify@10.0.0(@babel/core@7.22.5):
     dependencies:
@@ -33718,11 +34290,11 @@ snapshots:
       object.entries: 1.1.6
       semver: 6.3.0
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.35.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -33735,13 +34307,13 @@ snapshots:
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
 
-  eslint-config-airbnb-typescript@17.0.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0):
+  eslint-config-airbnb-typescript@17.0.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       eslint: 8.35.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0))(eslint@8.35.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0)
 
   eslint-config-prettier@8.8.0(eslint@8.35.0):
     dependencies:
@@ -33778,11 +34350,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0)
@@ -33820,7 +34392,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-typescript@2.7.1)(eslint@8.35.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -33829,7 +34401,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.27.5)(eslint@8.35.0))(eslint@8.35.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -33839,19 +34411,19 @@ snapshots:
       semver: 6.3.0
       tsconfig-paths: 3.14.2
     optionalDependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4):
+  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2):
     dependencies:
-      '@typescript-eslint/utils': 5.60.0(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.60.0(eslint@8.35.0)(typescript@5.5.2)
       eslint: 8.35.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.0.4))(eslint@8.35.0)(typescript@5.0.4)
-      jest: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@5.5.2))(eslint@8.35.0)(typescript@5.5.2)
+      jest: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -34247,11 +34819,30 @@ snapshots:
       expo: 48.0.19(@babel/core@7.22.5)
     optional: true
 
+  expo-application@5.1.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      expo: 48.0.19(@babel/core@7.24.5)
+    optional: true
+
   expo-asset@8.9.1(expo@48.0.19(@babel/core@7.22.5)):
     dependencies:
       blueimp-md5: 2.19.0
       expo-constants: 14.2.1(expo@48.0.19(@babel/core@7.22.5))
       expo-file-system: 15.2.2(expo@48.0.19(@babel/core@7.22.5))
+      invariant: 2.2.4
+      md5-file: 3.2.3
+      path-browserify: 1.0.1
+      url-parse: 1.5.10
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+    optional: true
+
+  expo-asset@8.9.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      blueimp-md5: 2.19.0
+      expo-constants: 14.2.1(expo@48.0.19(@babel/core@7.24.5))
+      expo-file-system: 15.2.2(expo@48.0.19(@babel/core@7.24.5))
       invariant: 2.2.4
       md5-file: 3.2.3
       path-browserify: 1.0.1
@@ -34270,9 +34861,24 @@ snapshots:
       - supports-color
     optional: true
 
+  expo-constants@14.2.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      '@expo/config': 8.0.2
+      expo: 48.0.19(@babel/core@7.24.5)
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   expo-file-system@15.2.2(expo@48.0.19(@babel/core@7.22.5)):
     dependencies:
       expo: 48.0.19(@babel/core@7.22.5)
+      uuid: 3.4.0
+    optional: true
+
+  expo-file-system@15.2.2(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      expo: 48.0.19(@babel/core@7.24.5)
       uuid: 3.4.0
     optional: true
 
@@ -34282,9 +34888,20 @@ snapshots:
       fontfaceobserver: 2.3.0
     optional: true
 
+  expo-font@11.1.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      expo: 48.0.19(@babel/core@7.24.5)
+      fontfaceobserver: 2.3.0
+    optional: true
+
   expo-keep-awake@12.0.1(expo@48.0.19(@babel/core@7.22.5)):
     dependencies:
       expo: 48.0.19(@babel/core@7.22.5)
+    optional: true
+
+  expo-keep-awake@12.0.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      expo: 48.0.19(@babel/core@7.24.5)
     optional: true
 
   expo-modules-autolinking@0.0.3:
@@ -34317,6 +34934,12 @@ snapshots:
       expo: 48.0.19(@babel/core@7.22.5)
     optional: true
 
+  expo-random@13.1.1(expo@48.0.19(@babel/core@7.24.5)):
+    dependencies:
+      base64-js: 1.5.1
+      expo: 48.0.19(@babel/core@7.24.5)
+    optional: true
+
   expo@48.0.19(@babel/core@7.22.5):
     dependencies:
       '@babel/runtime': 7.22.5
@@ -34332,6 +34955,39 @@ snapshots:
       expo-file-system: 15.2.2(expo@48.0.19(@babel/core@7.22.5))
       expo-font: 11.1.1(expo@48.0.19(@babel/core@7.22.5))
       expo-keep-awake: 12.0.1(expo@48.0.19(@babel/core@7.22.5))
+      expo-modules-autolinking: 1.2.0
+      expo-modules-core: 1.2.7
+      fbemitter: 3.0.0
+      getenv: 1.0.0
+      invariant: 2.2.4
+      md5-file: 3.2.3
+      node-fetch: 2.7.0
+      pretty-format: 26.6.2
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bluebird
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  expo@48.0.19(@babel/core@7.24.5):
+    dependencies:
+      '@babel/runtime': 7.22.5
+      '@expo/cli': 0.7.3(expo-modules-autolinking@1.2.0)
+      '@expo/config': 8.0.2
+      '@expo/config-plugins': 6.0.2
+      '@expo/vector-icons': 13.0.0
+      babel-preset-expo: 9.3.2(@babel/core@7.24.5)
+      cross-spawn: 6.0.5
+      expo-application: 5.1.1(expo@48.0.19(@babel/core@7.24.5))
+      expo-asset: 8.9.1(expo@48.0.19(@babel/core@7.24.5))
+      expo-constants: 14.2.1(expo@48.0.19(@babel/core@7.24.5))
+      expo-file-system: 15.2.2(expo@48.0.19(@babel/core@7.24.5))
+      expo-font: 11.1.1(expo@48.0.19(@babel/core@7.24.5))
+      expo-keep-awake: 12.0.1(expo@48.0.19(@babel/core@7.24.5))
       expo-modules-autolinking: 1.2.0
       expo-modules-core: 1.2.7
       fbemitter: 3.0.0
@@ -36567,6 +37223,24 @@ snapshots:
       - expo
       - react-native
 
+  isomorphic-webcrypto@2.3.8(expo@48.0.19(@babel/core@7.24.5))(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@peculiar/webcrypto': 1.4.3
+      asmcrypto.js: 0.22.0
+      b64-lite: 1.4.0
+      b64u-lite: 1.1.0
+      msrcrypto: 1.5.8
+      str2buf: 1.3.0
+      webcrypto-shim: 0.1.7
+    optionalDependencies:
+      '@unimodules/core': 7.1.2
+      '@unimodules/react-native-adapter': 6.3.9
+      expo-random: 13.1.1(expo@48.0.19(@babel/core@7.24.5))
+      react-native-securerandom: 0.1.1(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))
+    transitivePeerDependencies:
+      - expo
+      - react-native
+
   isomorphic-ws@4.0.1(ws@7.5.9):
     dependencies:
       ws: 7.5.9
@@ -36693,16 +37367,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-cli@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      '@jest/core': 28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-config: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -36731,16 +37405,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)):
+  jest-cli@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      jest-config: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -36750,16 +37424,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  jest-cli@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      jest-config: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -36769,16 +37443,35 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-cli@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-config: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
+  jest-cli@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -36818,7 +37511,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@28.1.3(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-config@28.1.3(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 28.1.3
@@ -36844,11 +37537,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.16.18
-      ts-node: 10.8.1(@types/node@18.7.19)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@18.7.19)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-config@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 28.1.3
@@ -36874,7 +37567,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.7.19
-      ts-node: 10.8.1(@types/node@18.7.19)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@18.7.19)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -36908,7 +37601,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)):
+  jest-config@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.5.0
@@ -36934,7 +37627,37 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 17.0.38
-      ts-node: 10.8.1(@types/node@17.0.38)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@17.0.38)(typescript@5.5.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-config@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
+    dependencies:
+      '@babel/core': 7.22.5
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.22.5)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 17.0.38
+      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -36968,7 +37691,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)):
+  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.5.0
@@ -36994,11 +37717,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.16.18
-      ts-node: 10.8.1(@types/node@17.0.38)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@17.0.38)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.5.0
@@ -37024,11 +37747,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.16.18
-      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.0.4)
+      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-config@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.5.0
@@ -37054,11 +37777,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.16.18
-      ts-node: 10.8.1(@types/node@18.7.19)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@18.7.19)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest-config@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.5.0
@@ -37084,7 +37807,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.7.19
-      ts-node: 10.8.1(@types/node@18.7.19)(typescript@4.9.5)
+      ts-node: 10.8.1(@types/node@18.7.19)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -37628,22 +38351,33 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))):
+  jest-watch-typeahead@2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))):
     dependencies:
       ansi-escapes: 6.2.0
       chalk: 5.2.0
-      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       jest-regex-util: 29.4.3
       jest-watcher: 29.5.0
       slash: 5.1.0
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.2(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))):
+  jest-watch-typeahead@2.2.2(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))):
     dependencies:
       ansi-escapes: 6.2.0
       chalk: 5.2.0
-      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      jest-regex-util: 29.4.3
+      jest-watcher: 29.5.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.1.0
+
+  jest-watch-typeahead@2.2.2(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))):
+    dependencies:
+      ansi-escapes: 6.2.0
+      chalk: 5.2.0
+      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-regex-util: 29.4.3
       jest-watcher: 29.5.0
       slash: 5.1.0
@@ -37708,12 +38442,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      '@jest/core': 28.1.3(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-cli: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -37730,34 +38464,45 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)):
+  jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      jest-cli: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
       - ts-node
 
-  jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      jest-cli: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
       - ts-node
 
-  jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)):
+  jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest-cli: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
+  jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)):
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -37886,6 +38631,32 @@ snapshots:
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
       - supports-color
+
+  jscodeshift@0.14.0(@babel/preset-env@7.22.5(@babel/core@7.24.5)):
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-env': 7.22.5(@babel/core@7.24.5)
+      '@babel/preset-flow': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-typescript': 7.22.5(@babel/core@7.22.5)
+      '@babel/register': 7.22.5(@babel/core@7.22.5)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.22.5)
+      chalk: 4.1.2
+      flow-parser: 0.209.1
+      graceful-fs: 4.2.11
+      micromatch: 4.0.5
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   jsdoc-type-pratt-parser@3.1.0: {}
 
@@ -39057,6 +39828,50 @@ snapshots:
       - supports-color
     optional: true
 
+  metro-react-native-babel-preset@0.73.9(@babel/core@7.24.5):
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-export-default-from': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-classes': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-self': 7.24.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-runtime': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/template': 7.24.0
+      react-refresh: 0.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   metro-react-native-babel-preset@0.76.5(@babel/core@7.22.5):
     dependencies:
       '@babel/core': 7.22.5
@@ -39154,6 +39969,19 @@ snapshots:
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.76.5
       metro-react-native-babel-preset: 0.76.5(@babel/core@7.22.5)
+      metro-source-map: 0.76.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  metro-react-native-babel-transformer@0.76.5(@babel/core@7.24.5):
+    dependencies:
+      '@babel/core': 7.24.5
+      babel-preset-fbjs: 3.4.0(@babel/core@7.24.5)
+      hermes-parser: 0.8.0
+      metro-babel-transformer: 0.76.5
+      metro-react-native-babel-preset: 0.76.5(@babel/core@7.24.5)
       metro-source-map: 0.76.5
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -41331,29 +42159,29 @@ snapshots:
       postcss: 8.4.13
       ts-node: 10.8.1(@types/node@18.16.18)(typescript@4.7.4)
 
-  postcss-load-config@3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  postcss-load-config@3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.24
-      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.0.4)
+      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.5.2)
 
-  postcss-load-config@4.0.1(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  postcss-load-config@4.0.1(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.1
     optionalDependencies:
       postcss: 8.4.36
-      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.0.4)
+      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.5.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  postcss-load-config@4.0.2(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.36
-      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.0.4)
+      ts-node: 10.8.1(@types/node@18.16.18)(typescript@5.5.2)
 
   postcss-loader@6.2.1(postcss@8.4.13)(webpack@5.88.0(esbuild@0.14.38)):
     dependencies:
@@ -42339,6 +43167,12 @@ snapshots:
       react-native: 0.72.0(@babel/core@7.22.5)(@babel/preset-env@7.22.5(@babel/core@7.22.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
     optional: true
 
+  react-native-securerandom@0.1.1(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      base64-js: 1.5.1
+      react-native: 0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
+    optional: true
+
   react-native@0.72.0(@babel/core@7.22.5)(@babel/preset-env@7.22.5(@babel/core@7.22.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1):
     dependencies:
       '@jest/create-cache-key-function': 29.5.0
@@ -42351,6 +43185,55 @@ snapshots:
       '@react-native/js-polyfills': 0.72.1
       '@react-native/normalize-colors': 0.72.0
       '@react-native/virtualized-lists': 0.72.5(react-native@0.72.0(@babel/core@7.22.5)(@babel/preset-env@7.22.5(@babel/core@7.22.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 4.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.5
+      invariant: 2.2.4
+      jest-environment-node: 29.5.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.76.5
+      metro-source-map: 0.76.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.3.1
+      react-devtools-core: 4.27.8
+      react-refresh: 0.4.3
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      use-sync-external-store: 1.2.0(react@18.3.1)
+      whatwg-fetch: 3.6.2
+      ws: 6.2.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - react-test-renderer
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@jest/create-cache-key-function': 29.5.0
+      '@react-native-community/cli': 11.3.2(@babel/core@7.24.5)
+      '@react-native-community/cli-platform-android': 11.3.2
+      '@react-native-community/cli-platform-ios': 11.3.2
+      '@react-native/assets-registry': 0.72.0
+      '@react-native/codegen': 0.72.6(@babel/preset-env@7.22.5(@babel/core@7.24.5))
+      '@react-native/gradle-plugin': 0.72.10
+      '@react-native/js-polyfills': 0.72.1
+      '@react-native/normalize-colors': 0.72.0
+      '@react-native/virtualized-lists': 0.72.5(react-native@0.72.0(@babel/core@7.24.5)(@babel/preset-env@7.22.5(@babel/core@7.24.5))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))
       abort-controller: 3.0.0
       anser: 1.4.10
       base64-js: 1.5.1
@@ -44520,7 +45403,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  tailwindcss@3.0.24(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -44537,7 +45420,7 @@ snapshots:
       picocolors: 1.0.0
       postcss: 8.4.24
       postcss-js: 4.0.1(postcss@8.4.24)
-      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       postcss-nested: 5.0.6(postcss@8.4.24)
       postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
@@ -44546,7 +45429,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)):
+  tailwindcss@3.4.3(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -44565,7 +45448,7 @@ snapshots:
       postcss: 8.4.36
       postcss-import: 15.1.0(postcss@8.4.36)
       postcss-js: 4.0.1(postcss@8.4.36)
-      postcss-load-config: 4.0.1(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      postcss-load-config: 4.0.1(postcss@8.4.36)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
       postcss-nested: 6.0.1(postcss@8.4.36)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.2
@@ -44938,21 +45821,21 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@28.0.5(@babel/core@7.22.5)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)))(typescript@4.9.5):
+  ts-jest@28.0.5(@babel/core@7.22.5)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)))(typescript@5.5.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest: 28.1.3(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-util: 28.1.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.2
-      typescript: 4.9.5
+      typescript: 5.5.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.22.5
-      babel-jest: 29.5.0(@babel/core@7.22.5)
+      babel-jest: 29.5.0(@babel/core@7.24.5)
       esbuild: 0.14.38
 
   ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.7.4):
@@ -44973,42 +45856,6 @@ snapshots:
       babel-jest: 29.5.0(@babel/core@7.22.5)
       esbuild: 0.14.38
 
-  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
-      jest-util: 29.5.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.2
-      typescript: 4.9.5
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.22.5
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.22.5)
-      esbuild: 0.14.38
-
-  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.54)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
-      jest-util: 29.5.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.2
-      typescript: 4.9.5
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.22.5
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.22.5)
-      esbuild: 0.14.54
-
   ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
@@ -45027,11 +45874,11 @@ snapshots:
       babel-jest: 29.5.0(@babel/core@7.22.5)
       esbuild: 0.15.18
 
-  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5):
+  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2)))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5))
+      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2))
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -45042,14 +45889,68 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.22.5
       '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.22.5)
+      babel-jest: 29.5.0(@babel/core@7.24.5)
       esbuild: 0.15.18
 
-  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5)))(typescript@4.9.5):
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.7.4):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@18.7.19)(ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5))
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.2
+      typescript: 4.7.4
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.5
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.24.5)
+      esbuild: 0.14.38
+
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.2
+      typescript: 5.5.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.5
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.24.5)
+      esbuild: 0.14.38
+
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.14.54)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@5.5.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.2
+      typescript: 5.5.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.5
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.24.5)
+      esbuild: 0.14.54
+
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4)))(typescript@4.9.5):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.7.4))
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -45058,27 +45959,63 @@ snapshots:
       typescript: 4.9.5
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.22.5
+      '@babel/core': 7.24.5
       '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.22.5)
+      babel-jest: 29.5.0(@babel/core@7.24.5)
       esbuild: 0.15.18
 
-  ts-jest@29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.20.2)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4)))(typescript@5.0.4):
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2)))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4))
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2))
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.2
-      typescript: 5.0.4
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.22.5
+      '@babel/core': 7.24.5
       '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.22.5)
+      babel-jest: 29.5.0(@babel/core@7.24.5)
+      esbuild: 0.15.18
+
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.15.18)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@4.9.5):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.2
+      typescript: 4.9.5
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.5
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.24.5)
+      esbuild: 0.15.18
+
+  ts-jest@29.0.5(@babel/core@7.24.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.24.5))(esbuild@0.20.2)(jest@29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2)))(typescript@5.5.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@18.16.18)(ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.2
+      typescript: 5.5.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.5
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.24.5)
       esbuild: 0.20.2
 
   ts-mixer@6.0.3: {}
@@ -45102,7 +46039,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5):
+  ts-node@10.8.1(@types/node@17.0.38)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -45116,7 +46053,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -45140,7 +46077,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.8.1(@types/node@18.16.18)(typescript@5.0.4):
+  ts-node@10.8.1(@types/node@18.16.18)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -45154,7 +46091,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -45177,7 +46114,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.8.1(@types/node@18.7.19)(typescript@4.9.5):
+  ts-node@10.8.1(@types/node@18.7.19)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -45191,7 +46128,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -45205,9 +46142,9 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.5.0
 
-  tsconfck@3.0.3(typescript@5.0.4):
+  tsconfck@3.0.3(typescript@5.5.2):
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.5.2
 
   tsconfig-paths@3.14.2:
     dependencies:
@@ -45253,10 +46190,10 @@ snapshots:
       tslib: 1.14.1
       typescript: 4.9.5
 
-  tsutils@3.21.0(typescript@5.0.4):
+  tsutils@3.21.0(typescript@5.5.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.5.2
 
   tty-browserify@0.0.1: {}
 
@@ -45363,7 +46300,7 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.0.4: {}
+  typescript@5.5.2: {}
 
   ua-parser-js@1.0.35: {}
 
@@ -45911,11 +46848,11 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.0.4)(vite@5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.5.2)(vite@5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.0.4)
+      tsconfck: 3.0.3(typescript@5.5.2)
     optionalDependencies:
       vite: 5.2.10(@types/node@18.16.18)(less@4.1.3)(terser@5.18.1)
     transitivePeerDependencies:


### PR DESCRIPTION
- **:arrow_up: Bump TS to 5.5.2**
- **:sparkles: Allow changing boost VCs before sending them**
- **:bookmark: Changesets**

# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
We've been stuck on TS 5.0.4 for a while, and I finally got that fixed today!

Also, right now, you can not actually change a boost before sending it (such as to add a `credentialStatus` field),
nor can you easily get the Brain Client object from the Network plugin

#### 🥴 TL; RL:
Upgrades TypeScript across the whole monorepo and allows for better flexibility when sending boosts

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- Upgrade to TS 5.5.2
    - In order to make this work, I had to do this weird change where I can't use `[T] extends [1 & T]` directly to determine if `T` is any, but I _can_ put that into a helper type `type IsAnyOrNever = [T] extends [1 & T] ? true : false` and use that: `IsAnyOrNever<T> ? true : false`. Don't ask me why, but that was the breaking change from the TS upgrade =(
- Update `sendBoost` type to allow overriding the boost
    - Very simply just allows passing in an override function that gives you the unsigned VC, and then expects you to return an unsigned VC that it will use to send the boost
    - In order to keep this backwords compatible, I made the last parameter _either_ a boolean or an object
- Add `getLCNClient` method to network plugin
    - This just allows for full flexibility when interacting with the LCN. Let's consumers do whatever they want with the TRPC client!

#### 🛠 Important tradeoffs made:
Just the annoying backwards compat boolean or object thing

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Build _everything_ (`pnpm exec nx build cli --skip-nx-cache`) and then open the CLI and try different
things like issuing creds. Also, try grabbing the client in the CLI via `learnCard.invoke.getLCNClient`
and hitting the API directly (e.g. `client.utilities.healthCheck.query()`)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
