### PR TITLE
[WE-3308] Recipient Count

### DIFF
--- a/.changeset/breezy-cars-march.md
+++ b/.changeset/breezy-cars-march.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Add ability to count recipients of a boost

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -372,6 +372,11 @@ export const getLearnCardNetworkPlugin = async (
                     includeUnacceptedBoosts,
                 });
             },
+            countBoostRecipients: async (_learnCard, uri, includeUnacceptedBoosts = true) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.boost.getBoostRecipientCount.query({ uri, includeUnacceptedBoosts });
+            },
             updateBoost: async (_learnCard, uri, updates, credential) => {
                 if (!userData) throw new Error('Please make an account first!');
 
@@ -430,7 +435,7 @@ export const getLearnCardNetworkPlugin = async (
                 if (boost?.type?.includes('BoostCredential')) boost.boostId = boostUri;
 
                 if (typeof options === 'object' && options.overideFn) {
-                    boost = options.overideFn(boost)
+                    boost = options.overideFn(boost);
                 }
 
                 const vc = await _learnCard.invoke.issueCredential(boost);

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -109,6 +109,7 @@ export type LearnCardNetworkPluginMethods = {
         skip?: number,
         includeUnacceptedBoosts?: boolean
     ) => Promise<BoostRecipientInfo[]>;
+    countBoostRecipients: (uri: string, includeUnacceptedBoosts?: boolean) => Promise<number>;
     updateBoost: (
         uri: string,
         updates: Partial<Omit<Boost, 'uri'>>,


### PR DESCRIPTION
- **:sparkles: Add Boost Recipient Count**
- **:bookmark: Changesets**

# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[WE-3308] Aug - badge count is inaccurate

#### 📚 What is the context and goal of this PR?
We don't have a good way to count the number of recipients for a boost

#### 🥴 TL; RL:
Adds a resolver to count boost recipients

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- New route: `getBoostRecipientCount`
- New plugin method: `countBoostRecipients`

#### 🛠 Important tradeoffs made:
None!

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run test suite, run this locally and connect a learncard to it in the CLI:

```
# First set up Neo4j by spinning up an instance and setting its info in .env inside of services/learn-card-network/brain-service
cd services/learn-card-network/brain-service

# Start local instance
pnpm start
```

```
# Open the CLI
pnpm exec nx start cli # Add --skip-nx-cache if it doesn't seem to be working

// Once it's open
let test = await initLearnCard({ seed: 'a', network: 'http://localhost:3000/trpc' });
let test2 = await initLearnCard({ seed: 'b', network: 'http://localhost:3000/trpc' });

// If you don't have accounts yet, make them

await test.invoke.createProfile({ profileId: 'testa' });
await test2.invoke.createProfile({ profileId: 'testb' });


// Create a boost
const uvc = test.invoke.getTestVc();
const uri = await test.invoke.createBoost(uvc);

// Count recipients (should be 0)
await test.invoke.countBoostRecipients(uri);

// Send boost
await test.invoke.sendBoost('testb', uri);

// Count recipients (should be 1)
await test.invoke.countBoostRecipients(uri);
```

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->
N/A

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote tests for this!

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
