### PR TITLE
[LC-270] Filter Boosts

### DIFF
--- a/.changeset/thick-tables-clean.md
+++ b/.changeset/thick-tables-clean.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': minor
+'@learncard/network-plugin': patch
+---
+
+Allow querying when getting/counting boosts

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -381,19 +381,19 @@ export const getLearnCardNetworkPlugin = async (
 
                 return client.boost.getBoost.query({ uri });
             },
-            getBoosts: async _learnCard => {
+            getBoosts: async (_learnCard, query) => {
                 console.warn(
                     'The getBoosts method is deprecated! Please use getPaginatedBoosts instead!'
                 );
 
                 if (!userData) throw new Error('Please make an account first!');
 
-                return client.boost.getBoosts.query();
+                return client.boost.getBoosts.query({ query });
             },
-            countBoosts: async _learnCard => {
+            countBoosts: async (_learnCard, query) => {
                 if (!userData) throw new Error('Please make an account first!');
 
-                return client.boost.countBoosts.query();
+                return client.boost.countBoosts.query({ query });
             },
             getPaginatedBoosts: async (_learnCard, options) => {
                 if (!userData) throw new Error('Please make an account first!');

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -115,8 +115,11 @@ export type LearnCardNetworkPluginMethods = {
     ) => Promise<string>;
     getBoost: (uri: string) => Promise<Boost & { boost: UnsignedVC }>;
     /** @deprecated Use getPaginatedBoosts */
-    getBoosts: () => Promise<{ name?: string; uri: string }[]>;
-    getPaginatedBoosts: (options?: PaginationOptionsType) => Promise<PaginatedBoostsType>;
+    getBoosts: (query?: Partial<Omit<Boost, 'uri'>>) => Promise<{ name?: string; uri: string }[]>;
+    getPaginatedBoosts: (
+        options?: PaginationOptionsType & { query?: Partial<Omit<Boost, 'uri'>> }
+    ) => Promise<PaginatedBoostsType>;
+    countBoosts: (query?: Partial<Omit<Boost, 'uri'>>) => Promise<number>;
     /** @deprecated Use getPaginatedBoostRecipients */
     getBoostRecipients: (
         uri: string,
@@ -220,7 +223,6 @@ export type LearnCardNetworkPluginMethods = {
     ) => Promise<VC | UnsignedVC | VP | JWE | ConsentFlowContract | ConsentFlowTerms>;
 
     getLCNClient: () => LCNClient;
-    countBoosts: () => Promise<number>;
 };
 
 /** @group LearnCardNetwork Plugin */

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -187,7 +187,7 @@ export const boostsRouter = t.router({
         .meta({
             openapi: {
                 protect: true,
-                method: 'GET',
+                method: 'POST',
                 path: '/boost',
                 tags: ['Boosts'],
                 summary: 'Get boosts',
@@ -196,12 +196,19 @@ export const boostsRouter = t.router({
                     "This endpoint gets the current user's boosts.\nWarning! This route is deprecated and currently has a hard limit of returning only the first 50 boosts. Please use getPaginatedBoosts instead",
             },
         })
-        .input(z.void())
+        .input(
+            z
+                .object({
+                    query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                })
+                .default({})
+        )
         .output(BoostValidator.omit({ id: true, boost: true }).extend({ uri: z.string() }).array())
-        .query(async ({ ctx }) => {
+        .query(async ({ ctx, input }) => {
+            const { query } = input;
             const { profile } = ctx.user;
 
-            const boosts = await getBoostsForProfile(profile, { limit: 50 });
+            const boosts = await getBoostsForProfile(profile, { limit: 50, query });
 
             return boosts.map(boost => {
                 const { id, boost: _boost, ...remaining } = boost;
@@ -213,19 +220,26 @@ export const boostsRouter = t.router({
         .meta({
             openapi: {
                 protect: true,
-                method: 'GET',
+                method: 'POST',
                 path: '/boost/count',
                 tags: ['Boosts'],
                 summary: 'Count managed boosts',
                 description: "This endpoint counts the current user's managed boosts.",
             },
         })
-        .input(z.void())
+        .input(
+            z
+                .object({
+                    query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                })
+                .default({})
+        )
         .output(z.number())
-        .query(async ({ ctx }) => {
+        .query(async ({ ctx, input }) => {
+            const { query } = input;
             const { profile } = ctx.user;
 
-            const count = await countBoostsForProfile(profile);
+            const count = await countBoostsForProfile(profile, { query });
 
             return count;
         }),
@@ -234,7 +248,7 @@ export const boostsRouter = t.router({
         .meta({
             openapi: {
                 protect: true,
-                method: 'GET',
+                method: 'POST',
                 path: '/boost/paginated',
                 tags: ['Boosts'],
                 summary: 'Get boosts',
@@ -244,14 +258,15 @@ export const boostsRouter = t.router({
         .input(
             PaginationOptionsValidator.extend({
                 limit: PaginationOptionsValidator.shape.limit.default(25),
+                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
             }).default({})
         )
         .output(PaginatedBoostsValidator)
         .query(async ({ ctx, input }) => {
-            const { limit, cursor } = input;
+            const { limit, cursor, query } = input;
             const { profile } = ctx.user;
 
-            const records = await getBoostsForProfile(profile, { limit: limit + 1, cursor });
+            const records = await getBoostsForProfile(profile, { limit: limit + 1, cursor, query });
 
             const hasMore = records.length > limit;
             const newCursor = records.at(hasMore ? -2 : -1)?.created;

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -157,6 +157,22 @@ describe('Boosts', () => {
 
             expect(boosts).toHaveLength(1);
         });
+
+        it('should allow querying boosts', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+
+            await expect(
+                userA.clients.fullAuth.boost.getBoosts({ query: { category: 'A' } })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getBoosts({
+                query: { category: 'A' },
+            });
+
+            expect(boosts).toHaveLength(1);
+            expect(boosts[0]?.category).toEqual('A');
+        });
     });
 
     describe('getPaginatedBoosts', () => {
@@ -195,6 +211,22 @@ describe('Boosts', () => {
             const boosts = await userA.clients.fullAuth.boost.getPaginatedBoosts();
 
             expect(boosts.records).toHaveLength(1);
+        });
+
+        it('should allow querying boosts', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+
+            await expect(
+                userA.clients.fullAuth.boost.getPaginatedBoosts({ query: { category: 'A' } })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getPaginatedBoosts({
+                query: { category: 'A' },
+            });
+
+            expect(boosts.records).toHaveLength(1);
+            expect(boosts.records[0]?.category).toEqual('A');
         });
 
         it('should paginate correctly', async () => {
@@ -1713,6 +1745,21 @@ describe('Boosts', () => {
 
             const count = await userA.clients.fullAuth.boost.countBoosts();
             expect(count).toBe(2); // userA should see 2 distinct boosts: one they created and one they're an admin of
+        });
+
+        it('should allow querying boosts', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+
+            await expect(
+                userA.clients.fullAuth.boost.countBoosts({ query: { category: 'A' } })
+            ).resolves.not.toThrow();
+
+            const count = await userA.clients.fullAuth.boost.countBoosts({
+                query: { category: 'A' },
+            });
+
+            expect(count).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-270] Count on the Earned and manage tabs like in a prior Figma design

#### 📚 What is the context and goal of this PR?
To get accurate counts, we need a count route, and that count route needs to be able to query for specific categories!

#### 🥴 TL; RL:
Updates get/count boost routes to accept a query

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- `getBoosts`, `countBoosts`, and `getPaginatedBoosts` were all updated to accept a query
    - The query is just a `Partial<Boost>`, meaning you can only do basic equality queries for now. We might want to open this up in the future to add like $in or $not or something
- `getBoosts` and `countBoosts` had to change from `GET` to `POST` in the HTTP API, because GET can't handle an object as input, and I didn't want to screw with the main API to account for that
#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the test suite. After that, to test manually, you'll need to do a couple of things:
- Run the Brain service by first running Neo4j: `docker run --env=NEO4J_AUTH=none -p 7474:7474 -p 7687:7687 neo4j`
- Then make sure you add `NEO4J_URI=neo4j://localhost:7687` to the .env file in `services/learn-card-network/brain-service`
- Then run `pnpm start` in the brain service dir
- Then run the CLI (`pnpm exec nx start cli --skip-nx-cache`) [Only skip nx cache if it like isn't working for some reason]
- Then run the following commands
- `let test = await initLearnCard({ seed: 'a', network: 'http://localhost:3000/trpc' })`
- `await test.invoke.createProfile({ profileId: 'test' })`
- `await test.invoke.createBoost(test.invoke.getTestVc(), { category: 'A' })`
- `await test.invoke.createBoost(test.invoke.getTestVc(), { category: 'B' })`
- `await test.invoke.countBoosts()` // 2
- `await test.invoke.countBoosts({ category: 'A' })` // 1

You can try out the queries for the other routes too! `test.invoke.getBoosts({ category: 'A' })` and `test.invoke.getPaginatedBoosts({ query: { category: 'A' } })`

Play around with it and make sure it works like you would expect!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote tests for this =)

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
