### PR TITLE
[LC-334] tRPC v11

### DIFF
--- a/.changeset/funny-nails-decide.md
+++ b/.changeset/funny-nails-decide.md
@@ -1,0 +1,8 @@
+---
+'@learncard/learn-cloud-service': minor
+'@learncard/network-brain-service': minor
+'@learncard/network-brain-client': minor
+'@learncard/learn-cloud-client': minor
+---
+
+Upgrade to tRPC v11 and use POST requests instead of GET requests

--- a/packages/learn-card-core/package.json
+++ b/packages/learn-card-core/package.json
@@ -38,7 +38,7 @@
         "shx": "^0.3.4",
         "sift": "^17.0.1",
         "ts-jest": "^29.0.3",
-        "tsc-alias": "^1.6.9"
+        "tsc-alias": "^1.8.10"
     },
     "types": "./dist/index.d.ts",
     "dependencies": {

--- a/packages/learn-card-network/brain-client/package.json
+++ b/packages/learn-card-network/brain-client/package.json
@@ -18,7 +18,6 @@
     },
     "dependencies": {
         "@learncard/network-brain-service": "workspace:*",
-        "@trpc/client": "^10.45.2",
-        "@trpc/server": "^10.45.2"
+        "@trpc/client": "11.0.0-rc.502"
     }
 }

--- a/packages/learn-card-network/brain-client/src/index.ts
+++ b/packages/learn-card-network/brain-client/src/index.ts
@@ -1,9 +1,9 @@
-import { createTRPCProxyClient, CreateTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import { createTRPCClient, CreateTRPCClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from '@learncard/network-brain-service';
 
 import { callbackLink } from './callbackLink';
 
-export type LCNClient = CreateTRPCProxyClient<AppRouter>;
+export type LCNClient = CreateTRPCClient<AppRouter>;
 
 export const getClient = async (
     url: string,
@@ -11,9 +11,10 @@ export const getClient = async (
 ): Promise<LCNClient> => {
     let challenges: string[] = [];
 
-    const challengeRequester = createTRPCProxyClient<AppRouter>({
+    const challengeRequester = createTRPCClient<AppRouter>({
         links: [
             httpBatchLink({
+                methodOverride: 'POST',
                 url,
                 maxURLLength: 2048,
                 headers: { Authorization: `Bearer ${await didAuthFunction()}` },
@@ -29,12 +30,13 @@ export const getClient = async (
 
     challenges = await getChallenges();
 
-    const trpc = createTRPCProxyClient<AppRouter>({
+    const trpc = createTRPCClient<AppRouter>({
         links: [
             callbackLink(async () => {
                 challenges = await getChallenges();
             }),
             httpBatchLink({
+                methodOverride: 'POST',
                 maxURLLength: 2048,
                 url,
                 headers: async () => {

--- a/packages/learn-card-network/cloud-client/package.json
+++ b/packages/learn-card-network/cloud-client/package.json
@@ -18,7 +18,6 @@
     },
     "dependencies": {
         "@learncard/learn-cloud-service": "workspace:*",
-        "@trpc/client": "^10.45.2",
-        "@trpc/server": "^10.45.2"
+        "@trpc/client": "11.0.0-rc.502"
     }
 }

--- a/packages/learn-card-network/cloud-client/src/index.ts
+++ b/packages/learn-card-network/cloud-client/src/index.ts
@@ -1,50 +1,24 @@
-import { createTRPCProxyClient, CreateTRPCProxyClient, httpBatchLink } from '@trpc/client';
-import type { inferRouterInputs } from '@trpc/server';
-import type {
-    JWE,
-    PaginatedEncryptedRecordsType,
-    PaginatedEncryptedCredentialRecordsType,
-} from '@learncard/types';
+import { createTRPCClient, CreateTRPCClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from '@learncard/learn-cloud-service';
 
 import { callbackLink } from './callbackLink';
 
-type Inputs = inferRouterInputs<AppRouter>;
-
-type Client = CreateTRPCProxyClient<AppRouter>;
-
-type OverriddenClient = Omit<Client, 'index' | 'customStorage'> & {
-    index: Client['index'] & {
-        get: {
-            query: (
-                args: Inputs['index']['get']
-            ) => Promise<PaginatedEncryptedCredentialRecordsType | JWE>;
-        };
-    };
-    customStorage: Omit<Client['customStorage'], 'read'> & {
-        read: {
-            query: (
-                args: Inputs['customStorage']['read']
-            ) => Promise<PaginatedEncryptedRecordsType>;
-        };
-    };
-};
-
 export const getClient = async (
     url: string,
     didAuthFunction: (challenge?: string) => Promise<string>
-) => {
+): Promise<CreateTRPCClient<AppRouter>> => {
     let challenges: string[] = [];
 
-    const challengeRequester = createTRPCProxyClient<AppRouter>({
+    const challengeRequester = createTRPCClient<AppRouter>({
         links: [
             httpBatchLink({
+                methodOverride: 'POST',
                 url,
                 maxURLLength: 3072,
                 headers: { Authorization: `Bearer ${await didAuthFunction()}` },
             }),
         ],
-    }) as OverriddenClient;
+    });
 
     const getChallenges = async (
         amount = 95 + Math.round((Math.random() - 0.5) * 5)
@@ -54,12 +28,13 @@ export const getClient = async (
 
     challenges = await getChallenges();
 
-    const trpc = createTRPCProxyClient<AppRouter>({
+    const trpc = createTRPCClient<AppRouter>({
         links: [
             callbackLink(async () => {
                 challenges = await getChallenges();
             }),
             httpBatchLink({
+                methodOverride: 'POST',
                 url,
                 maxURLLength: 3072,
                 headers: async () => {
@@ -69,7 +44,7 @@ export const getClient = async (
                 },
             }),
         ],
-    }) as OverriddenClient;
+    });
 
     return trpc;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,8 +530,8 @@ importers:
         specifier: ^29.0.3
         version: 29.0.5(@babel/core@7.22.5)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.22.5))(esbuild@0.14.38)(jest@29.5.0(@types/node@17.0.38)(ts-node@10.8.1(@types/node@17.0.38)(typescript@4.9.5)))(typescript@4.9.5)
       tsc-alias:
-        specifier: ^1.6.9
-        version: 1.6.9
+        specifier: ^1.8.10
+        version: 1.8.10
 
   packages/learn-card-helpers:
     dependencies:
@@ -679,11 +679,8 @@ importers:
         specifier: workspace:*
         version: link:../../../services/learn-card-network/brain-service
       '@trpc/client':
-        specifier: ^10.45.2
-        version: 10.45.2(@trpc/server@10.45.2)
-      '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502(@trpc/server@11.0.0-rc.502)
     devDependencies:
       '@learncard/types':
         specifier: workspace:*
@@ -701,11 +698,8 @@ importers:
         specifier: workspace:*
         version: link:../../../services/learn-card-network/learn-cloud-service
       '@trpc/client':
-        specifier: ^10.45.2
-        version: 10.45.2(@trpc/server@10.45.2)
-      '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502(@trpc/server@11.0.0-rc.502)
     devDependencies:
       '@learncard/types':
         specifier: workspace:*
@@ -1832,14 +1826,20 @@ importers:
         specifier: ^2.16.0
         version: 2.22.2
       '@sentry/serverless':
-        specifier: ^7.61.0
-        version: 7.61.0
+        specifier: ^7.114.0
+        version: 7.114.0
+      '@trpc/client':
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502(@trpc/server@11.0.0-rc.502)
       '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502
       '@types/lodash':
         specifier: ^4.14.191
         version: 4.14.191
+      better-trpc-openapi:
+        specifier: github:deldrid1/trpc-openapi#a99adb49e8e7c9304aa2988b425d36957d99fc53
+        version: https://codeload.github.com/deldrid1/trpc-openapi/tar.gz/a99adb49e8e7c9304aa2988b425d36957d99fc53(@trpc/server@11.0.0-rc.502)(zod@3.20.2)
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -1876,9 +1876,9 @@ importers:
       serverless-offline:
         specifier: ^12.0.4
         version: 12.0.4(serverless@3.26.0)
-      trpc-openapi:
-        specifier: ^1.2.0
-        version: 1.2.0(@trpc/server@10.45.2)(zod@3.20.2)
+      tsc-alias:
+        specifier: ^1.8.10
+        version: 1.8.10
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1986,17 +1986,20 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       '@sentry/serverless':
-        specifier: ^7.61.0
-        version: 7.61.0
+        specifier: ^7.114.0
+        version: 7.114.0
       '@trpc/client':
-        specifier: ^10.45.2
-        version: 10.45.2(@trpc/server@10.45.2)
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502(@trpc/server@11.0.0-rc.502)
       '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: 11.0.0-rc.502
+        version: 11.0.0-rc.502
       '@types/lodash':
         specifier: ^4.14.191
         version: 4.14.191
+      better-trpc-openapi:
+        specifier: github:deldrid1/trpc-openapi#a99adb49e8e7c9304aa2988b425d36957d99fc53
+        version: https://codeload.github.com/deldrid1/trpc-openapi/tar.gz/a99adb49e8e7c9304aa2988b425d36957d99fc53(@trpc/server@11.0.0-rc.502)(zod@3.20.2)
       bson:
         specifier: ^4.7.2
         version: 4.7.2
@@ -2045,9 +2048,9 @@ importers:
       simple-redis-mutex:
         specifier: ^1.3.1
         version: 1.3.1(ioredis@5.2.2)
-      trpc-openapi:
-        specifier: ^1.1.1
-        version: 1.1.1(@trpc/server@10.45.2)(zod@3.20.2)
+      tsc-alias:
+        specifier: ^1.8.10
+        version: 1.8.10
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2361,6 +2364,7 @@ packages:
   '@aws-cdk/aws-apigatewayv2-alpha@2.21.1-alpha.0':
     resolution: {integrity: sha512-FnPL9tLTEHI3B5N4MO6k17/GBYftT4vD5DIgX7qp3w0P4dbKpp2tc97uFNg84dg0bYN+EN8Vn81uX611ETDsNA==}
     engines: {node: '>= 14.15.0'}
+    deprecated: This package has been stabilized and moved to aws-cdk-lib
     peerDependencies:
       aws-cdk-lib: ^2.21.1
       constructs: ^10.0.0
@@ -2985,18 +2989,21 @@ packages:
   '@babel/plugin-proposal-async-generator-functions@7.20.7':
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-class-static-block@7.21.0':
     resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-static-block instead.
     peerDependencies:
       '@babel/core': ^7.12.0
 
@@ -3009,6 +3016,7 @@ packages:
   '@babel/plugin-proposal-dynamic-import@7.18.6':
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3021,59 +3029,69 @@ packages:
   '@babel/plugin-proposal-export-namespace-from@7.18.9':
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-json-strings@7.18.6':
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-json-strings instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-logical-assignment-operators@7.20.7':
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-numeric-separator@7.18.6':
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-object-rest-spread@7.12.1':
     resolution: {integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7':
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-catch-binding@7.18.6':
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-chaining@7.21.0':
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3086,12 +3104,14 @@ packages:
   '@babel/plugin-proposal-private-property-in-object@7.21.11':
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-unicode-property-regex@7.18.6':
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -4877,6 +4897,7 @@ packages:
   '@humanwhocodes/config-array@0.11.10':
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -4884,6 +4905,7 @@ packages:
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -5497,6 +5519,7 @@ packages:
   '@metamask/types@1.1.0':
     resolution: {integrity: sha512-EEV/GjlYkOSfSPnYXfOosxa3TqYtIW3fhg6jdw+cok/OhMgNn4wCfbENFqjytrHMU2f7ZKtBAvtiP5V8H44sSw==}
     engines: {node: '>=12.0.0'}
+    deprecated: '@metamask/types has been folded into @metamask/utils and is no longer being maintained. Please use @metamask/utils going forward.'
 
   '@metamask/utils@2.1.0':
     resolution: {integrity: sha512-4PHdo5B1ifpw6GbsdlDpp8oqA++rddSmt2pWBHtIGGL2tQMvmfHdaDDSns4JP9iC+AbMogVcUpv5Vt8ow1zsRA==}
@@ -5947,6 +5970,10 @@ packages:
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
 
+  '@sentry-internal/tracing@7.114.0':
+    resolution: {integrity: sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==}
+    engines: {node: '>=8'}
+
   '@sentry-internal/tracing@7.61.0':
     resolution: {integrity: sha512-zTr+MXEG4SxNxif42LIgm2RQn+JRXL2NuGhRaKSD2i4lXKFqHVGlVdoWqY5UfqnnJPokiTWIj9ejR8I5HV8Ogw==}
     engines: {node: '>=8'}
@@ -6014,6 +6041,10 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@sentry/core@7.114.0':
+    resolution: {integrity: sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==}
+    engines: {node: '>=8'}
+
   '@sentry/core@7.61.0':
     resolution: {integrity: sha512-zl0ZKRjIoYJQWYTd3K/U6zZfS4GDY9yGd2EH4vuYO4kfYtEp/nJ8A+tfAeDo0c9FGxZ0Q+5t5F4/SfwbgyyQzg==}
     engines: {node: '>=8'}
@@ -6026,16 +6057,32 @@ packages:
     resolution: {integrity: sha512-7408Z9FqQn/679gwxH7hijM167q/xWCMLJQiUGX4p8lVLy4yZZyne3KcYJ5NypbEQxM/2hwwApBdbettRCwbBQ==}
     engines: {node: '>= 14'}
 
+  '@sentry/integrations@7.114.0':
+    resolution: {integrity: sha512-BJIBWXGKeIH0ifd7goxOS29fBA8BkEgVVCahs6xIOXBjX1IRS6PmX0zYx/GP23nQTfhJiubv2XPzoYOlZZmDxg==}
+    engines: {node: '>=8'}
+
+  '@sentry/node@7.114.0':
+    resolution: {integrity: sha512-cqvi+OHV1Hj64mIGHoZtLgwrh1BG6ntcRjDLlVNMqml5rdTRD3TvG21579FtlqHlwZpbpF7K5xkwl8e5KL2hGw==}
+    engines: {node: '>=8'}
+
   '@sentry/node@7.61.0':
     resolution: {integrity: sha512-oTCqD/h92uvbRCrtCdiAqN6Mfe3vF7ywVHZ8Nq3hHmJp6XadUT+fCBwNQ7rjMyqJAOYAnx/vp6iN9n8C5qcYZQ==}
     engines: {node: '>=8'}
 
-  '@sentry/serverless@7.61.0':
-    resolution: {integrity: sha512-8nxvazvhX8bkYcALUR1mdHZs9QZeElek35AYJo1mKtp3e9MN5EpK8KjTMo3hLNqL2zkjPXwVIqZ5mJwRoSoc4Q==}
+  '@sentry/serverless@7.114.0':
+    resolution: {integrity: sha512-WQwbk9rcqZqPMefNCP4XbaImI+/ydBm+CnmUIS1EUDKg3QQqpPUZV22P1nIvXyNU1O5UTasw8kwTPp99iCPV5A==}
     engines: {node: '>=10'}
+
+  '@sentry/types@7.114.0':
+    resolution: {integrity: sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==}
+    engines: {node: '>=8'}
 
   '@sentry/types@7.61.0':
     resolution: {integrity: sha512-/GLlIBNR35NKPE/SfWi9W10dK9hE8qTShzsuPVn5wAJxpT3Lb4+dkwmKCTLUYxdkmvRDEudkfOxgalsfQGTAWA==}
+    engines: {node: '>=8'}
+
+  '@sentry/utils@7.114.0':
+    resolution: {integrity: sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==}
     engines: {node: '>=8'}
 
   '@sentry/utils@7.61.0':
@@ -6448,6 +6495,7 @@ packages:
 
   '@storybook/addon-styling@1.0.8':
     resolution: {integrity: sha512-Ubi75gHNFO60Sjti2n/i3f0utERNOYcpsRkWHdzV+C26kUemLG+2riKHUt8zVbNskyJxA0EZxh84HYItRe4coA==}
+    deprecated: 'This package has been split into @storybook/addon-styling-webpack and @storybook/addon-themes. More info: https://github.com/storybookjs/addon-styling'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -6831,13 +6879,13 @@ packages:
     peerDependencies:
       jest-environment-node: '>=25'
 
-  '@trpc/client@10.45.2':
-    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+  '@trpc/client@11.0.0-rc.502':
+    resolution: {integrity: sha512-ysFQ3wHnjzLcAqeuwx9/B/YV+2XN/kmfAdTUG+O/SUAdP2wAwo6XbhOxlHw0HWS5pDCsTfJkxDr1nMVkuFM07Q==}
     peerDependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.0.0-rc.502+2a8c56027
 
-  '@trpc/server@10.45.2':
-    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+  '@trpc/server@11.0.0-rc.502':
+    resolution: {integrity: sha512-n6B8Q/UqF+hFXyCTXq9AWSn6EkXBbVo/Bs7/QzZxe5KD5CdnBomC7A1y6Qr+i0eiOWwTHJZQ0az+gJetb2fdxw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -7514,6 +7562,7 @@ packages:
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -7793,6 +7842,7 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
@@ -8248,7 +8298,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   batch@0.6.1:
-    resolution: {integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=}
+    resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -8275,6 +8325,13 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  better-trpc-openapi@https://codeload.github.com/deldrid1/trpc-openapi/tar.gz/a99adb49e8e7c9304aa2988b425d36957d99fc53:
+    resolution: {tarball: https://codeload.github.com/deldrid1/trpc-openapi/tar.gz/a99adb49e8e7c9304aa2988b425d36957d99fc53}
+    version: 0.1.0
+    peerDependencies:
+      '@trpc/server': ^11.0.0-rc.502
+      zod: ^3.14.4
 
   big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -8493,7 +8550,7 @@ packages:
     engines: {node: '>=8.0.0'}
 
   buffer-equal@0.0.1:
-    resolution: {integrity: sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=}
+    resolution: {integrity: sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==}
     engines: {node: '>=0.4.0'}
 
   buffer-fill@1.0.0:
@@ -9103,7 +9160,7 @@ packages:
     engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -9187,7 +9244,7 @@ packages:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
   cookie-signature@1.0.6:
-    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.3.1:
     resolution: {integrity: sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==}
@@ -9926,6 +9983,7 @@ packages:
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
@@ -10013,7 +10071,7 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@3.1.9:
     resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
@@ -11069,7 +11127,7 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-url-parser@1.1.3:
-    resolution: {integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=}
+    resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
 
   fast-xml-parser@4.2.4:
     resolution: {integrity: sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==}
@@ -11478,6 +11536,7 @@ packages:
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -11623,6 +11682,7 @@ packages:
 
   glob@7.1.4:
     resolution: {integrity: sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -11630,14 +11690,17 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.0.3:
     resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@9.3.2:
     resolution: {integrity: sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==}
@@ -12201,6 +12264,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.1:
     resolution: {integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==}
@@ -12350,10 +12414,12 @@ packages:
   is-accessor-descriptor@0.1.6:
     resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.7
 
   is-accessor-descriptor@1.0.0:
     resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -12420,10 +12486,12 @@ packages:
   is-data-descriptor@0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.5
 
   is-data-descriptor@1.0.0:
     resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -13469,6 +13537,9 @@ packages:
   libsodium@0.7.11:
     resolution: {integrity: sha512-WPfJ7sS53I2s4iM58QxY3Inb83/6mjlYgcmZs7DJsvDlnmVUwNinBCi5vBT43P6bHRy01O4zsMU2CoVR6xJ40A==}
 
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -13553,6 +13624,9 @@ packages:
   local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -13956,7 +14030,7 @@ packages:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   media-typer@0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
   memfs@3.5.3:
@@ -14861,6 +14935,7 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
@@ -15058,6 +15133,7 @@ packages:
 
   osenv@0.1.5:
     resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -15409,6 +15485,7 @@ packages:
 
   phin@2.9.3:
     resolution: {integrity: sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -16357,6 +16434,7 @@ packages:
 
   read-package-json@2.1.2:
     resolution: {integrity: sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==}
+    deprecated: This package is no longer supported. Please use @npmcli/package-json instead.
 
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -16747,14 +16825,17 @@ packages:
 
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160-min@0.0.6:
@@ -17175,7 +17256,7 @@ packages:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.0.3:
-    resolution: {integrity: sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=}
+    resolution: {integrity: sha512-9jphSf3UbIgpOX/RKvX02iw/rN2TKdusnsPpGfO/rkcsrd+IRqgHZb4VGnmL0Cynps8Nj2hN45wsi30BzrHDIw==}
 
   setprototypeof@1.1.0:
     resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
@@ -17812,7 +17893,7 @@ packages:
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
@@ -18179,25 +18260,14 @@ packages:
     resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
 
   trim@0.0.1:
-    resolution: {integrity: sha1-WFhUf2spB1fulczMZm+1AITEYN0=}
+    resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
 
   trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
 
   trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
-
-  trpc-openapi@1.1.1:
-    resolution: {integrity: sha512-yz9uu2qdvVNjyU5pAVn9CAg9ZWu8YIOg5exgxwE7t1B/Pr94foIsLeQY0NV8SPpdqpJKVCcKrrl2VtTOLlnmJQ==}
-    peerDependencies:
-      '@trpc/server': ^10.0.0
-      zod: ^3.14.4
-
-  trpc-openapi@1.2.0:
-    resolution: {integrity: sha512-pfYoCd/3KYXWXvUPZBKJw455OOwngKN/6SIcj7Yit19OMLJ+8yVZkEvGEeg5wUSwfsiTdRsKuvqkRPXVSwV7ew==}
-    peerDependencies:
-      '@trpc/server': ^10.0.0
-      zod: ^3.14.4
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -18262,8 +18332,8 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tsc-alias@1.6.9:
-    resolution: {integrity: sha512-5lv5uAHn0cgxY1XfpXIdquUSz2xXq3ryQyNtxC6DYH7YT5rt/W+9Gsft2uyLFTh+ozk4qU8iCSP3VemjT69xlQ==}
+  tsc-alias@1.8.10:
+    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
     hasBin: true
 
   tsconfck@3.1.1:
@@ -18815,7 +18885,7 @@ packages:
     engines: {node: '>= 4'}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   uuid@3.4.0:
@@ -19028,6 +19098,7 @@ packages:
   vm2@3.9.19:
     resolution: {integrity: sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==}
     engines: {node: '>=6.0'}
+    deprecated: The library contains critical security issues and should not be used for production! The maintenance of the project has been discontinued. Consider migrating your code to isolated-vm.
     hasBin: true
 
   vscode-css-languageservice@6.2.6:
@@ -19408,7 +19479,7 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xregexp@2.0.0:
-    resolution: {integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=}
+    resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -19507,11 +19578,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod-to-json-schema@3.21.2:
-    resolution: {integrity: sha512-02yfKymfmIf2rM/5LYGlyw0daEel/f3MsSGMNJZWWf44ato+Y+diFugOpDtgvEUn3cYM5oDAGWW2NHeSD4mByw==}
-    peerDependencies:
-      zod: ^3.21.4
 
   zod-to-json-schema@3.23.2:
     resolution: {integrity: sha512-uSt90Gzc/tUfyNqxnjlfBs8W6WSGpNBv0rVsNxP/BVSMHMKGdthPYff4xtCHYloJGM0CFxFsb3NbC0eqPhfImw==}
@@ -27448,6 +27514,12 @@ snapshots:
       join-component: 1.1.0
     optional: true
 
+  '@sentry-internal/tracing@7.114.0':
+    dependencies:
+      '@sentry/core': 7.114.0
+      '@sentry/types': 7.114.0
+      '@sentry/utils': 7.114.0
+
   '@sentry-internal/tracing@7.61.0':
     dependencies:
       '@sentry/core': 7.61.0
@@ -27536,6 +27608,11 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/core@7.114.0':
+    dependencies:
+      '@sentry/types': 7.114.0
+      '@sentry/utils': 7.114.0
+
   '@sentry/core@7.61.0':
     dependencies:
       '@sentry/types': 7.61.0
@@ -27560,6 +27637,21 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/integrations@7.114.0':
+    dependencies:
+      '@sentry/core': 7.114.0
+      '@sentry/types': 7.114.0
+      '@sentry/utils': 7.114.0
+      localforage: 1.10.0
+
+  '@sentry/node@7.114.0':
+    dependencies:
+      '@sentry-internal/tracing': 7.114.0
+      '@sentry/core': 7.114.0
+      '@sentry/integrations': 7.114.0
+      '@sentry/types': 7.114.0
+      '@sentry/utils': 7.114.0
+
   '@sentry/node@7.61.0':
     dependencies:
       '@sentry-internal/tracing': 7.61.0
@@ -27573,19 +27665,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/serverless@7.61.0':
+  '@sentry/serverless@7.114.0':
     dependencies:
-      '@sentry/core': 7.61.0
-      '@sentry/node': 7.61.0
-      '@sentry/types': 7.61.0
-      '@sentry/utils': 7.61.0
+      '@sentry/core': 7.114.0
+      '@sentry/node': 7.114.0
+      '@sentry/types': 7.114.0
+      '@sentry/utils': 7.114.0
       '@types/aws-lambda': 8.10.106
       '@types/express': 4.17.15
-      tslib: 2.5.3
-    transitivePeerDependencies:
-      - supports-color
+
+  '@sentry/types@7.114.0': {}
 
   '@sentry/types@7.61.0': {}
+
+  '@sentry/utils@7.114.0':
+    dependencies:
+      '@sentry/types': 7.114.0
 
   '@sentry/utils@7.61.0':
     dependencies:
@@ -29101,11 +29196,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+  '@trpc/client@11.0.0-rc.502(@trpc/server@11.0.0-rc.502)':
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.0.0-rc.502
 
-  '@trpc/server@10.45.2': {}
+  '@trpc/server@11.0.0-rc.502': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -31410,6 +31505,19 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-trpc-openapi@https://codeload.github.com/deldrid1/trpc-openapi/tar.gz/a99adb49e8e7c9304aa2988b425d36957d99fc53(@trpc/server@11.0.0-rc.502)(zod@3.20.2):
+    dependencies:
+      '@trpc/server': 11.0.0-rc.502
+      co-body: 6.1.0
+      h3: 1.12.0
+      lodash.clonedeep: 4.5.0
+      node-mocks-http: 1.12.2
+      openapi-types: 12.1.3
+      zod: 3.20.2
+      zod-to-json-schema: 3.23.2(zod@3.20.2)
+    transitivePeerDependencies:
+      - uWebSockets.js
+
   big-integer@1.6.51: {}
 
   big.js@5.2.2: {}
@@ -32130,7 +32238,7 @@ snapshots:
   chokidar@3.5.3:
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -38811,6 +38919,10 @@ snapshots:
 
   libsodium@0.7.11: {}
 
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -38939,6 +39051,10 @@ snapshots:
     dependencies:
       mlly: 1.7.1
       pkg-types: 1.2.0
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-path@2.0.0:
     dependencies:
@@ -45608,29 +45724,6 @@ snapshots:
 
   trough@2.1.0: {}
 
-  trpc-openapi@1.1.1(@trpc/server@10.45.2)(zod@3.20.2):
-    dependencies:
-      '@trpc/server': 10.45.2
-      co-body: 6.1.0
-      lodash.clonedeep: 4.5.0
-      node-mocks-http: 1.12.2
-      openapi-types: 12.1.0
-      zod: 3.20.2
-      zod-to-json-schema: 3.21.2(zod@3.20.2)
-
-  trpc-openapi@1.2.0(@trpc/server@10.45.2)(zod@3.20.2):
-    dependencies:
-      '@trpc/server': 10.45.2
-      co-body: 6.1.0
-      h3: 1.12.0
-      lodash.clonedeep: 4.5.0
-      node-mocks-http: 1.12.2
-      openapi-types: 12.1.3
-      zod: 3.20.2
-      zod-to-json-schema: 3.23.2(zod@3.20.2)
-    transitivePeerDependencies:
-      - uWebSockets.js
-
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -45873,10 +45966,10 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsc-alias@1.6.9:
+  tsc-alias@1.8.10:
     dependencies:
       chokidar: 3.5.3
-      commander: 9.3.0
+      commander: 9.5.0
       globby: 11.1.0
       mylas: 2.1.13
       normalize-path: 3.0.0
@@ -47272,10 +47365,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.5.2
-
-  zod-to-json-schema@3.21.2(zod@3.20.2):
-    dependencies:
-      zod: 3.20.2
 
   zod-to-json-schema@3.23.2(zod@3.20.2):
     dependencies:

--- a/services/learn-card-network/brain-service/package.json
+++ b/services/learn-card-network/brain-service/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "test": "vitest",
         "test:watch": "vitest --watch",
-        "build": "shx rm -rf dist && node esbuild.mjs && tsc --p tsconfig.build.json",
+        "build": "shx rm -rf dist && node esbuild.mjs && tsc --p tsconfig.build.json && tsc --showConfig --p tsconfig.build.json > tsconfig.temp.json && tsc-alias --replacer ./tsc-alias-replacer.cjs -p tsconfig.temp.json && shx rm tsconfig.temp.json",
         "start": "PORT=3000 serverless offline --httpPort 3000 --websocketPort 3001 --lambdaPort 3002 --albPort 3003 --host 127.0.0.1 --config serverless-local.yml",
         "start-p-4000": "PORT=4000 serverless offline --httpPort 4000 --websocketPort 4001 --lambdaPort 4002 --albPort 4003 --host 127.0.0.1 --config serverless-local.yml",
         "dev": "pnpm start",
@@ -52,9 +52,11 @@
         "@learncard/vc-plugin": "workspace:*",
         "@learncard/vc-templates-plugin": "workspace:*",
         "@sentry/esbuild-plugin": "^2.16.0",
-        "@sentry/serverless": "^7.61.0",
-        "@trpc/server": "^10.45.2",
+        "@sentry/serverless": "^7.114.0",
+        "@trpc/client": "11.0.0-rc.502",
+        "@trpc/server": "11.0.0-rc.502",
         "@types/lodash": "^4.14.191",
+        "better-trpc-openapi": "github:deldrid1/trpc-openapi#a99adb49e8e7c9304aa2988b425d36957d99fc53",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -67,7 +69,7 @@
         "neo4j-driver": "^5.18.0",
         "neogma": "^1.13.0",
         "serverless-offline": "^12.0.4",
-        "trpc-openapi": "^1.2.0",
+        "tsc-alias": "^1.8.10",
         "uuid": "^9.0.0",
         "zod": "^3.20.2"
     }

--- a/services/learn-card-network/brain-service/src/index.ts
+++ b/services/learn-card-network/brain-service/src/index.ts
@@ -1,4 +1,5 @@
 export type { AppRouter } from './app';
+export type { Context } from './routes';
 
 export { appRouter as mainApp } from './app';
 export { app as didApp } from './dids';

--- a/services/learn-card-network/brain-service/src/openapi.ts
+++ b/services/learn-card-network/brain-service/src/openapi.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3 } from 'openapi-types';
-import { generateOpenApiDocument } from 'trpc-openapi';
+import { generateOpenApiDocument } from 'better-trpc-openapi';
 import express from 'express';
 
 import { appRouter } from './app';

--- a/services/learn-card-network/brain-service/src/routes/index.ts
+++ b/services/learn-card-network/brain-service/src/routes/index.ts
@@ -1,6 +1,10 @@
+import http from 'node:http';
+
 import { initTRPC, TRPCError } from '@trpc/server';
-import { APIGatewayEvent, CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { OpenApiMeta } from 'trpc-openapi';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import { NodeHTTPCreateContextFnOptions } from '@trpc/server/adapters/node-http';
+import { OpenApiMeta } from 'better-trpc-openapi';
 import jwtDecode from 'jwt-decode';
 import * as Sentry from '@sentry/serverless';
 
@@ -29,11 +33,19 @@ export type Context = {
 
 export const t = initTRPC.context<Context>().meta<OpenApiMeta>().create();
 
-export const createContext = async ({
-    event,
-}: CreateAWSLambdaContextOptions<APIGatewayEvent>): Promise<Context> => {
-    const authHeader = event.headers.authorization;
-    const domainName = event.requestContext.domainName;
+export const createContext = async (
+    options:
+        | CreateAWSLambdaContextOptions<APIGatewayProxyEventV2>
+        | NodeHTTPCreateContextFnOptions<http.IncomingMessage, http.ServerResponse>
+): Promise<Context> => {
+    const authHeader =
+        'event' in options
+            ? options.event.headers.authorization
+            : options.req.headers.authorization;
+    const domainName =
+        'event' in options
+            ? options.event.requestContext.domainName
+            : (options.req as any).requestContext.domainName;
 
     const domain =
         !domainName || process.env.IS_OFFLINE
@@ -74,7 +86,7 @@ export const createContext = async ({
 };
 
 export const openRoute = t.procedure
-    .use(t.middleware(Sentry.Handlers.trpcMiddleware({ attachRpcInput: true })))
+    .use(t.middleware(Sentry.Handlers.trpcMiddleware({ attachRpcInput: true }) as any))
     .use(({ ctx, next, path }) => {
         Sentry.configureScope(scope => {
             scope.setTransactionName(`trpc-${path}`);

--- a/services/learn-card-network/brain-service/tsc-alias-replacer.cjs
+++ b/services/learn-card-network/brain-service/tsc-alias-replacer.cjs
@@ -1,0 +1,35 @@
+// UPSTREAM: tsc-alias does not replace paths which start with @.
+// https://github.com/justkey007/tsc-alias/issues/212
+
+const path = require('path');
+
+const tsconfig = require('./tsconfig.json');
+
+const {
+    compilerOptions: { paths = {} },
+} = tsconfig;
+
+module.exports.default = ({ orig, file }) => {
+    if (orig.startsWith(`from '@`)) {
+        const key = orig.split("from '")[1].slice(0, -1);
+        const tsPath = paths[key]?.[0];
+        if (tsPath == null) return orig;
+        const target = path
+            .relative(file, tsPath)
+            .replace('./src', '')
+            .replace('.././', './')
+            .replace('.ts', '');
+        if (path != null) return `from '${target}'`;
+    } else if (orig.startsWith('import("@')) {
+        const key = orig.split('import("')[1].slice(0, -2);
+        const tsPath = paths[key]?.[0];
+        if (tsPath == null) return orig;
+        const target = path
+            .relative(file, tsPath)
+            .replace('./src', '')
+            .replace('.././', './')
+            .replace('.ts', '');
+        if (path != null) return `import("${target}")`;
+    }
+    return orig;
+};

--- a/services/learn-card-network/learn-cloud-service/lambda.ts
+++ b/services/learn-card-network/learn-cloud-service/lambda.ts
@@ -1,8 +1,10 @@
+import http from 'node:http';
+
 import serverlessHttp from 'serverless-http';
 import type { Context, APIGatewayProxyResultV2, APIGatewayProxyEventV2 } from 'aws-lambda';
 import { awsLambdaRequestHandler } from '@trpc/server/adapters/aws-lambda';
-import { createOpenApiAwsLambdaHandler } from 'trpc-openapi';
-import { TRPC_ERROR_CODE_HTTP_STATUS } from 'trpc-openapi/dist/adapters/node-http/errors';
+import { createOpenApiHttpHandler } from 'better-trpc-openapi';
+import { TRPC_ERROR_CODE_HTTP_STATUS } from 'better-trpc-openapi/dist/adapters/node-http/errors';
 import * as Sentry from '@sentry/serverless';
 
 import app from './src/openapi';
@@ -23,19 +25,29 @@ Sentry.AWSLambda.init({
 
 export const swaggerUiHandler = serverlessHttp(app, { basePath: '/docs' });
 
-export const _openApiHandler = createOpenApiAwsLambdaHandler({
-    router: appRouter,
-    createContext,
-    onError: ({ error, ctx, path }) => {
-        error.stack = error.stack?.replace('Mr: ', '');
-        error.name = error.message;
+export const _openApiHandler = serverlessHttp(
+    http.createServer(
+        createOpenApiHttpHandler({
+            router: appRouter,
+            createContext,
+            responseMeta: undefined as any,
+            maxBodySize: undefined as any,
+            onError: ({ error, ctx, path }) => {
+                error.stack = error.stack?.replace('Mr: ', '');
+                error.name = error.message;
 
-        Sentry.captureException(error, { extra: { ctx, path } });
-        Sentry.getActiveTransaction()?.setHttpStatus(TRPC_ERROR_CODE_HTTP_STATUS[error.code]);
-    },
-});
+                Sentry.captureException(error, { extra: { ctx, path } });
+                Sentry.getActiveTransaction()?.setHttpStatus(
+                    TRPC_ERROR_CODE_HTTP_STATUS[error.code]
+                );
+            },
+        })
+    ) as any,
+    { basePath: '/api' }
+);
 
 export const _trpcHandler = awsLambdaRequestHandler({
+    allowMethodOverride: true,
     router: appRouter,
     createContext,
     onError: ({ error, ctx, path }) => {

--- a/services/learn-card-network/learn-cloud-service/package.json
+++ b/services/learn-card-network/learn-cloud-service/package.json
@@ -6,7 +6,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "test": "vitest",
-        "build": "shx rm -rf dist && node esbuild.mjs && tsc --p tsconfig.build.json",
+        "build": "shx rm -rf dist && node esbuild.mjs && tsc --p tsconfig.build.json && tsc --showConfig --p tsconfig.build.json > tsconfig.temp.json && tsc-alias --replacer ./tsc-alias-replacer.cjs -p tsconfig.temp.json && shx rm tsconfig.temp.json",
         "start": "PORT=3000 serverless offline --httpPort 3000 --websocketPort 3001 --lambdaPort 3002 --albPort 3003 --config serverless-local.yml",
         "start-p-4000": "PORT=4000 serverless offline --httpPort 4000 --websocketPort 4001 --lambdaPort 4002 --albPort 4003 --config serverless-local.yml",
         "start-p-5000": "PORT=5000 serverless offline --httpPort 5000 --websocketPort 5001 --lambdaPort 5002 --albPort 5003 --config serverless-local.yml",
@@ -53,10 +53,11 @@
         "@learncard/vc-plugin": "workspace:*",
         "@learncard/vc-templates-plugin": "workspace:*",
         "@sentry/esbuild-plugin": "^2.5.0",
-        "@sentry/serverless": "^7.61.0",
-        "@trpc/client": "^10.45.2",
-        "@trpc/server": "^10.45.2",
+        "@sentry/serverless": "^7.114.0",
+        "@trpc/client": "11.0.0-rc.502",
+        "@trpc/server": "11.0.0-rc.502",
         "@types/lodash": "^4.14.191",
+        "better-trpc-openapi": "github:deldrid1/trpc-openapi#a99adb49e8e7c9304aa2988b425d36957d99fc53",
         "bson": "^4.7.2",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -73,7 +74,7 @@
         "neogma": "^1.11.1",
         "serverless-offline": "^12.0.4",
         "simple-redis-mutex": "^1.3.1",
-        "trpc-openapi": "^1.1.1",
+        "tsc-alias": "^1.8.10",
         "uuid": "^9.0.0",
         "zod": "^3.20.2"
     }

--- a/services/learn-card-network/learn-cloud-service/src/index.ts
+++ b/services/learn-card-network/learn-cloud-service/src/index.ts
@@ -1,6 +1,7 @@
 export type { Filter, UpdateFilter } from 'mongodb';
 
 export type { AppRouter } from './app';
+export type { Context } from '@routes';
 
 export { appRouter as mainApp } from './app';
 export { app as didApp } from './dids';

--- a/services/learn-card-network/learn-cloud-service/src/openapi.ts
+++ b/services/learn-card-network/learn-cloud-service/src/openapi.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3 } from 'openapi-types';
-import { generateOpenApiDocument } from 'trpc-openapi';
+import { generateOpenApiDocument } from 'better-trpc-openapi';
 import express from 'express';
 
 import { appRouter } from './app';

--- a/services/learn-card-network/learn-cloud-service/src/routes/index.ts
+++ b/services/learn-card-network/learn-cloud-service/src/routes/index.ts
@@ -1,6 +1,10 @@
+import http from 'node:http';
+
 import { initTRPC, TRPCError } from '@trpc/server';
-import { APIGatewayEvent, CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { OpenApiMeta } from 'trpc-openapi';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import { NodeHTTPCreateContextFnOptions } from '@trpc/server/adapters/node-http';
+import { OpenApiMeta } from 'better-trpc-openapi';
 import jwtDecode from 'jwt-decode';
 import * as Sentry from '@sentry/serverless';
 
@@ -18,11 +22,19 @@ export type Context = {
 
 export const t = initTRPC.context<Context>().meta<OpenApiMeta>().create();
 
-export const createContext = async ({
-    event,
-}: CreateAWSLambdaContextOptions<APIGatewayEvent>): Promise<Context> => {
-    const authHeader = event.headers.authorization;
-    const domainName = event.requestContext.domainName;
+export const createContext = async (
+    options:
+        | CreateAWSLambdaContextOptions<APIGatewayProxyEventV2>
+        | NodeHTTPCreateContextFnOptions<http.IncomingMessage, http.ServerResponse>
+): Promise<Context> => {
+    const authHeader =
+        'event' in options
+            ? options.event.headers.authorization
+            : options.req.headers.authorization;
+    const domainName =
+        'event' in options
+            ? options.event.requestContext.domainName
+            : (options.req as any).requestContext.domainName;
 
     const domain =
         !domainName || process.env.IS_OFFLINE
@@ -63,7 +75,7 @@ export const createContext = async ({
 };
 
 export const openRoute = t.procedure
-    .use(t.middleware(Sentry.Handlers.trpcMiddleware({ attachRpcInput: true })))
+    .use(t.middleware(Sentry.trpcMiddleware({ attachRpcInput: true }) as any))
     .use(({ ctx, next, path }) => {
         Sentry.configureScope(scope => {
             scope.setTransactionName(`trpc-${path}`);

--- a/services/learn-card-network/learn-cloud-service/tsc-alias-replacer.cjs
+++ b/services/learn-card-network/learn-cloud-service/tsc-alias-replacer.cjs
@@ -1,0 +1,35 @@
+// UPSTREAM: tsc-alias does not replace paths which start with @.
+// https://github.com/justkey007/tsc-alias/issues/212
+
+const path = require('path');
+
+const tsconfig = require('./tsconfig.json');
+
+const {
+    compilerOptions: { paths = {} },
+} = tsconfig;
+
+module.exports.default = ({ orig, file }) => {
+    if (orig.startsWith(`from '@`)) {
+        const key = orig.split("from '")[1].slice(0, -1);
+        const tsPath = paths[key]?.[0];
+        if (tsPath == null) return orig;
+        const target = path
+            .relative(file, tsPath)
+            .replace('./src', '')
+            .replace('.././', './')
+            .replace('.ts', '');
+        if (path != null) return `from '${target}'`;
+    } else if (orig.startsWith('import("@')) {
+        const key = orig.split('import("')[1].slice(0, -2);
+        const tsPath = paths[key]?.[0];
+        if (tsPath == null) return orig;
+        const target = path
+            .relative(file, tsPath)
+            .replace('./src', '')
+            .replace('.././', './')
+            .replace('.ts', '');
+        if (path != null) return `import("${target}")`;
+    }
+    return orig;
+};


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-334] Fix Request URL Length

#### 📚 What is the context and goal of this PR?
We are getting ourselves into trouble because sometimes a _single_ tRPC request can generate a URL
that is longer than 2,048 characters. To combat this, we can upgrade to tRPC v11 and override the
HTTP method used for tRPC to POST requests and move that query out of the URL and into the request
body!

#### 🥴 TL; RL:
Goes through pain to make the above happen!

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
There's a lot to break down here, but basically it just boils down to the fact that migrating to v11
was not _super_ straightforward. I had to bring in a PR for a fork of `trpc-openapi` just to be able
to keep the API server alive, and I had to pull some trickery with the build step for the server code.
This has resulted in _better_ built types though, as the old process was leaving in path aliases that
TS would just not understand!

#### 🛠 Important tradeoffs made:
`trpc-openapi` is unfortunately not very well maintained, and so the community is currently scrambling
to rally around an alternative for tRPC v11. For our specific usecase, I was able to take advantage
of one of those community efforts, but it's definitely not well suited for the future, and I almost
wonder if we should instead just consider forking `trpc-openapi` ourselves and maintaining it, 
considering how crucial it is to our whole process here!

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [ ] No
- [x] Yes

We will need to keep an eye on that `better-trpc-openapi` package and update it as progress happens.
Also, we'll want to watch tRPC for when v11 officially releases, and then move off of the current RC
that we are on

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Oh boy there's a lot to this one. So first, just pnpm i and build everything with `pnpm exec nx build cli --skip-nx-cache`

Then link `@learncard/init` in the LCA repo under `apps/learn-card-app`, `packages/learn-card-base`, `services/lca-api`, and `packages/plugins/lca-api-plugin`

Then, spin up a Neo4j instance with Docker: `docker run --env=NEO4J_AUTH=none -p 7474:7474 -p 7687:7687 neo4j`

Then, spin up a Mongo instance with Docker: `docker run -p 27017:27017 mongo`

Then, add the following to a .env file in `services/learn-card-network/brain-service`

```
SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
NEO4J_URI=neo4j://localhost:7687
NEO4J_USERNAME=neo4j
NEO4J_PASSWORD=asdfasdfasdfasdfasdfasdfasdfasdfasdf
```

Then, add the following to a .env file in `services/learn-card-network/learn-cloud-service`

```
LEARN_CLOUD_SEED=a
LEARN_CLOUD_MONGO_URI=mongodb://localhost:27017
LEARN_CLOUD_MONGO_DB_NAME=nicelol
```

Then, spin up the brain service on port 4000 by cding into `services/learn-card-network/brain-service` and running `pnpm start-p-4000`
Then, spin up the cloud service on port 5000 by cding into `services/learn-card-network/learn-cloud-service` and running `pnpm start-p-5000`

Then, in learn-card-base, go to `walletHelpers.ts` and in `getBespokeLearnCard` hardcode `network` to `http://localhost:4000/trpc` and `cloudUrl` to `http://localhost:5000/trpc`

If all goes right, you should be able to now spin up LCA and go to it locally and check your network tab to see POST requests getting sent to those tRPC servers!

You should also check that the api routes still work by going to http://localhost:4000/api/health-check and http://localhost:5000/api/health-check directly in your browser!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
This isn't really a test kind of PR =( Though the test suite still passes!

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
