### PR TITLE
[LC-250] Fix spacing for big titles in Boost display

### DIFF
--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.stories.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.stories.tsx
@@ -14,6 +14,7 @@ import {
     AllFieldsCredential,
     AllFieldsBackgroundColorCredential,
     BoostCredential,
+    LongTitleCredential,
 } from '../../helpers/test.helpers';
 
 export default {
@@ -58,7 +59,9 @@ BoostCredentialTest.args = {
         TestVerificationItems.SUCCESS.PROOF,
         TestVerificationItems.SUCCESS.NOT_EXPIRED,
     ],
-    customIDDescription: <div className='w-full flex items-center justify-center'>Hello World!</div>,
+    customIDDescription: (
+        <div className="w-full flex items-center justify-center">Hello World!</div>
+    ),
 };
 
 export const JFFCredentialTest = Template.bind({});
@@ -120,6 +123,22 @@ AllFieldsTest.args = {
 export const BackgroundColorTest = Template.bind({});
 BackgroundColorTest.args = {
     credential: AllFieldsBackgroundColorCredential,
+    // convertTagsToSkills: simpleConvertTagsToSkills,
+    handleXClick: () => console.log('X clicked!'),
+    onMediaAttachmentClick: undefined,
+    verificationItems: [
+        TestVerificationItems.SUCCESS.PROOF,
+        TestVerificationItems.SUCCESS.NO_EXPIRATION,
+        TestVerificationItems.FAILED.CONTEXT,
+        TestVerificationItems.FAILED.SIGNATURE,
+        TestVerificationItems.FAILED.PROOF_TYPE,
+        TestVerificationItems.FAILED.APPLICABLE_PROOF,
+    ],
+};
+
+export const LongTitleTest = Template.bind({});
+LongTitleTest.args = {
+    credential: LongTitleCredential,
     // convertTagsToSkills: simpleConvertTagsToSkills,
     handleXClick: () => console.log('X clicked!'),
     onMediaAttachmentClick: undefined,

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.stories.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.stories.tsx
@@ -139,6 +139,7 @@ BackgroundColorTest.args = {
 export const LongTitleTest = Template.bind({});
 LongTitleTest.args = {
     credential: LongTitleCredential,
+    showBackButton: false,
     // convertTagsToSkills: simpleConvertTagsToSkills,
     handleXClick: () => console.log('X clicked!'),
     onMediaAttachmentClick: undefined,

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -262,6 +262,12 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         );
     }
 
+    // these are constants so that the real header and the hidden-for-spacing header are identical
+    const headerClassName =
+        'vc-card-header px-[20px] pb-[10px] pt-[3px] overflow-visible mt-[40px] text-center bg-white border-y-[5px] border-[#EEF2FF] w-[calc(100%_+_16px)] rounded-t-[8px] z-50';
+    const headerFitTextClassName =
+        'vc-card-header-main-title text-[#18224E] leading-[80%] text-shadow text-[32px]';
+
     return (
         <Flipper className="w-full" flipKey={isFront}>
             <Flipped flipId="card">
@@ -273,17 +279,17 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                     <RibbonEnd
                         side="left"
                         className="absolute left-[-30px] top-[50px] z-0"
-                        height={`${headerHeight + 10}`}
+                        height="100"
                     />
                     <RibbonEnd
                         side="right"
                         className="absolute right-[-30px] top-[50px] z-0"
-                        height={`${headerHeight + 10}`}
+                        height="100"
                     />
 
                     <h1
                         ref={headerRef}
-                        className="vc-card-header px-[20px] pb-[10px] pt-[3px] overflow-visible mt-[40px] absolute text-center bg-white border-y-[5px] border-[#EEF2FF] shadow-bottom w-[calc(100%_+_16px)] rounded-t-[8px] z-50"
+                        className={`${headerClassName} absolute`}
                         style={{ wordBreak: 'break-word' }}
                     >
                         {customRibbonCategoryComponent && customRibbonCategoryComponent}
@@ -296,7 +302,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                             maxFontSize={32}
                             minFontSize={20}
                             width={((headerWidth ?? 290) - 40).toString()}
-                            className="vc-card-header-main-title text-[#18224E] leading-[100%] text-shadow text-[32px]"
+                            className={headerFitTextClassName}
                         />
                     </h1>
 
@@ -310,15 +316,34 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                     )}
 
                     <div
-                        className="relative pt-[114px] vc-card-content-container flex flex-col items-center grow min-h-0 w-full rounded-t-[30px] bg-[#353E64] rounded-b-[200px]"
-                        style={{ ...backgroundStyle, paddingTop: `${headerHeight + 49}px` }}
+                        className="relative vc-card-content-container flex flex-col items-center grow min-h-0 w-full rounded-t-[30px] bg-[#353E64] rounded-b-[200px]"
+                        style={backgroundStyle}
                     >
                         {/* 
-                    div in a div here so that we can have an outer scroll container with an inner container
-                    that has a rounded bottom at the bottom of the scrollable content 
-                */}
+                            div in a div here so that we can have an outer scroll container with an inner container
+                            that has a rounded bottom at the bottom of the scrollable content 
+                        */}
                         <Flipped flipId="scroll-container">
                             <div className="vc-card-content-scroll-container w-full pt-[20px] min-h-full flex flex-col justify-start items-center rounded-t-[30px] rounded-b-[200px] scrollbar-hide pb-[50px]">
+                                {/* Hidden header element for proper spacing/sizing purposes */}
+                                <h1
+                                    className={`${headerClassName} invisible`}
+                                    style={{ wordBreak: 'break-word' }}
+                                >
+                                    {customRibbonCategoryComponent && customRibbonCategoryComponent}
+                                    {!customRibbonCategoryComponent && (
+                                        <VCDisplayCardCategoryType categoryType={categoryType} />
+                                    )}
+
+                                    <FitText
+                                        text={_title ?? ''}
+                                        maxFontSize={32}
+                                        minFontSize={20}
+                                        width={((headerWidth ?? 290) - 40).toString()}
+                                        className={headerFitTextClassName}
+                                    />
+                                </h1>
+
                                 {isFront && (
                                     <Flipped flipId="face">
                                         <VC2FrontFaceInfo

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -139,7 +139,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         // Needs a small setTimeout otherwise it'll be wrong sometimes with multiline header.
         //   Probably because of the interaction with FitText
         setTimeout(() => {
-            setHeaderHeight(headerRef.current?.clientHeight ?? 100);
+            setHeaderHeight(headerRef.current?.clientHeight || 100);
             setHeaderWidth(headerRef.current?.clientWidth ?? 0);
         }, 10);
     });
@@ -273,12 +273,12 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                     <RibbonEnd
                         side="left"
                         className="absolute left-[-30px] top-[50px] z-0"
-                        height={'100'}
+                        height={`${headerHeight + 10}`}
                     />
                     <RibbonEnd
                         side="right"
                         className="absolute right-[-30px] top-[50px] z-0"
-                        height={'100'}
+                        height={`${headerHeight + 10}`}
                     />
 
                     <h1
@@ -311,7 +311,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
 
                     <div
                         className="relative pt-[114px] vc-card-content-container flex flex-col items-center grow min-h-0 w-full rounded-t-[30px] bg-[#353E64] rounded-b-[200px]"
-                        style={backgroundStyle}
+                        style={{ ...backgroundStyle, paddingTop: `${headerHeight + 49}px` }}
                     >
                         {/* 
                     div in a div here so that we can have an outer scroll container with an inner container

--- a/packages/react-learn-card/src/helpers/test.helpers.ts
+++ b/packages/react-learn-card/src/helpers/test.helpers.ts
@@ -171,6 +171,95 @@ export const AllFieldsBackgroundColorCredential = {
     display: { backgroundColor: 'lightblue' },
 };
 
+export const LongTitleCredential = {
+    name: 'This is a super long credential name because we want to test the ribbon with a long name',
+    '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+    ],
+    id: 'http://example.com/credentials/3527',
+    type: ['VerifiableCredential', 'OpenBadgeCredential'],
+    issuer: 'did:key:z6MksNj6FwQ7t7ejgJVXCNyaX655uHJ8mPJ8xLtxrqQDV2Bo',
+    issuanceDate: '2022-12-15T01:40:50.794Z',
+    credentialSubject: {
+        id: 'did:key:z6Mkqk4j3VnaRf4XHEoU6eT343VTfdfZG23CK6zaf5g5KKju',
+        type: ['AchievementSubject'],
+        achievement: {
+            id: 'https://example.com/achievements/21st-century-skills/teamwork',
+            tag: testTags,
+            name: 'This is a super long credential name because we want to test the ribbon with a long name',
+            type: ['Achievement'],
+            image: 'https://cdn.filestackcontent.com/04DxNAaQ66aphkQvbT9W',
+            description:
+                "You made a test credential with ALL the possible fields! Woah! That's great! There are so many fields on this credential! Let's make this even longer so that it gets truncated",
+            criteria: {
+                type: 'Criteria',
+                narrative:
+                    'You really know your crednetials! Pretty rad. Being able to find and handle all of these fields is incredible! This narrative is going to be pretty long so that we can see if you can handle long blocks of text too. This should probably be truncated off by now or something.',
+            },
+        },
+    },
+    proof: {
+        type: 'Ed25519Signature2020',
+        created: '2022-12-15T01:40:50.798Z',
+        proofPurpose: 'assertionMethod',
+        verificationMethod:
+            'did:key:z6MksNj6FwQ7t7ejgJVXCNyaX655uHJ8mPJ8xLtxrqQDV2Bo#z6MksNj6FwQ7t7ejgJVXCNyaX655uHJ8mPJ8xLtxrqQDV2Bo',
+        '@context': ['https://w3id.org/security/suites/ed25519-2020/v1'],
+        proofValue:
+            'z5R86gecRsBh1xmPJqdfqoNppxy4hbMZWtjZZNdaqGYtwBcPHNzXwAtHdqhTWQVprQn6B8xfQvqqvQo3ZjaTjt3tW',
+    },
+    display: { backgroundImage: 'https://images.unsplash.com/photo-1518199266791-5375a83190b7' },
+    attachments: [
+        {
+            type: 'document',
+            title: 'Custom PDF title',
+            url: 'https://cdn.filestackcontent.com/4LN0x2LQXSjIH3c5bfBr',
+        },
+        {
+            type: 'link',
+            title: 'Mooji',
+            url: 'https://www.moojisanghavibe.org',
+        },
+        {
+            type: 'document',
+            title: 'This is a text file with a super long name that goes to two lines',
+            url: 'https://cdn.filestackcontent.com/BqqfmVEbQFmRaqwvqTMA',
+        },
+        { type: 'photo', url: 'https://cdn.filestackcontent.com/XuMpArLAQ3qam5OdArih' },
+        { type: 'video', url: 'https://www.youtube.com/watch?v=fV7mWuCdkpY' },
+        { type: 'photo', url: 'https://cdn.filestackcontent.com/PNb6lViSaqGoKyRyXyyp' },
+        { type: 'photo', url: 'https://images.unsplash.com/photo-1607419145932-ed1fc8c034d8' },
+        {
+            type: 'link',
+            title: 'Metta Meditation',
+            url: 'https://unveilingtiamat.com/wp-content/uploads/2022/02/Radiant-Threefold-Path-Lovingkindness-Meditation-1.pdf?vgo_ee=KR53S3mb9fY4az4OUTbOR0zkASpiHornD%2Fz2wZTd1jg%3D&fbclid=IwAR1yXamIvuEs-PEJeXvbZp20NvlyvC2SQ-5QLATCepopuqIypO6Pfeb_6iM',
+        },
+        {
+            type: 'video',
+            title: 'Herbie Highlights 2022',
+            url: 'https://www.youtube.com/watch?v=8Mt4YAileOo',
+        },
+        {
+            type: 'video',
+            title: 'Ram Dass - Be Here Now',
+            url: 'https://vimeo.com/406283337',
+        },
+    ],
+    skills: [
+        {
+            category: 'digital',
+            skill: 'softwareProficiency',
+            subskills: ['productivitySuites', 'specializedSoftware', 'designSoftware'],
+        },
+        {
+            category: 'stem',
+            skill: 'technology',
+            subskills: ['coding', 'softwareDevelopment', 'dataAnalysis'],
+        },
+    ],
+};
+
 export const BoostCredential = {
     '@context': [
         'https://www.w3.org/2018/credentials/v1',


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1lK4SIJN1bXwzicOF3xyreRZG3Yjsi6l4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=c6_ME2k)
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-250](https://welibrary.atlassian.net/browse/LC-250)

#### 📚 What is the context and goal of this PR?
When a boost title was too big, it would clip the About box on the back of the the Boost

![image](https://github.com/user-attachments/assets/a1c1c5f7-c483-40b3-8807-64af70bc44ca)

Fixed that by using an invisible header element for spacing instead of a hardcoded amount of top padding

#### 🥴 TL; RL:
Fixed bad spacing on the back of a Boost when the header is big

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
![image](https://github.com/user-attachments/assets/0833c305-d1ec-4aae-8e8d-c49f38c7d89a)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
- Run `pnpm storybook` in `.../LearnCard/packages/react-learn-card`
- Check out the [Long Title Test](http://localhost:6006/?path=/story/vcdisplaycard2--long-title-test)
- Confirm that the About box isn't clipped on the back
- Or you can link LCA to local react-learn-card, build, `pnpm i` and then check out a boost with a long title (like [this one](https://learncard.app/claim/boost?claim=true&boostUri=lc:network:network.learncard.com/trpc:boost:89bd6bee-9e38-4997-a859-845c5c10b315&challenge=789c901c-6dab-487f-a2c3-25e2ed988be4))

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
