### PR TITLE
fix: [LC-417] Fix lightbox issue with LCA modal

### DIFF
--- a/packages/react-learn-card/src/components/Lightbox/Lightbox.tsx
+++ b/packages/react-learn-card/src/components/Lightbox/Lightbox.tsx
@@ -87,7 +87,7 @@ export const Lightbox: React.FC<LightboxProps> = ({ items, currentUrl, setCurren
         <>
             {createPortal(
                 <div
-                    className="absolute top-0 left-0 w-screen h-screen bg-[rgba(0,0,0,0.9)] text-white flex justify-center items-center z-[999999]"
+                    className="absolute lc-lightbox top-0 left-0 w-screen h-screen bg-[rgba(0,0,0,0.9)] text-white flex justify-center items-center z-[9999999]"
                     onClick={e => {
                         if (e.target !== innerRef.current) {
                             setCurrentUrl(undefined);


### PR DESCRIPTION
# Overview

LCA new modals are higher z than the lightbox component used in react-learn-card and that lightbox element is hard to target.

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [ ] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [ ] My code follows **style guidelines** (eslint / prettier)
- [ ] I have **manually tested** common end-2-end cases
- [ ] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [ ] Code is backwards compatible
- [ ] There is **not** a "Do Not Merge" label on this PR
- [ ] I have thoughtfully considered the security implications of this change.
- [ ] This change does not expose new public facing endpoints that do not have authentication
