### PR TITLE
Boost Queries with $in

### DIFF
--- a/.changeset/serious-books-check.md
+++ b/.changeset/serious-books-check.md
@@ -1,0 +1,7 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+'@learncard/types': patch
+---
+
+Add $in to boost queries

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -53,6 +53,18 @@ export const BoostValidator = z.object({
 });
 export type Boost = z.infer<typeof BoostValidator>;
 
+export const BoostQueryValidator = z
+    .object({
+        uri: z.string().or(z.object({ $in: z.string().array() })),
+        name: z.string().or(z.object({ $in: z.string().array() })),
+        type: z.string().or(z.object({ $in: z.string().array() })),
+        category: z.string().or(z.object({ $in: z.string().array() })),
+        status: LCNBoostStatus.or(z.object({ $in: LCNBoostStatus.array() })),
+        autoConnectRecipients: z.boolean(),
+    })
+    .partial();
+export type BoostQuery = z.infer<typeof BoostQueryValidator>;
+
 export const PaginatedBoostsValidator = PaginationResponseValidator.extend({
     records: BoostValidator.array(),
 });

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -28,6 +28,7 @@ import {
     ConsentFlowDataQuery,
     BoostRecipientInfo,
     BoostPermissions,
+    BoostQuery,
 } from '@learncard/types';
 import { Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
@@ -121,32 +122,32 @@ export type LearnCardNetworkPluginMethods = {
     ) => Promise<string>;
     getBoost: (uri: string) => Promise<Boost & { boost: UnsignedVC }>;
     /** @deprecated Use getPaginatedBoosts */
-    getBoosts: (query?: Partial<Omit<Boost, 'uri'>>) => Promise<{ name?: string; uri: string }[]>;
+    getBoosts: (query?: BoostQuery) => Promise<{ name?: string; uri: string }[]>;
     getPaginatedBoosts: (
-        options?: PaginationOptionsType & { query?: Partial<Omit<Boost, 'uri'>> }
+        options?: PaginationOptionsType & { query?: BoostQuery }
     ) => Promise<PaginatedBoostsType>;
-    countBoosts: (query?: Partial<Omit<Boost, 'uri'>>) => Promise<number>;
+    countBoosts: (query?: BoostQuery) => Promise<number>;
     getBoostChildren: (
         uri: string,
         options?: PaginationOptionsType & {
-            query?: Partial<Omit<Boost, 'uri'>>;
+            query?: BoostQuery;
             numberOfGenerations?: number;
         }
     ) => Promise<PaginatedBoostsType>;
     countBoostChildren: (
         uri: string,
-        options?: { query?: Partial<Omit<Boost, 'uri'>>; numberOfGenerations?: number }
+        options?: { query?: BoostQuery; numberOfGenerations?: number }
     ) => Promise<number>;
     getBoostParents: (
         uri: string,
         options?: PaginationOptionsType & {
-            query?: Partial<Omit<Boost, 'uri'>>;
+            query?: BoostQuery;
             numberOfGenerations?: number;
         }
     ) => Promise<PaginatedBoostsType>;
     countBoostParents: (
         uri: string,
-        options?: { query?: Partial<Omit<Boost, 'uri'>>; numberOfGenerations?: number }
+        options?: { query?: BoostQuery; numberOfGenerations?: number }
     ) => Promise<number>;
     makeBoostParent: (uris: { parentUri: string; childUri: string }) => Promise<boolean>;
     removeBoostParent: (uris: { parentUri: string; childUri: string }) => Promise<boolean>;

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -13,6 +13,7 @@ import {
     PaginationOptionsValidator,
     PaginatedLCNProfilesValidator,
     BoostPermissions,
+    BoostQueryValidator,
 } from '@learncard/types';
 
 import { t, profileRoute } from '@routes';
@@ -276,13 +277,7 @@ export const boostsRouter = t.router({
                     "This endpoint gets the current user's boosts.\nWarning! This route is deprecated and currently has a hard limit of returning only the first 50 boosts. Please use getPaginatedBoosts instead",
             },
         })
-        .input(
-            z
-                .object({
-                    query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
-                })
-                .default({})
-        )
+        .input(z.object({ query: BoostQueryValidator.optional() }).default({}))
         .output(BoostValidator.omit({ id: true, boost: true }).extend({ uri: z.string() }).array())
         .query(async ({ ctx, input }) => {
             const { query } = input;
@@ -307,13 +302,7 @@ export const boostsRouter = t.router({
                 description: "This endpoint counts the current user's managed boosts.",
             },
         })
-        .input(
-            z
-                .object({
-                    query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
-                })
-                .default({})
-        )
+        .input(z.object({ query: BoostQueryValidator.optional() }).default({}))
         .output(z.number())
         .query(async ({ ctx, input }) => {
             const { query } = input;
@@ -338,7 +327,7 @@ export const boostsRouter = t.router({
         .input(
             PaginationOptionsValidator.extend({
                 limit: PaginationOptionsValidator.shape.limit.default(25),
-                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                query: BoostQueryValidator.optional(),
             }).default({})
         )
         .output(PaginatedBoostsValidator)
@@ -477,7 +466,7 @@ export const boostsRouter = t.router({
             PaginationOptionsValidator.extend({
                 limit: PaginationOptionsValidator.shape.limit.default(25),
                 uri: z.string(),
-                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                query: BoostQueryValidator.optional(),
                 numberOfGenerations: z.number().default(1),
             })
         )
@@ -526,7 +515,7 @@ export const boostsRouter = t.router({
         .input(
             z.object({
                 uri: z.string(),
-                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                query: BoostQueryValidator.optional(),
                 numberOfGenerations: z.number().default(1),
             })
         )
@@ -556,7 +545,7 @@ export const boostsRouter = t.router({
             PaginationOptionsValidator.extend({
                 limit: PaginationOptionsValidator.shape.limit.default(25),
                 uri: z.string(),
-                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                query: BoostQueryValidator.optional(),
                 numberOfGenerations: z.number().default(1),
             })
         )
@@ -605,7 +594,7 @@ export const boostsRouter = t.router({
         .input(
             z.object({
                 uri: z.string(),
-                query: BoostValidator.omit({ id: true, boost: true }).partial().optional(),
+                query: BoostQueryValidator.optional(),
                 numberOfGenerations: z.number().default(1),
             })
         )

--- a/services/learn-card-network/brain-service/test-setup.ts
+++ b/services/learn-card-network/brain-service/test-setup.ts
@@ -1,7 +1,7 @@
 import { Neo4jContainer } from '@testcontainers/neo4j';
 
 export default async function setup({ provide }) {
-    const container = await new Neo4jContainer().withReuse().start();
+    const container = await new Neo4jContainer('neo4j:5').withReuse().start();
 
     provide('neo4j-uri', container.getBoltUri());
     provide('neo4j-password', container.getPassword());

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -174,6 +174,24 @@ describe('Boosts', () => {
             expect(boosts).toHaveLength(1);
             expect(boosts[0]?.category).toEqual('A');
         });
+
+        it('should allow querying with $in', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'C' });
+
+            await expect(
+                userA.clients.fullAuth.boost.getBoosts({ query: { category: { $in: ['A', 'B'] } } })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getBoosts({
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(boosts).toHaveLength(2);
+            expect(boosts[0]?.category).not.toEqual('C');
+            expect(boosts[1]?.category).not.toEqual('C');
+        });
     });
 
     describe('getPaginatedBoosts', () => {
@@ -228,6 +246,26 @@ describe('Boosts', () => {
 
             expect(boosts.records).toHaveLength(1);
             expect(boosts.records[0]?.category).toEqual('A');
+        });
+
+        it('should allow querying with $in', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'C' });
+
+            await expect(
+                userA.clients.fullAuth.boost.getPaginatedBoosts({
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getPaginatedBoosts({
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(boosts.records).toHaveLength(2);
+            expect(boosts.records[0]?.category).not.toEqual('C');
+            expect(boosts.records[1]?.category).not.toEqual('C');
         });
 
         it('should paginate correctly', async () => {
@@ -1813,6 +1851,24 @@ describe('Boosts', () => {
 
             expect(count).toEqual(1);
         });
+
+        it('should allow querying with $in', async () => {
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'A' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'B' });
+            await userA.clients.fullAuth.boost.createBoost({ credential: testVc, category: 'C' });
+
+            await expect(
+                userA.clients.fullAuth.boost.countBoosts({
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const count = await userA.clients.fullAuth.boost.countBoosts({
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(count).toEqual(2);
+        });
     });
 
     describe('createChildBoost', () => {
@@ -2125,6 +2181,40 @@ describe('Boosts', () => {
             expect(boosts.records[0]?.category).toEqual('A');
         });
 
+        it('should allow querying with $in', async () => {
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'A' },
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'B' },
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'C' },
+            });
+
+            await expect(
+                userA.clients.fullAuth.boost.getBoostChildren({
+                    uri: parentUri,
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getBoostChildren({
+                uri: parentUri,
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(boosts.records).toHaveLength(2);
+            expect(boosts.records[0]?.category).not.toEqual('C');
+            expect(boosts.records[1]?.category).not.toEqual('C');
+        });
+
         it('should paginate correctly', async () => {
             const parentUri = await userA.clients.fullAuth.boost.createBoost({
                 credential: testVc,
@@ -2318,6 +2408,38 @@ describe('Boosts', () => {
 
             expect(count).toEqual(1);
         });
+
+        it('should allow querying with $in', async () => {
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'A' },
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'B' },
+            });
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testVc, category: 'C' },
+            });
+
+            await expect(
+                userA.clients.fullAuth.boost.countBoostChildren({
+                    uri: parentUri,
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const count = await userA.clients.fullAuth.boost.countBoostChildren({
+                uri: parentUri,
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(count).toEqual(2);
+        });
     });
 
     describe('getBoostParents', () => {
@@ -2474,6 +2596,44 @@ describe('Boosts', () => {
 
             expect(boosts.records).toHaveLength(1);
             expect(boosts.records[0]?.category).toEqual('A');
+        });
+
+        it('should allow querying with $in', async () => {
+            const parent1Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'A',
+            });
+            const parent2Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'B',
+            });
+            const parent3Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'C',
+            });
+            const childUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+            });
+
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent1Uri, childUri });
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent2Uri, childUri });
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent3Uri, childUri });
+
+            await expect(
+                userA.clients.fullAuth.boost.getBoostParents({
+                    uri: childUri,
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const boosts = await userA.clients.fullAuth.boost.getBoostParents({
+                uri: childUri,
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(boosts.records).toHaveLength(2);
+            expect(boosts.records[0]?.category).not.toEqual('C');
+            expect(boosts.records[1]?.category).not.toEqual('C');
         });
 
         it('should paginate correctly', async () => {
@@ -2668,6 +2828,42 @@ describe('Boosts', () => {
             });
 
             expect(count).toEqual(1);
+        });
+
+        it('should allow querying with $in', async () => {
+            const parent1Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'A',
+            });
+            const parent2Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'B',
+            });
+            const parent3Uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+                category: 'C',
+            });
+            const childUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testVc,
+            });
+
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent1Uri, childUri });
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent2Uri, childUri });
+            await userA.clients.fullAuth.boost.makeBoostParent({ parentUri: parent3Uri, childUri });
+
+            await expect(
+                userA.clients.fullAuth.boost.countBoostParents({
+                    uri: childUri,
+                    query: { category: { $in: ['A', 'B'] } },
+                })
+            ).resolves.not.toThrow();
+
+            const count = await userA.clients.fullAuth.boost.countBoostParents({
+                uri: childUri,
+                query: { category: { $in: ['A', 'B'] } },
+            });
+
+            expect(count).toEqual(2);
         });
     });
 
@@ -2987,10 +3183,11 @@ describe('Boosts', () => {
                 uri: grandParentUri,
             });
 
-            const grandParentPermissions = await userA.clients.fullAuth.boost.getOtherBoostPermissions({
-                profileId: 'userb',
-                uri: grandParentUri,
-            });
+            const grandParentPermissions =
+                await userA.clients.fullAuth.boost.getOtherBoostPermissions({
+                    profileId: 'userb',
+                    uri: grandParentUri,
+                });
 
             expect(grandParentPermissions.canEditChildren).toEqual('*');
 
@@ -3001,10 +3198,11 @@ describe('Boosts', () => {
 
             expect(parentPermissions.canEdit).toBeTruthy();
 
-            const grandChildPermissions = await userA.clients.fullAuth.boost.getOtherBoostPermissions({
-                profileId: 'userb',
-                uri: grandChildUri,
-            });
+            const grandChildPermissions =
+                await userA.clients.fullAuth.boost.getOtherBoostPermissions({
+                    profileId: 'userb',
+                    uri: grandChildUri,
+                });
 
             expect(grandChildPermissions.canEdit).toBeTruthy();
         });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
In order to more efficiently implement Scout troops, we need to be able to query for managed boosts
using $in

#### 🥴 TL; RL:
Adds the ability to use $in (like Mongo) when querying for boosts

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:
I believe this slightly lowers performance

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the test suite!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I added tests for all relevant routes =)

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
