### PR TITLE
[LC-634] Default Permissions When Claiming

### DIFF
--- a/.changeset/curly-melons-share.md
+++ b/.changeset/curly-melons-share.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/types': patch
+---
+
+Add default permissions you can receive when claiming a boost

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -40,6 +40,21 @@ export const SentCredentialInfoValidator = z.object({
 });
 export type SentCredentialInfo = z.infer<typeof SentCredentialInfoValidator>;
 
+export const BoostPermissionsValidator = z.object({
+    role: z.string(),
+    canEdit: z.boolean(),
+    canIssue: z.boolean(),
+    canRevoke: z.boolean(),
+    canManagePermissions: z.boolean(),
+    canIssueChildren: z.string(),
+    canCreateChildren: z.string(),
+    canEditChildren: z.string(),
+    canRevokeChildren: z.string(),
+    canManageChildrenPermissions: z.string(),
+    canViewAnalytics: z.boolean(),
+});
+export type BoostPermissions = z.infer<typeof BoostPermissionsValidator>;
+
 export const LCNBoostStatus = z.enum(['DRAFT', 'LIVE']);
 export type LCNBoostStatusEnum = z.infer<typeof LCNBoostStatus>;
 
@@ -50,6 +65,7 @@ export const BoostValidator = z.object({
     category: z.string().optional(),
     status: LCNBoostStatus.optional(),
     autoConnectRecipients: z.boolean().optional(),
+    claimPermissions: BoostPermissionsValidator.optional(),
 });
 export type Boost = z.infer<typeof BoostValidator>;
 
@@ -84,21 +100,6 @@ export const LCNBoostClaimLinkOptionsValidator = z.object({
     totalUses: z.number().optional(),
 });
 export type LCNBoostClaimLinkOptionsType = z.infer<typeof LCNBoostClaimLinkOptionsValidator>;
-
-export const BoostPermissionsValidator = z.object({
-    role: z.string(),
-    canEdit: z.boolean(),
-    canIssue: z.boolean(),
-    canRevoke: z.boolean(),
-    canManagePermissions: z.boolean(),
-    canIssueChildren: z.string(),
-    canCreateChildren: z.string(),
-    canEditChildren: z.string(),
-    canRevokeChildren: z.string(),
-    canManageChildrenPermissions: z.string(),
-    canViewAnalytics: z.boolean(),
-});
-export type BoostPermissions = z.infer<typeof BoostPermissionsValidator>;
 
 export const LCNSigningAuthorityValidator = z.object({
     endpoint: z.string(),

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/create.ts
@@ -1,4 +1,6 @@
-import { CredentialInstance, ProfileInstance } from '@models';
+import { QueryBuilder } from 'neogma';
+
+import { CredentialInstance, Credential, ProfileInstance, Boost, Role, Profile } from '@models';
 
 export const createSentCredentialRelationship = async (
     from: ProfileInstance,
@@ -22,4 +24,34 @@ export const createReceivedCredentialRelationship = async (
         where: { profileId: to.profileId },
         properties: { from: from.profileId, date: new Date().toISOString() },
     });
+};
+
+export const setDefaultClaimedRole = async (
+    profile: ProfileInstance,
+    credential: CredentialInstance
+): Promise<void> => {
+    await new QueryBuilder()
+        .match({
+            related: [
+                { identifier: 'credential', model: Credential, where: { id: credential.id } },
+                {
+                    ...Credential.getRelationshipByAlias('instanceOf'),
+                    identifier: 'instanceOf',
+                    direction: 'out',
+                },
+                { identifier: 'boost', model: Boost },
+                Boost.getRelationshipByAlias('claimRole'),
+                { identifier: 'role', model: Role },
+            ],
+        })
+        .with('boost, role')
+        .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })
+        .create({
+            related: [
+                { identifier: 'profile' },
+                `-[:${Boost.getRelationshipByAlias('hasRole').name} { roleId: role.id }]->`,
+                { identifier: 'boost' },
+            ],
+        })
+        .run();
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
@@ -5,10 +5,10 @@ export const getCredentialSentToProfile = async (
     to: ProfileInstance
 ): Promise<
     | {
-          source: ProfileInstance;
-          relationship: ProfileRelationships['credentialSent']['RelationshipProperties'];
-          target: CredentialInstance;
-      }
+        source: ProfileInstance;
+        relationship: ProfileRelationships['credentialSent']['RelationshipProperties'];
+        target: CredentialInstance;
+    }
     | undefined
 > => {
     return (
@@ -25,11 +25,6 @@ export const getCredentialOwner = async (
     const id = credential.id;
 
     return (
-        await Profile.findRelationships({
-            alias: 'credentialSent',
-            where: {
-                target: { id },
-            },
-        })
+        await Profile.findRelationships({ alias: 'credentialSent', where: { target: { id } } })
     )[0]?.source;
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/role/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/role/relationships/create.ts
@@ -1,0 +1,12 @@
+import { BoostPermissions } from '@learncard/types';
+import { BoostInstance } from '@models';
+import { createRole } from '../create';
+
+export const addClaimPermissionsForBoost = async (
+    boost: BoostInstance,
+    permissions: BoostPermissions
+): Promise<void> => {
+    const role = await createRole(permissions);
+
+    await boost.relateTo({ alias: 'claimRole', where: { id: role.id } });
+};

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -239,10 +239,12 @@ export const sendBoost = async (
             await Promise.all([
                 createBoostInstanceOfRelationship(credentialInstance, boost),
                 createSentCredentialRelationship(from, to, credentialInstance),
-                ...(autoAcceptCredential ? [setDefaultClaimedRole(to, credentialInstance)] : []),
+                ...(autoAcceptCredential
+                    ? [createReceivedCredentialRelationship(to, from, credentialInstance)]
+                    : []),
             ]);
 
-            await setDefaultClaimedRole(to, credentialInstance);
+            if (autoAcceptCredential) await setDefaultClaimedRole(to, credentialInstance);
 
             boostUri = getCredentialUri(credentialInstance.id, domain);
             if (process.env.NODE_ENV !== 'test') {
@@ -263,7 +265,7 @@ export const sendBoost = async (
                 : []),
         ]);
 
-        await setDefaultClaimedRole(to, credentialInstance);
+        if (autoAcceptCredential) await setDefaultClaimedRole(to, credentialInstance);
 
         boostUri = getCredentialUri(credentialInstance.id, domain);
         if (process.env.NODE_ENV !== 'test') {

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -12,6 +12,7 @@ import { createBoostInstanceOfRelationship } from '@accesslayer/boost/relationsh
 import {
     createSentCredentialRelationship,
     createReceivedCredentialRelationship,
+    setDefaultClaimedRole,
 } from '@accesslayer/credential/relationships/create';
 import { getCredentialUri } from './credential.helpers';
 import { getLearnCard } from './learnCard.helpers';
@@ -238,10 +239,10 @@ export const sendBoost = async (
             await Promise.all([
                 createBoostInstanceOfRelationship(credentialInstance, boost),
                 createSentCredentialRelationship(from, to, credentialInstance),
-                ...(autoAcceptCredential
-                    ? [createReceivedCredentialRelationship(to, from, credentialInstance)]
-                    : []),
+                ...(autoAcceptCredential ? [setDefaultClaimedRole(to, credentialInstance)] : []),
             ]);
+
+            await setDefaultClaimedRole(to, credentialInstance);
 
             boostUri = getCredentialUri(credentialInstance.id, domain);
             if (process.env.NODE_ENV !== 'test') {
@@ -261,6 +262,8 @@ export const sendBoost = async (
                 ? [createReceivedCredentialRelationship(to, from, credentialInstance)]
                 : []),
         ]);
+
+        await setDefaultClaimedRole(to, credentialInstance);
 
         boostUri = getCredentialUri(credentialInstance.id, domain);
         if (process.env.NODE_ENV !== 'test') {

--- a/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
@@ -7,6 +7,7 @@ import { storeCredential } from '@accesslayer/credential/create';
 import {
     createReceivedCredentialRelationship,
     createSentCredentialRelationship,
+    setDefaultClaimedRole,
 } from '@accesslayer/credential/relationships/create';
 import { getCredentialSentToProfile } from '@accesslayer/credential/relationships/read';
 import { constructUri, getUriParts } from './uri.helpers';
@@ -63,6 +64,8 @@ export const acceptCredential = async (profile: ProfileInstance, uri: string): P
     }
 
     await createReceivedCredentialRelationship(profile, pendingVc.source, pendingVc.target);
+
+    await setDefaultClaimedRole(profile, pendingVc.target);
 
     await addNotificationToQueue({
         type: LCNNotificationTypeEnumValidator.enum.BOOST_ACCEPTED,

--- a/services/learn-card-network/brain-service/src/models/Boost.ts
+++ b/services/learn-card-network/brain-service/src/models/Boost.ts
@@ -5,6 +5,7 @@ import { neogma } from '@instance';
 
 import { Profile, ProfileInstance } from './Profile';
 import { BoostType, BoostStatus } from 'types/boost';
+import { Role, RoleInstance } from './Role';
 
 export type BoostRelationships = {
     createdBy: ModelRelatedNodesI<
@@ -20,6 +21,7 @@ export type BoostRelationships = {
         Partial<BoostPermissions> & { roleId: string },
         Partial<BoostPermissions> & { roleId: string }
     >;
+    claimRole: ModelRelatedNodesI<typeof Role, RoleInstance>;
 };
 
 export type BoostInstance = NeogmaInstance<BoostType, BoostRelationships>;
@@ -93,6 +95,7 @@ export const Boost = ModelFactory<BoostType, BoostRelationships>(
                     },
                 },
             },
+            claimRole: { model: Role, direction: 'out', name: 'CLAIM_ROLE' },
         },
     },
     neogma

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { v4 as uuid } from 'uuid';
 
 import {
+    BoostValidator as ConsumerBoostValidator,
     UnsignedVCValidator,
     VCValidator,
     JWEValidator,
@@ -79,6 +80,7 @@ import {
 import { getIdFromUri } from '@helpers/uri.helpers';
 import { updateBoostPermissions } from '@accesslayer/boost/relationships/update';
 import { EMPTY_PERMISSIONS, QUERYABLE_PERMISSIONS } from 'src/constants/permissions';
+import { addClaimPermissionsForBoost } from '@accesslayer/role/relationships/create';
 
 export const boostsRouter = t.router({
     sendBoost: profileRoute
@@ -158,16 +160,26 @@ export const boostsRouter = t.router({
             },
         })
         .input(
-            BoostValidator.partial()
-                .omit({ id: true, boost: true })
-                .extend({ credential: VCValidator.or(UnsignedVCValidator) })
+            ConsumerBoostValidator.partial()
+                .omit({ uri: true, claimPermissions: true })
+                .extend({
+                    credential: VCValidator.or(UnsignedVCValidator),
+                    claimPermissions: BoostPermissionsValidator.partial().optional(),
+                })
         )
         .output(z.string())
         .mutation(async ({ input, ctx }) => {
             const { profile } = ctx.user;
-            const { credential, ...metadata } = input;
+            const { credential, claimPermissions, ...metadata } = input;
 
             const boost = await createBoost(credential, profile, metadata, ctx.domain);
+
+            if (claimPermissions) {
+                await addClaimPermissionsForBoost(boost, {
+                    ...EMPTY_PERMISSIONS,
+                    ...claimPermissions,
+                });
+            }
 
             return getBoostUri(boost.id, ctx.domain);
         }),
@@ -186,9 +198,12 @@ export const boostsRouter = t.router({
         .input(
             z.object({
                 parentUri: z.string(),
-                boost: BoostValidator.partial()
-                    .omit({ id: true, boost: true })
-                    .extend({ credential: VCValidator.or(UnsignedVCValidator) }),
+                boost: ConsumerBoostValidator.partial()
+                    .omit({ uri: true, claimPermissions: true })
+                    .extend({
+                        credential: VCValidator.or(UnsignedVCValidator),
+                        claimPermissions: BoostPermissionsValidator.partial().optional(),
+                    }),
             })
         )
         .output(z.string())
@@ -196,7 +211,7 @@ export const boostsRouter = t.router({
             const { profile } = ctx.user;
             const {
                 parentUri,
-                boost: { credential, ...metadata },
+                boost: { credential, claimPermissions, ...metadata },
             } = input;
 
             const parentBoost = await getBoostByUri(parentUri);
@@ -220,6 +235,13 @@ export const boostsRouter = t.router({
             const childBoost = await createBoost(credential, profile, metadata, ctx.domain);
 
             await setBoostAsParent(parentBoost, childBoost);
+
+            if (claimPermissions) {
+                await addClaimPermissionsForBoost(childBoost, {
+                    ...EMPTY_PERMISSIONS,
+                    ...claimPermissions,
+                });
+            }
 
             return getBoostUri(childBoost.id, ctx.domain);
         }),

--- a/services/learn-card-network/brain-service/src/types/boost.ts
+++ b/services/learn-card-network/brain-service/src/types/boost.ts
@@ -12,7 +12,7 @@ import {
 export const BoostStatus = LCNBoostStatus;
 export type BoostStatusEnum = LCNBoostStatusEnum;
 
-export const BoostValidator = _BoostValidator.omit({ uri: true }).extend({
+export const BoostValidator = _BoostValidator.omit({ uri: true, claimPermissions: true }).extend({
     id: z.string(),
     boost: z.string(),
 });

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -280,7 +280,7 @@ describe('Boosts', () => {
             const uri = await userA.clients.fullAuth.boost.createBoost({
                 credential: testUnsignedBoost,
             });
-            const userBProfile = await userB.clients.fullAuth.profile.getProfile();
+            const userBProfile = (await userB.clients.fullAuth.profile.getProfile())!;
 
             const credential = await userA.learnCard.invoke.issueCredential({
                 ...testUnsignedBoost,
@@ -323,7 +323,7 @@ describe('Boosts', () => {
             const uri = await userA.clients.fullAuth.boost.createBoost({
                 credential: testUnsignedBoost,
             });
-            const userBProfile = await userB.clients.fullAuth.profile.getProfile();
+            const userBProfile = (await userB.clients.fullAuth.profile.getProfile())!;
 
             const credential = await userA.learnCard.invoke.issueCredential({
                 ...testUnsignedBoost,
@@ -351,7 +351,7 @@ describe('Boosts', () => {
 
             await userA.clients.fullAuth.boost.addBoostAdmin({ uri, profileId: 'userb' });
 
-            const userCProfile = await userC.clients.fullAuth.profile.getProfile();
+            const userCProfile = (await userC.clients.fullAuth.profile.getProfile())!;
 
             const credential = await userB.learnCard.invoke.issueCredential({
                 ...testUnsignedBoost,
@@ -377,7 +377,7 @@ describe('Boosts', () => {
                 credential: testUnsignedBoost,
             });
 
-            const userCProfile = await userC.clients.fullAuth.profile.getProfile();
+            const userCProfile = (await userC.clients.fullAuth.profile.getProfile())!;
 
             const credential = await userB.learnCard.invoke.issueCredential({
                 ...testUnsignedBoost,
@@ -402,8 +402,8 @@ describe('Boosts', () => {
             const uri = await userA.clients.fullAuth.boost.createBoost({
                 credential: testUnsignedBoost,
             });
-            const userAProfile = await userA.clients.fullAuth.profile.getProfile();
-            const userBProfile = await userB.clients.fullAuth.profile.getProfile();
+            const userAProfile = (await userA.clients.fullAuth.profile.getProfile())!;
+            const userBProfile = (await userB.clients.fullAuth.profile.getProfile())!;
 
             const credential = await userA.learnCard.invoke.issueCredential({
                 ...testUnsignedBoost,
@@ -2987,10 +2987,11 @@ describe('Boosts', () => {
                 uri: grandParentUri,
             });
 
-            const grandParentPermissions = await userA.clients.fullAuth.boost.getOtherBoostPermissions({
-                profileId: 'userb',
-                uri: grandParentUri,
-            });
+            const grandParentPermissions =
+                await userA.clients.fullAuth.boost.getOtherBoostPermissions({
+                    profileId: 'userb',
+                    uri: grandParentUri,
+                });
 
             expect(grandParentPermissions.canEditChildren).toEqual('*');
 
@@ -3001,10 +3002,11 @@ describe('Boosts', () => {
 
             expect(parentPermissions.canEdit).toBeTruthy();
 
-            const grandChildPermissions = await userA.clients.fullAuth.boost.getOtherBoostPermissions({
-                profileId: 'userb',
-                uri: grandChildUri,
-            });
+            const grandChildPermissions =
+                await userA.clients.fullAuth.boost.getOtherBoostPermissions({
+                    profileId: 'userb',
+                    uri: grandChildUri,
+                });
 
             expect(grandChildPermissions.canEdit).toBeTruthy();
         });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

[LC-634] Back-End: Default Role when Claiming

#### 📚 What is the context and goal of this PR?

To ease with the troops setup, we want to be able to set a default role/permissions that you get automatically
when claiming a boost

#### 🥴 TL; RL:

Adds the ability to give a profile default permissions at the time that they claim a boost

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Boosts now have a `claimPermissions` field on them.
- `claimPermissions` is just a regular permissions object that specifies the permissions a user gets when claiming the boost
- When setting `claimPermissions`, a new `Role` node is made and attached with those permissions!

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

Just run the test suite =)

If you'd like to try it out yourself, spin up the LCN with docker (`cd services/learn-card-network && docker compose up`)

Then:

```ts
let a = await initLearnCard({
  seed: "a",
  network: "http://localhost:4000/trpc",
  cloud: { url: "http://localhost:5000/trpc" },
});
let b = await initLearnCard({
  seed: "b",
  network: "http://localhost:4000/trpc",
  cloud: { url: "http://localhost:5000/trpc" },
});

await a.invoke.createProfile({ profileId: "usera" });
await b.invoke.createProfile({ profileId: "userb" });

const testUnsignedBoost = {
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://purl.imsglobal.org/spec/ob/v3p0/context.json",
    {
      type: "@type",
      xsd: "https://www.w3.org/2001/XMLSchema#",
      lcn: "https://docs.learncard.com/definitions#",
      BoostCredential: {
        "@id": "lcn:boostCredential",
        "@context": {
          boostId: { "@id": "lcn:boostId", "@type": "xsd:string" },
          display: {
            "@id": "lcn:boostDisplay",
            "@context": {
              backgroundImage: {
                "@id": "lcn:boostBackgroundImage",
                "@type": "xsd:string",
              },
              backgroundColor: {
                "@id": "lcn:boostBackgroundColor",
                "@type": "xsd:string",
              },
            },
          },
          image: { "@id": "lcn:boostImage", "@type": "xsd:string" },
          attachments: {
            "@id": "lcn:boostAttachments",
            "@container": "@set",
            "@context": {
              type: { "@id": "lcn:boostAttachmentType", "@type": "xsd:string" },
              title: {
                "@id": "lcn:boostAttachmentTitle",
                "@type": "xsd:string",
              },
              url: { "@id": "lcn:boostAttachmentUrl", "@type": "xsd:string" },
            },
          },
        },
      },
    },
  ],
  type: ["VerifiableCredential", "OpenBadgeCredential", "BoostCredential"],
  issuer: "did:web:localhost%3A3000:users:test",
  issuanceDate: "2020-08-19T21:41:50Z",
  name: "Example Boost",
  credentialSubject: {
    id: "did:example:d23dd687a7dc6787646f2eb98d0",
    type: ["AchievementSubject"],
    achievement: {
      id: "urn:uuid:123",
      type: ["Achievement"],
      achievementType: "Influencer",
      name: "Awesome Badge",
      description: "Awesome People Earn Awesome Badge",
      image: "",
      criteria: { narrative: "Earned by being awesome." },
    },
  },
};

const claimPermissions = {
  role: "admin",
  canEdit: true,
  canIssue: true,
  canRevoke: true,
  canManagePermissions: true,
  canIssueChildren: "*",
  canCreateChildren: "*",
  canEditChildren: "*",
  canRevokeChildren: "*",
  canManageChildrenPermissions: "*",
  canViewAnalytics: true,
};

const uri = await test.invoke.createBoost(testUnsignedBoost, {
  claimPermissions,
});

// These permissions should be empty
await a.invoke.getBoostPermissions(uri, 'userb');
await b.invoke.getBoostPermissions(uri);

const sentUri = await a.invoke.sendBoost('userb', uri);

// These permissions should still be empty
await a.invoke.getBoostPermissions(uri, 'userb');
await b.invoke.getBoostPermissions(uri);

await b.invoke.acceptCredential(sentUri);

// These permissions should match the claimPermissions object
await a.invoke.getBoostPermissions(uri, 'userb');
await b.invoke.getBoostPermissions(uri);
```

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote tests for claiming via `acceptCredential` as well as via a claim link

# Documentation

#### 📜 Gitbook

<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook

<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->

# ✅ PR Checklist

- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:

- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
