### PR TITLE
Improve Initialization Speed

### DIFF
--- a/.changeset/clever-ducks-vanish.md
+++ b/.changeset/clever-ducks-vanish.md
@@ -1,0 +1,8 @@
+---
+'@learncard/network-brain-client': minor
+'@learncard/learn-cloud-client': minor
+'@learncard/network-plugin': minor
+'@learncard/learn-cloud-plugin': minor
+---
+
+Don't await network calls during init

--- a/packages/learn-card-network/brain-client/src/index.ts
+++ b/packages/learn-card-network/brain-client/src/index.ts
@@ -32,7 +32,7 @@ export const getClient = async (
         return challengeRequester.utilities.getChallenges.query({ amount });
     };
 
-    challenges = await getChallenges();
+    getChallenges().then(result => (challenges = result));
 
     const trpc = createTRPCProxyClient<AppRouter>({
         transformer: {

--- a/packages/learn-card-network/cloud-client/src/index.ts
+++ b/packages/learn-card-network/cloud-client/src/index.ts
@@ -54,7 +54,7 @@ export const getClient = async (
         return challengeRequester.utilities.getChallenges.query({ amount });
     };
 
-    challenges = await getChallenges();
+    getChallenges().then(result => (challenges = result));
 
     const trpc = createTRPCProxyClient<AppRouter>({
         links: [

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -28,7 +28,7 @@ export const getLearnCardNetworkPlugin = async (
     learnCard: LearnCard<any, 'id', LearnCardNetworkPluginDependentMethods>,
     url: string
 ): Promise<LearnCardNetworkPlugin> => {
-    const existingDid = learnCard.id.did();
+    let did = learnCard.id.did();
 
     learnCard?.debug?.('Adding LearnCardNetwork Plugin');
     const client = await getClient(url, async challenge => {
@@ -41,13 +41,11 @@ export const getLearnCardNetworkPlugin = async (
 
     let userData: LCNProfile | undefined;
 
-    try {
-        userData = await client.profile.getProfile.query();
-    } catch (error) {
-        learnCard.debug?.('No profile!', error);
-    }
+    const initialQuery = client.profile.getProfile.query().then(result => {
+        userData = result;
 
-    let did = userData?.did || existingDid;
+        if (userData?.did) did = userData.did;
+    });
 
     return {
         name: 'LearnCard Network',
@@ -171,6 +169,8 @@ export const getLearnCardNetworkPlugin = async (
                 return false;
             },
             getProfile: async (_learnCard, profileId) => {
+                await initialQuery;
+
                 if (!profileId) return client.profile.getProfile.query();
 
                 return client.profile.getOtherProfile.query({ profileId });
@@ -493,7 +493,7 @@ export const getLearnCardNetworkPlugin = async (
                     limit,
                     cursor,
                     includeUnacceptedBoosts,
-                    query
+                    query,
                 });
             },
             countBoostRecipients: async (_learnCard, uri, includeUnacceptedBoosts = true) => {

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -37,6 +37,7 @@ import { VerifyExtension } from '@learncard/vc-plugin';
 
 /** @group LearnCardNetwork Plugin */
 export type LearnCardNetworkPluginDependentMethods = {
+    __init__?: () => Promise<void>;
     getDIDObject: () => DID;
     getDidAuthVp: (options?: ProofOptions) => Promise<VP | string>;
     issueCredential: (

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -37,7 +37,6 @@ import { VerifyExtension } from '@learncard/vc-plugin';
 
 /** @group LearnCardNetwork Plugin */
 export type LearnCardNetworkPluginDependentMethods = {
-    __init__?: () => Promise<void>;
     getDIDObject: () => DID;
     getDidAuthVp: (options?: ProofOptions) => Promise<VP | string>;
     issueCredential: (

--- a/packages/plugins/learn-cloud/src/plugin.ts
+++ b/packages/plugins/learn-cloud/src/plugin.ts
@@ -49,11 +49,14 @@ export const getLearnCloudPlugin = async (
     learnCard.debug?.('Adding LearnCloud Plugin');
 
     let client = await getLearnCloudClient(url, learnCard);
-    let dids = await client.user.getDids.query();
+
+    let dids: string[] = [learnCard.id.did()];
+
+    client.user.getDids.query().then(result => (dids = result));
 
     let otherClients: Record<string, LearnCloudClient> = {};
 
-    const learnCloudDid = await client.utilities.getDid.query();
+    const learnCloudDid = client.utilities.getDid.query();
 
     const getOtherClient = async (url: string) => {
         if (!otherClients[url]) otherClients[url] = await getLearnCloudClient(url, learnCard);
@@ -101,7 +104,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 return client.customStorage.create.mutate({
-                    item: await generateJWE(_learnCard, learnCloudDid, item),
+                    item: await generateJWE(_learnCard, await learnCloudDid, item),
                 });
             },
             learnCloudCreateMany: async (_learnCard, documents) => {
@@ -114,7 +117,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 return client.customStorage.createMany.mutate({
-                    items: await generateJWE(_learnCard, learnCloudDid, items),
+                    items: await generateJWE(_learnCard, await learnCloudDid, items),
                 });
             },
             learnCloudRead: async (_learnCard, query, includeAssociatedDids) => {
@@ -186,7 +189,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 const jwe: JWE = (await client.customStorage.read.query({
-                    query: await generateJWE(_learnCard, learnCloudDid, {
+                    query: await generateJWE(_learnCard, await learnCloudDid, {
                         ...unencryptedEntries,
                         ...(fields.length > 0 ? { fields: { $in: fields } } : {}),
                     }),
@@ -228,7 +231,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 return client.customStorage.count.query({
-                    query: await generateJWE(_learnCard, learnCloudDid, {
+                    query: await generateJWE(_learnCard, await learnCloudDid, {
                         ...unencryptedEntries,
                         ...(fields.length > 0 ? { fields: { $in: fields } } : {}),
                     }),
@@ -243,12 +246,12 @@ export const getLearnCloudPlugin = async (
                 const updates = await Promise.all(
                     documents.map(async document =>
                         client.customStorage.update.mutate({
-                            query: await generateJWE(_learnCard, learnCloudDid, {
+                            query: await generateJWE(_learnCard, await learnCloudDid, {
                                 _id: document._id,
                             }),
                             update: await generateJWE(
                                 _learnCard,
-                                learnCloudDid,
+                                await learnCloudDid,
                                 await generateEncryptedRecord(
                                     _learnCard,
                                     { ...document, ...update },
@@ -278,7 +281,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 return client.customStorage.delete.mutate({
-                    query: await generateJWE(_learnCard, learnCloudDid, {
+                    query: await generateJWE(_learnCard, await learnCloudDid, {
                         ...unencryptedEntries,
                         ...(fields.length > 0 ? { fields: { $in: fields } } : {}),
                     }),
@@ -485,7 +488,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 const jwe: JWE = (await client.index.get.query({
-                    query: await generateJWE(_learnCard, learnCloudDid, {
+                    query: await generateJWE(_learnCard, await learnCloudDid, {
                         ...unencryptedEntries,
                         ...(fields.length > 0 ? { fields: { $in: fields } } : {}),
                     }),
@@ -550,7 +553,7 @@ export const getLearnCloudPlugin = async (
                 );
 
                 const jwe = await client.index.count.query({
-                    query: await generateJWE(_learnCard, learnCloudDid, {
+                    query: await generateJWE(_learnCard, await learnCloudDid, {
                         ...unencryptedEntries,
                         ...(fields.length > 0 ? { fields: { $in: fields } } : {}),
                     }),
@@ -572,7 +575,7 @@ export const getLearnCloudPlugin = async (
                 const id = record.id || _learnCard.invoke.crypto().randomUUID();
 
                 return client.index.add.mutate({
-                    record: await generateJWE(_learnCard, learnCloudDid, {
+                    record: await generateJWE(_learnCard, await learnCloudDid, {
                         ...(await generateEncryptedRecord(
                             _learnCard,
                             { ...record, id },
@@ -603,7 +606,7 @@ export const getLearnCloudPlugin = async (
                         );
 
                         return client.index.addMany.mutate({
-                            records: await generateJWE(_learnCard, learnCloudDid, records),
+                            records: await generateJWE(_learnCard, await learnCloudDid, records),
                         });
                     })
                 );
@@ -625,7 +628,7 @@ export const getLearnCloudPlugin = async (
                     id: await hash(_learnCard, id),
                     updates: await generateJWE(
                         _learnCard,
-                        learnCloudDid,
+                        await learnCloudDid,
                         await generateEncryptedRecord(_learnCard, newRecord, unencryptedFields)
                     ),
                 });

--- a/tests/e2e/tests/init.spec.ts
+++ b/tests/e2e/tests/init.spec.ts
@@ -1,0 +1,51 @@
+import { initLearnCard } from '@learncard/init';
+import { describe, test, expect } from 'vitest';
+
+describe('Init', () => {
+    // TODO: This test is kind of just a demo for a hacky way of making sure your did is correct.
+    // In the future, we should make this more robust, likely by adding in signals that can be awaited!
+    test('LCN plugin should not have your did right away, but you should be able to know that it does by awaiting getProfile', async () => {
+        const learnCard = await initLearnCard({
+            seed: 'a',
+            network: 'http://localhost:4000/trpc',
+            cloud: { url: 'http://localhost:4100/trpc' },
+        });
+
+        const didKey = learnCard.id.did('key');
+
+        expect(didKey.includes('web')).toBeFalsy();
+
+        try {
+            await learnCard.invoke.createProfile({
+                profileId: 'test',
+                displayName: 'Test',
+                bio: '',
+                shortBio: '',
+            });
+        } catch (error) {
+            // Profile might already exist, nothing to see here
+        }
+
+        const didWeb = learnCard.id.did();
+
+        expect(didWeb.includes('web')).toBeTruthy();
+        expect(didWeb).not.toEqual(didKey);
+
+        const learnCard2 = await initLearnCard({
+            seed: 'a',
+            network: 'http://localhost:4000/trpc',
+            cloud: { url: 'http://localhost:4100/trpc' },
+        });
+
+        expect(learnCard2.id.did()).toEqual(didKey);
+
+        const learnCard3 = await initLearnCard({
+            seed: 'a',
+            network: 'http://localhost:4000/trpc',
+            cloud: { url: 'http://localhost:4100/trpc' },
+        });
+        await learnCard3.invoke.getProfile();
+
+        expect(learnCard3.id.did()).toEqual(didWeb);
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
While I was working on the family stuff, I realized that we are unnecessarily `await`ing multiple
different tRPC requests to LearnCloud and LCN when calling `initLearnCard`

#### 🥴 TL; RL:
Removes the `await` from the relevant calls

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:
For almost everything I was able to move the `await` to be in front of any method that actually needed
these things, with the only exception being the call to `learnCard.id.did()` after you've gotten your LCN account
If it's totally necessary, you can forcibly make sure that is properly waited for by calling `await learnCard.invoke.getProfile`
prior to calling it, but I think that in every current case, there is a reasonable delay between when
you would initialize the wallet vs getting the did.

This situation _does_ bother me though, and there's a couple of more robust fixes:
- Making `id.did()` Return a promise so that we can `await` the first network call in the LCN plugin
- Adding the concept of `signal`s to `@learncard/core` so that we can register that first call as like an init signal and then await it in `@learncard/init`
- Adding a convention method like `__init__` that a user could `await` to make sure all plugins are ready

I think all of those options have a lot of various tradeoffs, with `id.did` becoming async being my favorite, though it's a _huge_ breaking change, so I don't think it's feasible.
Signals seems second best, but if I do that, I want to have like a really solid implementation for it, so I'm not gonna add those in this PR!

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
`pnpm exec nx start cli --skip-nx-cache` And then feel the speed when you call `initLearnCard`, especially with `network: true`!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I added an E2E test demoing the did problem mentioned above. In practical scenarios, you usually wouldn't need
to think about it because the request is so quick, but in script-type scenarios such as a test like that,
awaiting `getProfile` is the solution!

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
