### PR TITLE
Add Display Field to LCN Profiles

### DIFF
--- a/.changeset/clean-gifts-film.md
+++ b/.changeset/clean-gifts-film.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/types': patch
+---
+
+Add display field to profiles

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -3,6 +3,21 @@ import { z } from 'zod';
 import { PaginationResponseValidator } from './mongo';
 import { StringQuery } from './queries';
 
+export const LCNProfileDisplayValidator = z.object({
+    backgroundColor: z.string().optional(),
+    backgroundImage: z.string().optional(),
+    fadeBackgroundImage: z.boolean().optional(),
+    repeatBackgroundImage: z.boolean().optional(),
+    fontColor: z.string().optional(),
+    accentColor: z.string().optional(),
+    accentFontColor: z.string().optional(),
+    idBackgroundImage: z.string().optional(),
+    fadeIdBackgroundImage: z.boolean().optional(),
+    idBackgroundColor: z.string().optional(),
+    repeatIdBackgroundImage: z.boolean().optional(),
+});
+export type LCNProfileDisplay = z.infer<typeof LCNProfileDisplayValidator>;
+
 export const LCNProfileValidator = z.object({
     profileId: z.string().min(3).max(40),
     displayName: z.string().default(''),
@@ -16,6 +31,7 @@ export const LCNProfileValidator = z.object({
     isServiceProfile: z.boolean().default(false).optional(),
     type: z.string().optional(),
     notificationsWebhook: z.string().url().startsWith('http').optional(),
+    display: LCNProfileDisplayValidator.optional(),
 });
 export type LCNProfile = z.infer<typeof LCNProfileValidator>;
 

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/create.ts
@@ -2,17 +2,18 @@ import { QueryBuilder, BindParam } from 'neogma';
 import { UnsignedVC, VC } from '@learncard/types';
 import { v4 as uuid } from 'uuid';
 
-import { Boost, BoostInstance, ProfileInstance } from '@models';
+import { Boost, BoostInstance } from '@models';
 import { BoostStatus, BoostType } from 'types/boost';
 import { convertCredentialToBoostTemplateJSON } from '@helpers/boost.helpers';
 import { getDidWeb } from '@helpers/did.helpers';
 import { getCreatorRole } from '@accesslayer/role/read';
 import { flattenObject } from '@helpers/objects.helpers';
 import { getBoostById } from './read';
+import { ProfileType } from 'types/profile';
 
 export const createBoost = async (
     credential: UnsignedVC | VC,
-    creator: ProfileInstance,
+    creator: ProfileType,
     metadata: Omit<BoostType, 'id' | 'boost'> = {},
     domain: string
 ): Promise<BoostInstance> => {

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/read.ts
@@ -6,10 +6,11 @@ import {
     convertQueryResultToPropertiesObjectArray,
     getMatchQueryWhere,
 } from '@helpers/neo4j.helpers';
-import { Boost, Profile, BoostInstance, ProfileInstance } from '@models';
+import { Boost, Profile, BoostInstance } from '@models';
 import { BoostType } from 'types/boost';
 import { BoostQuery } from '@learncard/types';
 import { inflateObject } from '@helpers/objects.helpers';
+import { ProfileType } from 'types/profile';
 
 export const getBoostById = async (id: string): Promise<BoostInstance | null> => {
     return Boost.findOne({ where: { id } });
@@ -28,7 +29,7 @@ export const getBoostsByUri = async (uris: string[]): Promise<BoostInstance[]> =
 };
 
 export const getBoostsForProfile = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         limit,
         cursor,
@@ -74,7 +75,7 @@ export const getBoostsForProfile = async (
 };
 
 export const countBoostsForProfile = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     { query: matchQuery = {} }: { query?: BoostQuery }
 ): Promise<number> => {
     const query = new QueryBuilder(

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/create.ts
@@ -1,5 +1,6 @@
 import { getAdminRole, getEmptyRole } from '@accesslayer/role/read';
-import { CredentialInstance, ProfileInstance, BoostInstance } from '@models';
+import { CredentialInstance, BoostInstance } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const createBoostInstanceOfRelationship = async (
     credential: CredentialInstance,
@@ -9,8 +10,8 @@ export const createBoostInstanceOfRelationship = async (
 };
 
 export const createReceivedCredentialRelationship = async (
-    to: ProfileInstance,
-    from: ProfileInstance,
+    to: ProfileType,
+    from: ProfileType,
     credential: CredentialInstance
 ): Promise<void> => {
     await credential.relateTo({
@@ -21,7 +22,7 @@ export const createReceivedCredentialRelationship = async (
 };
 
 export const setProfileAsBoostAdmin = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     boost: BoostInstance
 ): Promise<void> => {
     const role = await getAdminRole(); // Ensure admin role exists
@@ -33,7 +34,7 @@ export const setProfileAsBoostAdmin = async (
 };
 
 export const giveProfileEmptyPermissions = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     boost: BoostInstance
 ): Promise<void> => {
     const role = await getEmptyRole(); // Ensure empty role exists

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/delete.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/delete.ts
@@ -1,7 +1,8 @@
-import { ProfileInstance, BoostInstance, Boost } from '@models';
+import { BoostInstance, Boost } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const removeProfileAsBoostAdmin = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     boost: BoostInstance
 ): Promise<void> => {
     await Boost.deleteRelationships({

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/update.ts
@@ -1,8 +1,9 @@
 import { BoostPermissions } from '@learncard/types';
-import { BoostInstance, ProfileInstance } from '@models';
+import { BoostInstance } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const updateBoostPermissions = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     boost: BoostInstance,
     permissions: Partial<BoostPermissions>
 ): Promise<boolean> => {

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
@@ -1,13 +1,7 @@
 import { QueryBuilder, BindParam } from 'neogma';
 import mapValues from 'lodash/mapValues';
 import { convertQueryResultToPropertiesObjectArray } from '@helpers/neo4j.helpers';
-import {
-    Profile,
-    ProfileInstance,
-    ConsentFlowContract,
-    ConsentFlowTerms,
-    ConsentFlowTransaction,
-} from '@models';
+import { Profile, ConsentFlowContract, ConsentFlowTerms, ConsentFlowTransaction } from '@models';
 import {
     DbTermsType,
     FlatDbTermsType,
@@ -27,9 +21,10 @@ import {
 import { getIdFromUri } from '@helpers/uri.helpers';
 import { flattenObject, inflateObject } from '@helpers/objects.helpers';
 import { convertDataQueryToNeo4jQuery } from '@helpers/contract.helpers';
+import { ProfileType } from 'types/profile';
 
 export const isProfileConsentFlowContractAdmin = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     contract: DbContractType
 ): Promise<boolean> => {
     const query = new QueryBuilder().match({
@@ -46,7 +41,7 @@ export const isProfileConsentFlowContractAdmin = async (
 };
 
 export const hasProfileConsentedToContract = async (
-    profile: ProfileInstance | string,
+    profile: ProfileType | string,
     contract: DbContractType
 ): Promise<boolean> => {
     const query = new QueryBuilder().match({
@@ -97,7 +92,7 @@ export const getContractDetailsByUri = async (
 };
 
 export const getContractTermsForProfile = async (
-    profile: ProfileInstance | string,
+    profile: ProfileType | string,
     contract: DbContractType
 ): Promise<DbTermsType | null> => {
     const result = convertQueryResultToPropertiesObjectArray<{
@@ -157,11 +152,11 @@ export const getContractTermsById = async (
 
     return result.length > 0
         ? {
-              consenter: result[0]!.consenter,
-              terms: inflateObject(result[0]!.terms),
-              contract: inflateObject(result[0]!.contract),
-              contractOwner: result[0]!.contractOwner,
-          }
+            consenter: result[0]!.consenter,
+            terms: inflateObject(result[0]!.terms),
+            contract: inflateObject(result[0]!.contract),
+            contractOwner: result[0]!.contractOwner,
+        }
         : null;
 };
 
@@ -177,7 +172,7 @@ export const getContractTermsByUri = async (
 };
 
 export const getConsentFlowContractsForProfile = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         query: matchQuery = {},
         limit,
@@ -209,7 +204,7 @@ export const getConsentFlowContractsForProfile = async (
 };
 
 export const getConsentedContractsForProfile = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         query: matchQuery = {},
         limit,

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
@@ -4,7 +4,6 @@ import {
     CredentialInstance,
     CredentialRelationships,
     Profile,
-    ProfileInstance,
     ProfileRelationships,
 } from '@models';
 import { SentCredentialInfo } from '@learncard/types';
@@ -28,14 +27,8 @@ export const getCredentialByUri = async (uri: string): Promise<CredentialInstanc
 
 export const getReceivedCredentialsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
-    {
-        limit,
-        from,
-    }: {
-        limit: number;
-        from?: string[];
-    }
+    profile: ProfileType,
+    { limit, from }: { limit: number; from?: string[] }
 ): Promise<SentCredentialInfo[]> => {
     const matchQuery = new QueryBuilder().match({
         related: [
@@ -57,8 +50,8 @@ export const getReceivedCredentialsForProfile = async (
     const query =
         from && from.length > 0
             ? matchQuery.where(
-                  new Where({ source: { profileId: { [Op.in]: from } } }, matchQuery.getBindParam())
-              )
+                new Where({ source: { profileId: { [Op.in]: from } } }, matchQuery.getBindParam())
+            )
             : matchQuery;
 
     const results = convertQueryResultToPropertiesObjectArray<{
@@ -78,14 +71,8 @@ export const getReceivedCredentialsForProfile = async (
 
 export const getSentCredentialsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
-    {
-        limit,
-        to,
-    }: {
-        limit: number;
-        to?: string[];
-    }
+    profile: ProfileType,
+    { limit, to }: { limit: number; to?: string[] }
 ): Promise<SentCredentialInfo[]> => {
     const matchQuery = new QueryBuilder().match({
         related: [
@@ -102,8 +89,8 @@ export const getSentCredentialsForProfile = async (
     const whereQuery =
         to && to.length > 0
             ? matchQuery.where(
-                  new Where({ sent: { to: { [Op.in]: to } } }, matchQuery.getBindParam())
-              )
+                new Where({ sent: { to: { [Op.in]: to } } }, matchQuery.getBindParam())
+            )
             : matchQuery;
 
     const query = whereQuery.match({
@@ -136,14 +123,8 @@ export const getSentCredentialsForProfile = async (
 
 export const getIncomingCredentialsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
-    {
-        limit,
-        from,
-    }: {
-        limit: number;
-        from?: string[];
-    }
+    profile: ProfileType,
+    { limit, from }: { limit: number; from?: string[] }
 ): Promise<SentCredentialInfo[]> => {
     const whereFrom =
         from && from.length > 0
@@ -169,8 +150,7 @@ export const getIncomingCredentialsForProfile = async (
             })
             // Don't return credentials that have been accepted
             .where(
-                `NOT (credential)-[:CREDENTIAL_RECEIVED]->()${
-                    whereFrom ? `AND ${whereFrom.getStatement('text')}` : ''
+                `NOT (credential)-[:CREDENTIAL_RECEIVED]->()${whereFrom ? `AND ${whereFrom.getStatement('text')}` : ''
                 }`
             )
             .return('source, relationship, credential')

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/create.ts
@@ -1,22 +1,23 @@
 import { QueryBuilder } from 'neogma';
 
-import { CredentialInstance, Credential, ProfileInstance, Boost, Role, Profile } from '@models';
+import { CredentialInstance, Credential, Boost, Role, Profile } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const createSentCredentialRelationship = async (
-    from: ProfileInstance,
-    to: ProfileInstance,
+    from: ProfileType,
+    to: ProfileType,
     credential: CredentialInstance
 ): Promise<void> => {
-    await from.relateTo({
+    await Profile.relateTo({
         alias: 'credentialSent',
-        where: { id: credential.id },
+        where: { source: { profileId: from.profileId }, target: { id: credential.id } },
         properties: { to: to.profileId, date: new Date().toISOString() },
     });
 };
 
 export const createReceivedCredentialRelationship = async (
-    to: ProfileInstance,
-    from: ProfileInstance,
+    to: ProfileType,
+    from: ProfileType,
     credential: CredentialInstance
 ): Promise<void> => {
     await credential.relateTo({
@@ -27,7 +28,7 @@ export const createReceivedCredentialRelationship = async (
 };
 
 export const setDefaultClaimedRole = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     credential: CredentialInstance
 ): Promise<void> => {
     await new QueryBuilder()

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
@@ -1,30 +1,40 @@
-import { CredentialInstance, Profile, ProfileRelationships, ProfileInstance } from '@models';
+import { inflateObject } from '@helpers/objects.helpers';
+import { CredentialInstance, Profile, ProfileRelationships } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const getCredentialSentToProfile = async (
     id: string,
-    to: ProfileInstance
+    to: ProfileType
 ): Promise<
     | {
-        source: ProfileInstance;
+        source: ProfileType;
         relationship: ProfileRelationships['credentialSent']['RelationshipProperties'];
         target: CredentialInstance;
     }
     | undefined
 > => {
-    return (
+    const data = (
         await Profile.findRelationships({
             alias: 'credentialSent',
             where: { relationship: { to: to.profileId }, target: { id } },
         })
     )[0];
+
+    if (!data) return undefined;
+
+    return { ...data, source: inflateObject(data.source.dataValues as any) };
 };
 
 export const getCredentialOwner = async (
     credential: CredentialInstance
-): Promise<ProfileInstance | undefined> => {
+): Promise<ProfileType | undefined> => {
     const id = credential.id;
 
-    return (
+    const owner = (
         await Profile.findRelationships({ alias: 'credentialSent', where: { target: { id } } })
     )[0]?.source;
+
+    if (!owner) return undefined;
+
+    return inflateObject<ProfileType>(owner.dataValues as any);
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/presentation/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/presentation/read.ts
@@ -4,7 +4,6 @@ import {
     PresentationInstance,
     PresentationRelationships,
     Profile,
-    ProfileInstance,
     ProfileRelationships,
 } from '@models';
 import { SentCredentialInfo } from '@learncard/types';
@@ -28,7 +27,7 @@ export const getPresentationByUri = async (uri: string): Promise<PresentationIns
 
 export const getReceivedPresentationsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         limit,
         from,
@@ -57,8 +56,8 @@ export const getReceivedPresentationsForProfile = async (
     const query =
         from && from.length > 0
             ? matchQuery.where(
-                  new Where({ source: { profileId: { [Op.in]: from } } }, matchQuery.getBindParam())
-              )
+                new Where({ source: { profileId: { [Op.in]: from } } }, matchQuery.getBindParam())
+            )
             : matchQuery;
 
     const results = convertQueryResultToPropertiesObjectArray<{
@@ -78,7 +77,7 @@ export const getReceivedPresentationsForProfile = async (
 
 export const getSentPresentationsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         limit,
         to,
@@ -102,8 +101,8 @@ export const getSentPresentationsForProfile = async (
     const whereQuery =
         to && to.length > 0
             ? matchQuery.where(
-                  new Where({ sent: { to: { [Op.in]: to } } }, matchQuery.getBindParam())
-              )
+                new Where({ sent: { to: { [Op.in]: to } } }, matchQuery.getBindParam())
+            )
             : matchQuery;
 
     const query = whereQuery.match({
@@ -136,7 +135,7 @@ export const getSentPresentationsForProfile = async (
 
 export const getIncomingPresentationsForProfile = async (
     domain: string,
-    profile: ProfileInstance,
+    profile: ProfileType,
     {
         limit,
         from,
@@ -169,8 +168,7 @@ export const getIncomingPresentationsForProfile = async (
             })
             // Don't return presentations that have been accepted
             .where(
-                `NOT (presentation)-[:PRESENTATION_RECEIVED]->()${
-                    whereFrom ? `AND ${whereFrom.getStatement('text')}` : ''
+                `NOT (presentation)-[:PRESENTATION_RECEIVED]->()${whereFrom ? `AND ${whereFrom.getStatement('text')}` : ''
                 }`
             )
             .return('source, relationship, presentation')

--- a/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/create.ts
@@ -1,20 +1,21 @@
-import { PresentationInstance, ProfileInstance } from '@models';
+import { PresentationInstance, Profile } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const createSentPresentationRelationship = async (
-    from: ProfileInstance,
-    to: ProfileInstance,
+    from: ProfileType,
+    to: ProfileType,
     presentation: PresentationInstance
 ): Promise<void> => {
-    await from.relateTo({
+    await Profile.relateTo({
         alias: 'presentationSent',
-        where: { id: presentation.id },
+        where: { source: { profileId: from.profileId }, target: { id: presentation.id } },
         properties: { to: to.profileId, date: new Date().toISOString() },
     });
 };
 
 export const createReceivedPresentationRelationship = async (
-    to: ProfileInstance,
-    from: ProfileInstance,
+    to: ProfileType,
+    from: ProfileType,
     presentation: PresentationInstance
 ): Promise<void> => {
     await presentation.relateTo({

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/create.ts
@@ -1,7 +1,24 @@
+import { flattenObject, inflateObject } from '@helpers/objects.helpers';
+import { transformProfileId } from '@helpers/profile.helpers';
 import { LCNProfile } from '@learncard/types';
 
-import { Profile, ProfileInstance } from '@models';
+import { Profile } from '@models';
+import { BindParam, QueryBuilder } from 'neogma';
+import { ProfileType } from 'types/profile';
 
-export const createProfile = async (input: LCNProfile): Promise<ProfileInstance> => {
-    return Profile.createOne(input);
+export const createProfile = async (input: LCNProfile): Promise<ProfileType> => {
+    const result = await new QueryBuilder(
+        new BindParam({
+            params: flattenObject({ ...input, profileId: transformProfileId(input.profileId) }),
+        })
+    )
+        .create({ model: Profile, identifier: 'profile' })
+        .set('profile += $params')
+        .return('profile')
+        .limit(1)
+        .run();
+
+    const profile = result.records[0]?.get('profile').properties!;
+
+    return inflateObject<ProfileType>(profile as any);
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/delete.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/delete.ts
@@ -1,5 +1,6 @@
-import { ProfileInstance } from '@models';
+import { Profile } from '@models';
+import { ProfileType } from 'types/profile';
 
-export const deleteProfile = async (profile: ProfileInstance): Promise<void> => {
-    await profile.delete({ detach: true });
+export const deleteProfile = async (profile: ProfileType): Promise<void> => {
+    await Profile.delete({ detach: true, where: { profileId: profile.profileId } });
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/create.ts
@@ -1,0 +1,17 @@
+import { Profile } from '@models';
+import { ProfileType } from 'types/profile';
+
+export const createProfileManagedByRelationship = async (
+    manager: ProfileType,
+    managee: ProfileType
+): Promise<boolean> => {
+    return Boolean(
+        await Profile.relateTo({
+            alias: 'managedBy',
+            where: {
+                source: { profileId: managee.profileId },
+                target: { profileId: manager.profileId },
+            },
+        })
+    );
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/relationships/read.ts
@@ -1,7 +1,8 @@
 import { Op, QueryBuilder, Where } from 'neogma';
 import { convertQueryResultToPropertiesObjectArray } from '@helpers/neo4j.helpers';
 import { Profile } from '@models';
-import { ProfileType } from 'types/profile';
+import { FlatProfileType, ProfileType } from 'types/profile';
+import { inflateObject } from '@helpers/objects.helpers';
 
 export const getManagedServiceProfiles = async (
     profileId: string,
@@ -26,8 +27,8 @@ export const getManagedServiceProfiles = async (
         : _query;
 
     const results = convertQueryResultToPropertiesObjectArray<{
-        managed: ProfileType;
+        managed: FlatProfileType;
     }>(await query.return('managed').orderBy('managed.profileId').limit(limit).run());
 
-    return results.map(({ managed }) => managed);
+    return results.map(({ managed }) => inflateObject(managed as any));
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/profile/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/profile/update.ts
@@ -1,0 +1,22 @@
+import { QueryBuilder, BindParam } from 'neogma';
+import { flattenObject } from '@helpers/objects.helpers';
+import { Profile } from '@models';
+import { ProfileType } from 'types/profile';
+
+export const updateProfile = async (profile: ProfileType, updates: Partial<ProfileType>) => {
+    const currentDisplay = profile.display;
+    const newDisplay = { ...(currentDisplay || {}), ...(updates.display || {}) };
+
+    const newUpdates = flattenObject<Partial<ProfileType>>({
+        ...updates,
+        ...((currentDisplay || newDisplay) && { display: newDisplay }),
+    });
+
+    const query = new QueryBuilder(new BindParam({ params: newUpdates }))
+        .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })
+        .set('profile += $params');
+
+    const result = await query.run();
+
+    return result.summary.updateStatistics.containsUpdates();
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/create.ts
@@ -1,14 +1,18 @@
-import { SigningAuthorityInstance, ProfileInstance } from '@models';
+import { SigningAuthorityInstance, Profile } from '@models';
+import { ProfileType } from 'types/profile';
 
 export const createUseSigningAuthorityRelationship = async (
-    user: ProfileInstance,
+    user: ProfileType,
     signingAuthority: SigningAuthorityInstance,
     name: string,
     did: string
 ): Promise<void> => {
-    await user.relateTo({
+    await Profile.relateTo({
         alias: 'usesSigningAuthority',
-        where: { endpoint: signingAuthority.endpoint },
+        where: {
+            source: { profileId: user.profileId },
+            target: { endpoint: signingAuthority.endpoint },
+        },
         properties: { name, did },
     });
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/read.ts
@@ -1,12 +1,13 @@
-import { ProfileInstance } from '@models';
-import { SigningAuthorityForUserType } from 'types/profile';
+import { Profile } from '@models';
+import { ProfileType, SigningAuthorityForUserType } from 'types/profile';
 
 export const getSigningAuthoritiesForUser = async (
-    user: ProfileInstance
+    user: ProfileType
 ): Promise<SigningAuthorityForUserType[]> => {
     return (
-        await user.findRelationships({
+        await Profile.findRelationships({
             alias: 'usesSigningAuthority',
+            where: { source: { profileId: user.profileId } },
         })
     ).map(relationship => {
         return {
@@ -17,14 +18,15 @@ export const getSigningAuthoritiesForUser = async (
 };
 
 export const getSigningAuthorityForUserByName = async (
-    user: ProfileInstance,
+    user: ProfileType,
     endpoint: string,
     name: string
 ): Promise<SigningAuthorityForUserType | undefined> => {
     return (
-        await user.findRelationships({
+        await Profile.findRelationships({
             alias: 'usesSigningAuthority',
             where: {
+                source: { profileId: user.profileId },
                 relationship: { name },
                 target: { endpoint },
             },

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -2,10 +2,10 @@ import isEqual from 'lodash/isEqual';
 import { v4 as uuidv4 } from 'uuid';
 import { VC, JWE, UnsignedVC, LCNNotificationTypeEnumValidator } from '@learncard/types';
 import { isEncrypted } from '@learncard/helpers';
-import { SigningAuthorityForUserType } from 'types/profile';
+import { ProfileType, SigningAuthorityForUserType } from 'types/profile';
 
 import { getBoostOwner } from '@accesslayer/boost/relationships/read';
-import { BoostInstance, ProfileInstance } from '@models';
+import { BoostInstance } from '@models';
 import { constructUri } from './uri.helpers';
 import { storeCredential } from '@accesslayer/credential/create';
 import { createBoostInstanceOfRelationship } from '@accesslayer/boost/relationships/create';
@@ -25,7 +25,7 @@ export const getBoostUri = (id: string, domain: string): string =>
     constructUri('boost', id, domain);
 
 export const isProfileBoostOwner = async (
-    profile: ProfileInstance,
+    profile: ProfileType,
     boost: BoostInstance
 ): Promise<boolean> => {
     const owner = await getBoostOwner(boost);
@@ -220,8 +220,8 @@ export const decryptCredential = async (credential: VC | JWE): Promise<VC | fals
 };
 
 export const sendBoost = async (
-    from: ProfileInstance,
-    to: ProfileInstance,
+    from: ProfileType,
+    to: ProfileType,
     boost: BoostInstance,
     credential: VC | JWE,
     domain: string,
@@ -277,8 +277,8 @@ export const sendBoost = async (
         if (!skipNotification) {
             await addNotificationToQueue({
                 type: LCNNotificationTypeEnumValidator.enum.BOOST_RECEIVED,
-                to: to.dataValues,
-                from: from.dataValues,
+                to: to,
+                from: from,
                 message: {
                     title: 'Boost Received',
                     body: `${from.displayName} has boosted you!`,
@@ -346,8 +346,8 @@ export const constructCertifiedBoostCredential = async (
 export const issueClaimLinkBoost = async (
     boost: BoostInstance,
     domain: string,
-    from: ProfileInstance,
-    to: ProfileInstance,
+    from: ProfileType,
+    to: ProfileType,
     signingAuthorityForUser: SigningAuthorityForUserType
 ): Promise<string> => {
     const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC | VC;

--- a/services/learn-card-network/brain-service/src/helpers/presentation.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/presentation.helpers.ts
@@ -1,8 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { VP, JWE, LCNNotificationTypeEnumValidator } from '@learncard/types';
 
-import { ProfileInstance } from '@models';
-
 import { storePresentation } from '@accesslayer/presentation/create';
 import {
     createReceivedPresentationRelationship,
@@ -11,13 +9,14 @@ import {
 import { getPresentationSentToProfile } from '@accesslayer/presentation/relationships/read';
 import { constructUri, getUriParts } from './uri.helpers';
 import { addNotificationToQueue } from './notifications.helpers';
+import { ProfileType } from 'types/profile';
 
 export const getPresentationUri = (id: string, domain: string): string =>
     constructUri('presentation', id, domain);
 
 export const sendPresentation = async (
-    from: ProfileInstance,
-    to: ProfileInstance,
+    from: ProfileType,
+    to: ProfileType,
     presentation: VP | JWE,
     domain: string
 ): Promise<string> => {
@@ -29,15 +28,13 @@ export const sendPresentation = async (
 
     await addNotificationToQueue({
         type: LCNNotificationTypeEnumValidator.enum.PRESENTATION_RECEIVED,
-        to: to.dataValues,
-        from: from.dataValues,
+        to,
+        from,
         message: {
             title: 'Presentation Received',
             body: `${from.displayName} has sent you a presentation!`,
         },
-        data: {
-            vpUris: [uri],
-        },
+        data: { vpUris: [uri] },
     });
 
     return uri;
@@ -46,10 +43,7 @@ export const sendPresentation = async (
 /**
  * Accepts a VP
  */
-export const acceptPresentation = async (
-    profile: ProfileInstance,
-    uri: string
-): Promise<boolean> => {
+export const acceptPresentation = async (profile: ProfileType, uri: string): Promise<boolean> => {
     const { id, type } = getUriParts(uri);
 
     if (type !== 'presentation') {

--- a/services/learn-card-network/brain-service/src/helpers/signingAuthority.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/signingAuthority.helpers.ts
@@ -1,8 +1,7 @@
 import dotenv from 'dotenv';
 import { getDidWebLearnCard, getLearnCard } from '@helpers/learnCard.helpers';
 import { UnsignedVC, VCValidator, JWEValidator, VC, JWE } from '@learncard/types';
-import { SigningAuthorityForUserType } from 'types/profile';
-import { ProfileInstance } from '@models';
+import { ProfileType, SigningAuthorityForUserType } from 'types/profile';
 import { getDidWeb } from '@helpers/did.helpers';
 
 dotenv.config();
@@ -18,7 +17,7 @@ const _mockIssueCredentialWithSigningAuthority = async (credential: UnsignedVC) 
 };
 
 export async function issueCredentialWithSigningAuthority(
-    owner: ProfileInstance,
+    owner: ProfileType,
     credential: UnsignedVC,
     signingAuthorityForUser: SigningAuthorityForUserType,
     encrypt: boolean = true

--- a/services/learn-card-network/brain-service/src/models/Profile.ts
+++ b/services/learn-card-network/brain-service/src/models/Profile.ts
@@ -6,7 +6,7 @@ import { Credential, CredentialInstance } from './Credential';
 import { Presentation, PresentationInstance } from './Presentation';
 import { SigningAuthority } from './SigningAuthority';
 import { transformProfileId } from '@helpers/profile.helpers';
-import { ProfileType } from 'types/profile';
+import { FlatProfileType } from 'types/profile';
 import { SigningAuthorityInstance } from './SigningAuthority';
 
 export type ProfileRelationships = {
@@ -34,9 +34,9 @@ export type ProfileRelationships = {
     >;
 };
 
-export type ProfileInstance = NeogmaInstance<ProfileType, ProfileRelationships>;
+export type ProfileInstance = NeogmaInstance<FlatProfileType, ProfileRelationships>;
 
-export const Profile = ModelFactory<ProfileType, ProfileRelationships>(
+export const Profile = ModelFactory<FlatProfileType, ProfileRelationships>(
     {
         label: 'Profile',
         schema: {

--- a/services/learn-card-network/brain-service/src/routes/index.ts
+++ b/services/learn-card-network/brain-service/src/routes/index.ts
@@ -10,7 +10,7 @@ import { RegExpTransformer } from '@learncard/helpers';
 import { getProfileByDid } from '@accesslayer/profile/read';
 import { getEmptyLearnCard } from '@helpers/learnCard.helpers';
 import { invalidateChallengeForDid, isChallengeValidForDid } from '@cache/challenges';
-import { ProfileInstance } from '@models';
+import { ProfileType } from 'types/profile';
 
 export type DidAuthVP = {
     iss: string;
@@ -112,7 +112,7 @@ export const didRoute = openRoute.use(async ({ ctx, next }) => {
 
         if (!didDoc.controller) {
             return next({
-                ctx: { ...ctx, user: { ...ctx.user, profile: null as ProfileInstance | null } },
+                ctx: { ...ctx, user: { ...ctx.user, profile: null as ProfileType | null } },
             });
         }
 

--- a/services/learn-card-network/brain-service/src/types/profile.ts
+++ b/services/learn-card-network/brain-service/src/types/profile.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
     LCNProfile,
     LCNProfileValidator,
@@ -9,6 +10,9 @@ import {
 
 export const ProfileValidator = LCNProfileValidator;
 export type ProfileType = LCNProfile;
+
+export const FlatProfileValidator = ProfileValidator.omit({ display: true }).catchall(z.any());
+export type FlatProfileType = z.infer<typeof FlatProfileValidator>;
 
 export const SigningAuthorityValidator = LCNSigningAuthorityValidator;
 export type SigningAuthorityType = LCNSigningAuthorityType;


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
To make the personal LearnCard screen work, we need to include more display metadata for profiles

#### 🥴 TL; RL:
Adds a `display` object with these fields as requested:
```ts
export type profileDisplay = {
    // container styles
    backgroundColor?: string;
    backgroundImage?: string;
    fadeBackgroundImage?: boolean;
    repeatBackgroundImage?: boolean;

    // id styles
    fontColor?: string;
    accentColor?: string;
    accentFontColor?: string;
    idBackgroundImage?: string;
    fadeIdBackgroundImage?: boolean;
    idBackgroundColor?: string;
    repeatIdBackgroundImage?: boolean;
};
```

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Because this is a nested object, I had to restructure the `Profile` neo4j object to use flatten/inflate
during storage. This time, I decided that the access layer should just totally hide that from everything
else (as opposed to boosts, where application code is more responsible), which kind of resulted in a
pretty big refactor, but I think this was actually a net positive, and I want to in the future move
towards instances never being exposed and things always being done via `QueryBuilder`, because I think
it's more maintainable.

#### 🛠 Important tradeoffs made:
Confusingly, you now should pretty much _never_ use the `Profile` model directly! It will strip out
the display field =(

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [ ] No
- [x] Yes
`Profile` can not be used directly, and I think that there is like a major restructuring that should
happen to make this more obvious. For now though, it's fine to just use access layer methods as-is
and it will cause no harm

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the test suite! There are tests for the display fields =)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
Added tests for creating and updating display fields

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
