### PR TITLE
Don't Always Associate Dids in LearnCloud

### DIFF
--- a/.changeset/four-papayas-drum.md
+++ b/.changeset/four-papayas-drum.md
@@ -1,0 +1,6 @@
+---
+'@learncard/learn-cloud-plugin': patch
+'@learncard/init': patch
+---
+
+Allow not automatically associating dids in LearnCloud

--- a/packages/learn-card-init/src/initializers/didWebLearnCardFromSeed.ts
+++ b/packages/learn-card-init/src/initializers/didWebLearnCardFromSeed.ts
@@ -30,6 +30,7 @@ export const didWebLearnCardFromSeed = async ({
         url = 'https://cloud.learncard.com/trpc',
         unencryptedFields = [],
         unencryptedCustomFields = [],
+        automaticallyAssociateDids = true,
     } = {},
     ceramicIdx = defaultCeramicIDXArgs,
     didkit,
@@ -54,7 +55,13 @@ export const didWebLearnCardFromSeed = async ({
     const ceramicLc = await templateLc.addPlugin(await getCeramicPlugin(templateLc, ceramicIdx));
 
     const cloudLc = await ceramicLc.addPlugin(
-        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields)
+        await getLearnCloudPlugin(
+            ceramicLc,
+            url,
+            unencryptedFields,
+            unencryptedCustomFields,
+            automaticallyAssociateDids
+        )
     );
 
     const idxLc = await cloudLc.addPlugin(await getIDXPlugin(cloudLc, ceramicIdx));

--- a/packages/learn-card-init/src/initializers/didWebNetworkLearnCardFromSeed.ts
+++ b/packages/learn-card-init/src/initializers/didWebNetworkLearnCardFromSeed.ts
@@ -34,6 +34,7 @@ export const didWebNetworkLearnCardFromSeed = async ({
         url = 'https://cloud.learncard.com/trpc',
         unencryptedFields = [],
         unencryptedCustomFields = [],
+        automaticallyAssociateDids = true,
     } = {},
     ceramicIdx = defaultCeramicIDXArgs,
     didkit,
@@ -62,7 +63,13 @@ export const didWebNetworkLearnCardFromSeed = async ({
     const ceramicLc = await templateLc.addPlugin(await getCeramicPlugin(templateLc, ceramicIdx));
 
     const cloudLc = await ceramicLc.addPlugin(
-        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields)
+        await getLearnCloudPlugin(
+            ceramicLc,
+            url,
+            unencryptedFields,
+            unencryptedCustomFields,
+            automaticallyAssociateDids
+        )
     );
 
     const idxLc = await cloudLc.addPlugin(await getIDXPlugin(cloudLc, ceramicIdx));

--- a/packages/learn-card-init/src/initializers/learnCardFromSeed.ts
+++ b/packages/learn-card-init/src/initializers/learnCardFromSeed.ts
@@ -29,6 +29,7 @@ export const learnCardFromSeed = async ({
         url = 'https://cloud.learncard.com/trpc',
         unencryptedFields = [],
         unencryptedCustomFields = [],
+        automaticallyAssociateDids = true,
     } = {},
     ceramicIdx = defaultCeramicIDXArgs,
     didkit,
@@ -53,7 +54,7 @@ export const learnCardFromSeed = async ({
     const ceramicLc = await templateLc.addPlugin(await getCeramicPlugin(templateLc, ceramicIdx));
 
     const cloudLc = await ceramicLc.addPlugin(
-        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields)
+        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields, automaticallyAssociateDids)
     );
 
     const idxLc = await cloudLc.addPlugin(await getIDXPlugin(cloudLc, ceramicIdx));

--- a/packages/learn-card-init/src/initializers/networkLearnCardFromSeed.ts
+++ b/packages/learn-card-init/src/initializers/networkLearnCardFromSeed.ts
@@ -32,6 +32,7 @@ export const networkLearnCardFromSeed = async ({
         url = 'https://cloud.learncard.com/trpc',
         unencryptedFields = [],
         unencryptedCustomFields = [],
+        automaticallyAssociateDids = true,
     } = {},
     ceramicIdx = defaultCeramicIDXArgs,
     didkit,
@@ -58,7 +59,13 @@ export const networkLearnCardFromSeed = async ({
     const ceramicLc = await templateLc.addPlugin(await getCeramicPlugin(templateLc, ceramicIdx));
 
     const cloudLc = await ceramicLc.addPlugin(
-        await getLearnCloudPlugin(ceramicLc, url, unencryptedFields, unencryptedCustomFields)
+        await getLearnCloudPlugin(
+            ceramicLc,
+            url,
+            unencryptedFields,
+            unencryptedCustomFields,
+            automaticallyAssociateDids
+        )
     );
 
     const idxLc = await cloudLc.addPlugin(await getIDXPlugin(cloudLc, ceramicIdx));

--- a/packages/learn-card-init/src/types/LearnCard.ts
+++ b/packages/learn-card-init/src/types/LearnCard.ts
@@ -23,7 +23,12 @@ import { InitFunction, GenericInitFunction } from './helpers';
 
 /** @group LearnCard */
 export type LearnCardConfig = {
-    cloud?: { url?: string; unencryptedFields?: string[]; unencryptedCustomFields?: string[] };
+    cloud?: {
+        url?: string;
+        unencryptedFields?: string[];
+        unencryptedCustomFields?: string[];
+        automaticallyAssociateDids?: boolean;
+    };
     ceramicIdx: CeramicArgs & IDXArgs;
     didkit: InitInput | Promise<InitInput>;
     allowRemoteContexts?: boolean;

--- a/packages/plugins/learn-cloud/src/plugin.ts
+++ b/packages/plugins/learn-cloud/src/plugin.ts
@@ -42,7 +42,8 @@ export const getLearnCloudPlugin = async (
     initialLearnCard: LearnCard<any, 'id', LearnCloudPluginDependentMethods>,
     url: string,
     unencryptedFields: string[] = [],
-    unencryptedCustomFields: string[] = []
+    unencryptedCustomFields: string[] = [],
+    automaticallyAssociateDids = true,
 ): Promise<LearnCloudPlugin> => {
     let learnCard = initialLearnCard;
 
@@ -71,7 +72,7 @@ export const getLearnCloudPlugin = async (
         const newDid = _learnCard.id.did();
 
         if (oldDid !== newDid) {
-            if (!dids.includes(newDid)) {
+            if (!dids.includes(newDid) && automaticallyAssociateDids) {
                 const presentation = await _learnCard.invoke.getDidAuthVp();
 
                 await client.user.addDid.mutate({ presentation });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
When switching to a Child Account, it's linking the child's LearnCloud with the parent, which we don't want!

#### 🥴 TL; RL:
Allow not automatically associating dids in the LearnCloud plugin via init flag

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:
Yet another long name init config variable. This could have possibly been done in a different way,
but I like this approach

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
