### PR TITLE
[LC-740] Claim Hooks

### DIFF
--- a/.changeset/shiny-hounds-smell.md
+++ b/.changeset/shiny-hounds-smell.md
@@ -1,0 +1,7 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+'@learncard/types': patch
+---
+
+Add lightweight claim hooks

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -128,6 +128,61 @@ export const BoostPermissionsValidator = z.object({
 });
 export type BoostPermissions = z.infer<typeof BoostPermissionsValidator>;
 
+export const BoostPermissionsQueryValidator = z
+    .object({
+        role: StringQuery,
+        canEdit: z.boolean(),
+        canIssue: z.boolean(),
+        canRevoke: z.boolean(),
+        canManagePermissions: z.boolean(),
+        canIssueChildren: StringQuery,
+        canCreateChildren: StringQuery,
+        canEditChildren: StringQuery,
+        canRevokeChildren: StringQuery,
+        canManageChildrenPermissions: StringQuery,
+        canManageChildrenProfiles: z.boolean(),
+        canViewAnalytics: z.boolean(),
+    })
+    .partial();
+export type BoostPermissionsQuery = z.infer<typeof BoostPermissionsQueryValidator>;
+
+export const ClaimHookTypeValidator = z.enum(['GRANT_PERMISSIONS']);
+export type ClaimHookType = z.infer<typeof ClaimHookTypeValidator>;
+
+export const ClaimHookValidator = z.discriminatedUnion('type', [
+    z.object({
+        type: z.literal(ClaimHookTypeValidator.Values.GRANT_PERMISSIONS),
+        data: z.object({
+            claimUri: z.string(),
+            targetUri: z.string(),
+            permissions: BoostPermissionsValidator.partial(),
+        }),
+    }),
+]);
+export type ClaimHook = z.infer<typeof ClaimHookValidator>;
+
+export const ClaimHookQueryValidator = z
+    .object({
+        type: StringQuery,
+        data: z.object({
+            claimUri: StringQuery,
+            targetUri: StringQuery,
+            permissions: BoostPermissionsQueryValidator,
+        }),
+    })
+    .deepPartial();
+export type ClaimHookQuery = z.infer<typeof ClaimHookQueryValidator>;
+
+export const FullClaimHookValidator = z
+    .object({ id: z.string(), createdAt: z.string(), updatedAt: z.string() })
+    .and(ClaimHookValidator);
+export type FullClaimHook = z.infer<typeof FullClaimHookValidator>;
+
+export const PaginatedClaimHooksValidator = PaginationResponseValidator.extend({
+    records: FullClaimHookValidator.array(),
+});
+export type PaginatedClaimHooksType = z.infer<typeof PaginatedClaimHooksValidator>;
+
 export const LCNBoostStatus = z.enum(['DRAFT', 'LIVE']);
 export type LCNBoostStatusEnum = z.infer<typeof LCNBoostStatus>;
 

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -812,6 +812,24 @@ export const getLearnCardNetworkPlugin = async (
                 return result;
             },
 
+            createClaimHook: async (_learnCard, hook) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.claimHook.createClaimHook.mutate({ hook });
+            },
+
+            getClaimHooksForBoost: async (_learnCard, options) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.claimHook.getClaimHooksForBoost.query(options);
+            },
+
+            deleteClaimHook: async (_learnCard, id) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.claimHook.deleteClaimHook.mutate({ id });
+            },
+
             resolveFromLCN: async (_learnCard, uri) => {
                 const result = await client.storage.resolve.query({ uri });
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -35,6 +35,9 @@ import {
     PaginatedLCNProfileManagers,
     PaginatedLCNProfilesAndManagers,
     DidDocument,
+    ClaimHook,
+    ClaimHookQuery,
+    PaginatedClaimHooksType,
 } from '@learncard/types';
 import { Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
@@ -302,6 +305,12 @@ export type LearnCardNetworkPluginMethods = {
     getMyDidMetadata: () => Promise<Array<Partial<DidDocument> & { id: string }>>;
     updateDidMetadata: (id: string, updates: Partial<DidDocument>) => Promise<boolean>;
     deleteDidMetadata: (id: string) => Promise<boolean>;
+
+    createClaimHook: (hook: ClaimHook) => Promise<string>;
+    getClaimHooksForBoost: (
+        options: Partial<PaginationOptionsType> & { uri: string; query?: ClaimHookQuery }
+    ) => Promise<PaginatedClaimHooksType>;
+    deleteClaimHook: (id: string) => Promise<boolean>;
 
     resolveFromLCN: (
         uri: string

--- a/services/learn-card-network/brain-service/src/accesslayer/claim-hook/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/claim-hook/create.ts
@@ -1,0 +1,20 @@
+import { v4 as uuid } from 'uuid';
+
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+
+import { ClaimHook } from '@models';
+
+export const createClaimHook = async (
+    claimHook: Omit<ClaimHookType, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<ClaimHookType> => {
+    const id = uuid();
+
+    return (
+        await ClaimHook.createOne({
+            id,
+            ...claimHook,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+        })
+    ).dataValues;
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/claim-hook/delete.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/claim-hook/delete.ts
@@ -1,0 +1,6 @@
+import { ClaimHook } from '@models';
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+
+export const deleteClaimHook = async (claimHook: ClaimHookType): Promise<void> => {
+    await ClaimHook.delete({ where: { id: claimHook.id }, detach: true });
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/claim-hook/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/claim-hook/read.ts
@@ -1,0 +1,71 @@
+import { BindParam, QueryBuilder } from 'neogma';
+
+import {
+    convertObjectRegExpToNeo4j,
+    convertQueryResultToPropertiesObjectArray,
+    getMatchQueryWhere,
+} from '@helpers/neo4j.helpers';
+import { Boost, ClaimHook, Role } from '@models';
+import { BoostType } from 'types/boost';
+import { ClaimHookQuery, FullClaimHook } from '@learncard/types';
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+import { Role as RoleType } from 'types/role';
+import { getBoostUri } from '@helpers/boost.helpers';
+
+export const getClaimHookById = async (id: string): Promise<ClaimHookType | null> => {
+    return ClaimHook.findOne({ where: { id } });
+};
+
+export const getClaimHooksForBoost = async (
+    boost: BoostType,
+    {
+        domain,
+        limit,
+        cursor,
+        query: matchQuery = {},
+    }: { domain: string; limit: number; cursor?: string; query?: ClaimHookQuery }
+): Promise<FullClaimHook[]> => {
+    const _query = new QueryBuilder(
+        new BindParam({ matchQuery: convertObjectRegExpToNeo4j(matchQuery), cursor })
+    )
+        .match({
+            related: [
+                { model: Boost, identifier: 'target' },
+                { ...ClaimHook.getRelationshipByAlias('target'), direction: 'in' },
+                { identifier: 'hook', model: ClaimHook },
+                ClaimHook.getRelationshipByAlias('hookFor'),
+                { model: Boost, where: { id: boost.id } },
+            ],
+        })
+        .match({
+            related: [
+                { identifier: 'hook' },
+                ClaimHook.getRelationshipByAlias('roleToGrant'),
+                { model: Role, identifier: 'roleToGrant' },
+            ],
+        })
+        .where(getMatchQueryWhere('hook'));
+
+    const query = cursor ? _query.raw('AND hook.updatedAt < $cursor') : _query;
+
+    const results = convertQueryResultToPropertiesObjectArray<{
+        target: BoostType;
+        hook: ClaimHookType;
+        roleToGrant: RoleType;
+    }>(
+        await query
+            .return('DISTINCT hook, target, roleToGrant')
+            .orderBy('hook.updatedAt DESC')
+            .limit(limit)
+            .run()
+    );
+
+    return results.map(result => ({
+        ...result.hook,
+        data: {
+            claimUri: getBoostUri(boost.id, domain),
+            targetUri: getBoostUri(result.target.id, domain),
+            permissions: result.roleToGrant,
+        },
+    }));
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/claim-hook/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/claim-hook/relationships/create.ts
@@ -1,0 +1,35 @@
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+
+import { BoostType } from 'types/boost';
+import { Role as RoleType } from 'types/role';
+import { ClaimHook } from '@models';
+
+export const addClaimHookForBoost = async (
+    boost: BoostType,
+    claimHook: ClaimHookType
+): Promise<void> => {
+    await ClaimHook.relateTo({
+        alias: 'hookFor',
+        where: { source: { id: claimHook.id }, target: { id: boost.id } },
+    });
+};
+
+export const addClaimHookTarget = async (
+    boost: BoostType,
+    claimHook: ClaimHookType
+): Promise<void> => {
+    await ClaimHook.relateTo({
+        alias: 'target',
+        where: { source: { id: claimHook.id }, target: { id: boost.id } },
+    });
+};
+
+export const addRoleToGrantForClaimHook = async (
+    claimHook: ClaimHookType,
+    role: RoleType
+): Promise<void> => {
+    await ClaimHook.relateTo({
+        alias: 'roleToGrant',
+        where: { source: { id: claimHook.id }, target: { id: role.id } },
+    });
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/claim-hook/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/claim-hook/relationships/read.ts
@@ -1,0 +1,14 @@
+import { ClaimHook, BoostInstance } from '@models';
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+
+export const getClaimBoostForClaimHook = async (
+    claimHook: ClaimHookType
+): Promise<BoostInstance | undefined> => {
+    const result = await ClaimHook.findRelationships({
+        alias: 'hookFor',
+        limit: 1,
+        where: { source: { id: claimHook.id } },
+    });
+
+    return result[0]?.target;
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/role/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/role/create.ts
@@ -9,8 +9,11 @@ import {
     EMPTY_PERMISSIONS,
 } from 'src/constants/permissions';
 
-export const createRole = async (role: BoostPermissions): Promise<RoleInstance> => {
+export const createRole = async (_role: Partial<BoostPermissions>): Promise<RoleInstance> => {
     const id = uuid();
+
+    // Default any unsent fields to empty and random UUID for role name if none supplied
+    const role = { ...EMPTY_PERMISSIONS, role: uuid(), ..._role };
 
     return Role.createOne({ id, ...role });
 };

--- a/services/learn-card-network/brain-service/src/app.ts
+++ b/services/learn-card-network/brain-service/src/app.ts
@@ -1,5 +1,6 @@
 import { t } from '@routes';
 import { boostsRouter } from '@routes/boosts';
+import { claimHooksRouter } from '@routes/claim-hooks';
 import { profilesRouter } from '@routes/profiles';
 import { profileManagersRouter } from '@routes/profile-manager';
 import { credentialsRouter } from '@routes/credentials';
@@ -13,6 +14,7 @@ export { createContext } from '@routes';
 
 export const appRouter = t.router({
     boost: boostsRouter,
+    claimHook: claimHooksRouter,
     profile: profilesRouter,
     profileManager: profileManagersRouter,
     credential: credentialsRouter,

--- a/services/learn-card-network/brain-service/src/helpers/claim-hooks.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/claim-hooks.helpers.ts
@@ -1,0 +1,53 @@
+import { QueryBuilder } from 'neogma';
+
+import { CredentialInstance, Credential, Boost, Profile, ClaimHook, Role } from '@models';
+import { ProfileType } from 'types/profile';
+import { clearDidWebCacheForChildProfileManagers } from '@accesslayer/boost/relationships/update';
+
+export const processClaimHooks = async (
+    profile: ProfileType,
+    credential: CredentialInstance
+): Promise<void> => {
+    await new QueryBuilder()
+        .match({
+            related: [
+                { identifier: 'credential', model: Credential, where: { id: credential.id } },
+                {
+                    ...Credential.getRelationshipByAlias('instanceOf'),
+                    identifier: 'instanceOf',
+                    direction: 'out',
+                },
+                { identifier: 'boost', model: Boost },
+                { ...ClaimHook.getRelationshipByAlias('hookFor'), direction: 'in' },
+                { identifier: 'claimHook', model: ClaimHook },
+                ClaimHook.getRelationshipByAlias('target'),
+                { identifier: 'targetBoost', model: Boost },
+            ],
+        })
+        .with('boost, claimHook, targetBoost')
+        .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })
+        .with('claimHook, targetBoost, profile')
+        .match({
+            related: [
+                { identifier: 'claimHook' },
+                ClaimHook.getRelationshipByAlias('roleToGrant'),
+                { identifier: 'role', model: Role },
+            ],
+        })
+        .create({
+            related: [
+                { identifier: 'profile' },
+                `-[:${Boost.getRelationshipByAlias('hasRole').name} { roleId: role.id }]->`,
+                { identifier: 'targetBoost' },
+            ],
+        })
+        .run();
+
+    try {
+        const vc = JSON.parse(credential.credential);
+
+        if (vc.boostId) await clearDidWebCacheForChildProfileManagers(vc.boostId);
+    } catch (error) {
+        console.error('Invalid credential JSON?', error);
+    }
+};

--- a/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
@@ -11,6 +11,7 @@ import { getCredentialSentToProfile } from '@accesslayer/credential/relationship
 import { constructUri, getUriParts } from './uri.helpers';
 import { addNotificationToQueue } from './notifications.helpers';
 import { ProfileType } from 'types/profile';
+import { processClaimHooks } from './claim-hooks.helpers';
 
 export const getCredentialUri = (id: string, domain: string): string =>
     constructUri('credential', id, domain);
@@ -61,6 +62,8 @@ export const acceptCredential = async (profile: ProfileType, uri: string): Promi
     }
 
     await createReceivedCredentialRelationship(profile, pendingVc.source, pendingVc.target);
+
+    await processClaimHooks(profile, pendingVc.target);
 
     await setDefaultClaimedRole(profile, pendingVc.target);
 

--- a/services/learn-card-network/brain-service/src/models/ClaimHook.ts
+++ b/services/learn-card-network/brain-service/src/models/ClaimHook.ts
@@ -1,0 +1,35 @@
+import { ModelFactory, ModelRelatedNodesI, NeogmaInstance } from 'neogma';
+
+import { neogma } from '@instance';
+import { ClaimHook as ClaimHookType } from 'types/claim-hook';
+import Boost, { BoostInstance } from './Boost';
+import Role, { RoleInstance } from './Role';
+
+export type ClaimHookRelationships = {
+    hookFor: ModelRelatedNodesI<typeof Boost, BoostInstance>;
+    target: ModelRelatedNodesI<typeof Boost, BoostInstance>;
+    roleToGrant: ModelRelatedNodesI<typeof Role, RoleInstance>;
+};
+
+export type ClaimHookInstance = NeogmaInstance<ClaimHookType, ClaimHookRelationships>;
+
+export const ClaimHook = ModelFactory<ClaimHookType, ClaimHookRelationships>(
+    {
+        label: 'ClaimHook',
+        schema: {
+            id: { type: 'string', required: true, uniqueItems: true },
+            type: { type: 'string', required: true },
+            createdAt: { type: 'string', required: true },
+            updatedAt: { type: 'string', required: true },
+        },
+        primaryKeyField: 'id',
+        relationships: {
+            hookFor: { model: Boost, direction: 'out', name: 'HOOK_FOR' },
+            target: { model: Boost, direction: 'out', name: 'TARGET' },
+            roleToGrant: { model: Role, direction: 'out', name: 'ROLE_TO_GRANT' },
+        },
+    },
+    neogma
+);
+
+export default ClaimHook;

--- a/services/learn-card-network/brain-service/src/models/index.ts
+++ b/services/learn-card-network/brain-service/src/models/index.ts
@@ -63,6 +63,7 @@ Presentation.addRelationships({
 export * from './Role';
 export * from './Boost';
 export * from './Profile';
+export * from './ClaimHook';
 export * from './Credential';
 export * from './Presentation';
 export * from './ProfileManager';

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -83,11 +83,7 @@ import {
 } from '@cache/claim-links';
 import { getBlockedAndBlockedByIds, isRelationshipBlocked } from '@helpers/connection.helpers';
 import { getDidWeb, getManagedDidWeb } from '@helpers/did.helpers';
-import {
-    giveProfileEmptyPermissions,
-    setBoostAsParent,
-    setProfileAsBoostAdmin,
-} from '@accesslayer/boost/relationships/create';
+import { setBoostAsParent, setProfileAsBoostAdmin } from '@accesslayer/boost/relationships/create';
 import {
     removeBoostAsParent,
     removeProfileAsBoostAdmin,
@@ -1271,9 +1267,8 @@ export const boostsRouter = t.router({
                 });
             }
 
-            const currentPermissions = await getBoostPermissions(boost, otherProfile);
-
-            if (!currentPermissions) await giveProfileEmptyPermissions(otherProfile, boost);
+            // Ensure that there is at least an empty permissions relationship
+            await getBoostPermissions(boost, otherProfile, true);
 
             const newPermissions = Object.entries(updates).reduce<Partial<BoostPermissions>>(
                 (newPermissionsObject, [permission, value]) => {
@@ -1580,4 +1575,5 @@ export const boostsRouter = t.router({
             return removeBoostAsParent(parentBoost, childBoost);
         }),
 });
+
 export type BoostsRouter = typeof boostsRouter;

--- a/services/learn-card-network/brain-service/src/routes/claim-hooks.ts
+++ b/services/learn-card-network/brain-service/src/routes/claim-hooks.ts
@@ -1,0 +1,207 @@
+import { z } from 'zod';
+
+import {
+    ClaimHookQueryValidator,
+    ClaimHookValidator,
+    PaginatedClaimHooksValidator,
+    PaginationOptionsValidator,
+} from '@learncard/types';
+
+import { t, profileRoute } from '@routes';
+
+import { TRPCError } from '@trpc/server';
+import { getBoostByUri } from '@accesslayer/boost/read';
+import { getBoostPermissions, isProfileBoostAdmin } from '@accesslayer/boost/relationships/read';
+import { createClaimHook } from '@accesslayer/claim-hook/create';
+import {
+    addClaimHookForBoost,
+    addClaimHookTarget,
+    addRoleToGrantForClaimHook,
+} from '@accesslayer/claim-hook/relationships/create';
+import { createRole } from '@accesslayer/role/create';
+import { getClaimHookById, getClaimHooksForBoost } from '@accesslayer/claim-hook/read';
+import { deleteClaimHook } from '@accesslayer/claim-hook/delete';
+import { getClaimBoostForClaimHook } from '@accesslayer/claim-hook/relationships/read';
+
+export const claimHooksRouter = t.router({
+    createClaimHook: profileRoute
+        .meta({
+            openapi: {
+                protect: true,
+                method: 'POST',
+                path: '/claim-hook/create',
+                tags: ['Claim Hooks'],
+                summary: 'Creates a claim hook',
+                description:
+                    'This route creates a claim hook. Claim hooks are an atomic action that will be performed when a boost is claimed',
+            },
+        })
+        .input(z.object({ hook: ClaimHookValidator }))
+        .output(z.string())
+        .mutation(async ({ input, ctx }) => {
+            const { profile } = ctx.user;
+            const { hook } = input;
+
+            if (hook.type === 'GRANT_PERMISSIONS') {
+                const {
+                    data: { claimUri, targetUri, permissions: claimPermissions },
+                    type,
+                } = hook;
+                const claimBoost = await getBoostByUri(claimUri);
+                const targetBoost = await getBoostByUri(targetUri);
+
+                if (!claimBoost) {
+                    throw new TRPCError({
+                        code: 'NOT_FOUND',
+                        message: 'Could not find claim boost',
+                    });
+                }
+
+                if (!targetBoost) {
+                    throw new TRPCError({
+                        code: 'NOT_FOUND',
+                        message: 'Could not find target boost',
+                    });
+                }
+
+                if (!(await isProfileBoostAdmin(profile, claimBoost))) {
+                    throw new TRPCError({
+                        code: 'UNAUTHORIZED',
+                        message: 'Profile does not have admin rights over claim boost',
+                    });
+                }
+
+                const permissions = await getBoostPermissions(targetBoost, profile);
+
+                if (!permissions.canManagePermissions) {
+                    throw new TRPCError({
+                        code: 'UNAUTHORIZED',
+                        message: 'Profile does not have permission to create this Claim Hook',
+                    });
+                }
+
+                for (let permission in claimPermissions) {
+                    if (
+                        permission !== 'role' &&
+                        !permissions[permission as keyof typeof permissions]
+                    ) {
+                        throw new TRPCError({
+                            code: 'UNAUTHORIZED',
+                            message: `Profile does not have permission to create a GRANT_PERMISSIONS Claim Hook with permission ${permission}`,
+                        });
+                    }
+                }
+
+                const claimHook = await createClaimHook({ type });
+
+                await Promise.all([
+                    createRole(claimPermissions).then(role =>
+                        addRoleToGrantForClaimHook(claimHook, role)
+                    ),
+                    addClaimHookForBoost(claimBoost, claimHook),
+                    addClaimHookTarget(targetBoost, claimHook),
+                ]);
+
+                return claimHook.id;
+            }
+
+            throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message: `Unknown Claim Hook Type: ${hook.type}`,
+            });
+        }),
+
+    getClaimHooksForBoost: profileRoute
+        .meta({
+            openapi: {
+                protect: true,
+                method: 'POST',
+                path: '/claim-hook/get',
+                tags: ['Claim Hooks'],
+                summary: 'Gets Claim Hooks',
+                description: 'This route gets claim hooks attached to a given boost',
+            },
+        })
+        .input(
+            PaginationOptionsValidator.extend({
+                limit: PaginationOptionsValidator.shape.limit.default(25),
+                query: ClaimHookQueryValidator.optional(),
+                uri: z.string(),
+            })
+        )
+        .output(PaginatedClaimHooksValidator)
+        .query(async ({ ctx, input }) => {
+            const { limit, cursor, query, uri } = input;
+            const { domain } = ctx;
+
+            const boost = await getBoostByUri(uri);
+
+            if (!boost) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Could not find boost',
+                });
+            }
+
+            const records = await getClaimHooksForBoost(boost, {
+                limit: limit + 1,
+                cursor,
+                query,
+                domain,
+            });
+
+            const hasMore = records.length > limit;
+            const newCursor = records.at(hasMore ? -2 : -1)?.updatedAt;
+
+            return {
+                hasMore,
+                records: records.slice(0, limit),
+                ...(newCursor && { cursor: newCursor }),
+            };
+        }),
+
+    deleteClaimHook: profileRoute
+        .meta({
+            openapi: {
+                protect: true,
+                method: 'POST',
+                path: '/claim-hook/update',
+                tags: ['Claim Hooks'],
+                summary: 'Delete a Claim Hook',
+                description: 'This route deletes a claim hook',
+            },
+        })
+        .input(z.object({ id: z.string() }))
+        .output(z.boolean())
+        .mutation(async ({ input, ctx }) => {
+            const { profile } = ctx.user;
+            const { id } = input;
+
+            const claimHook = await getClaimHookById(id);
+
+            if (!claimHook) {
+                throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find Claim Hook' });
+            }
+
+            const claimBoost = await getClaimBoostForClaimHook(claimHook);
+
+            if (!claimBoost) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Could not find Claim Boost for Claim Hook for permissions check...',
+                });
+            }
+
+            if (!(await isProfileBoostAdmin(profile, claimBoost))) {
+                throw new TRPCError({
+                    code: 'UNAUTHORIZED',
+                    message: 'Profile does not have admin rights over claim boost',
+                });
+            }
+
+            await deleteClaimHook(claimHook);
+
+            return true;
+        }),
+});
+export type ClaimHooksRouter = typeof claimHooksRouter;

--- a/services/learn-card-network/brain-service/src/types/claim-hook.ts
+++ b/services/learn-card-network/brain-service/src/types/claim-hook.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { ClaimHookTypeValidator } from '@learncard/types';
+
+export const ClaimHookValidator = z.object({
+    id: z.string(),
+    type: ClaimHookTypeValidator,
+    createdAt: z.string(),
+    updatedAt: z.string(),
+});
+export type ClaimHook = z.infer<typeof ClaimHookValidator>;

--- a/services/learn-card-network/brain-service/test/claim-hooks.spec.ts
+++ b/services/learn-card-network/brain-service/test/claim-hooks.spec.ts
@@ -1,0 +1,356 @@
+import { getClient, getUser } from './helpers/getClient';
+import { sendBoost, testUnsignedBoost } from './helpers/send';
+import { Profile, Credential, Boost, ClaimHook, Role } from '@models';
+
+const noAuthClient = getClient();
+let userA: Awaited<ReturnType<typeof getUser>>;
+let userB: Awaited<ReturnType<typeof getUser>>;
+let userC: Awaited<ReturnType<typeof getUser>>;
+let userD: Awaited<ReturnType<typeof getUser>>;
+let userE: Awaited<ReturnType<typeof getUser>>;
+
+describe('Claim Hooks', () => {
+    beforeAll(async () => {
+        userA = await getUser();
+        userB = await getUser('b'.repeat(64));
+        userC = await getUser('c'.repeat(64));
+        userD = await getUser('d'.repeat(64));
+        userE = await getUser('e'.repeat(64));
+    });
+
+    describe('createClaimhook', () => {
+        let claimUri: string;
+        let targetUri: string;
+
+        beforeEach(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+            await ClaimHook.delete({ detach: true, where: {} });
+            await Role.delete({ detach: true, where: {} });
+
+            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+            claimUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+            targetUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+        });
+
+        afterAll(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+        });
+
+        it('should not allow you to create a Claim Hook without full auth', async () => {
+            await expect(
+                noAuthClient.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).rejects.toMatchObject({
+                code: 'UNAUTHORIZED',
+            });
+            await expect(
+                userA.clients.partialAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        it('should allow you to create a Claim Hook', async () => {
+            await expect(
+                userA.clients.fullAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).resolves.not.toThrow();
+        });
+
+        it('should run the claim hook when claiming the claim boost', async () => {
+            await userA.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            });
+
+            const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+                uri: targetUri,
+            });
+
+            expect(oldPermissions.canIssue).toBeFalsy();
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                claimUri,
+                true
+            );
+
+            const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+                uri: targetUri,
+            });
+
+            expect(newPermissions.canIssue).toBeTruthy();
+        });
+
+        it('should only allow admins to create claim hooks', async () => {
+            await userA.clients.fullAuth.boost.addBoostAdmin({
+                profileId: 'userb',
+                uri: targetUri,
+            });
+
+            await expect(
+                userB.clients.fullAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+            await userA.clients.fullAuth.boost.addBoostAdmin({ profileId: 'userb', uri: claimUri });
+
+            await expect(
+                userB.clients.fullAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).resolves.not.toThrow();
+        });
+
+        it('should restrict grantable permissions based on the users permissions', async () => {
+            await userA.clients.fullAuth.boost.addBoostAdmin({
+                profileId: 'userb',
+                uri: claimUri,
+            });
+
+            await expect(
+                userB.clients.fullAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+            await userA.clients.fullAuth.boost.updateOtherBoostPermissions({
+                profileId: 'userb',
+                uri: targetUri,
+                updates: { canIssue: true, canManagePermissions: true },
+            });
+
+            await expect(
+                userB.clients.fullAuth.claimHook.createClaimHook({
+                    hook: {
+                        type: 'GRANT_PERMISSIONS',
+                        data: {
+                            claimUri,
+                            targetUri,
+                            permissions: { canIssue: true },
+                        },
+                    },
+                })
+            ).resolves.not.toThrow();
+        });
+    });
+
+    describe('getClaimHooksForBoost', () => {
+        let claimUri: string;
+        let targetUri: string;
+        let hookId: string;
+
+        beforeEach(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+            await ClaimHook.delete({ detach: true, where: {} });
+            await Role.delete({ detach: true, where: {} });
+
+            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+            claimUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+            targetUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            });
+        });
+
+        afterAll(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+        });
+
+        it('should not allow you to get Claim Hooks without full auth', async () => {
+            await expect(
+                noAuthClient.claimHook.getClaimHooksForBoost({ uri: claimUri })
+            ).rejects.toMatchObject({
+                code: 'UNAUTHORIZED',
+            });
+            await expect(
+                userA.clients.partialAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        it('should allow you to get Claim Hooks', async () => {
+            await expect(
+                userA.clients.fullAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
+            ).resolves.not.toThrow();
+        });
+
+        it('should return full info about claim hooks', async () => {
+            const hooks = await userA.clients.fullAuth.claimHook.getClaimHooksForBoost({
+                uri: claimUri,
+            });
+
+            expect(hooks.records).toHaveLength(1);
+
+            const hook = hooks.records[0]!;
+
+            expect(hook.id).toEqual(hookId);
+            expect(hook.type).toEqual('GRANT_PERMISSIONS');
+            expect(hook.createdAt).toBeDefined();
+            expect(hook.updatedAt).toBeDefined();
+            expect(hook.data.claimUri).toEqual(claimUri);
+            expect(hook.data.targetUri).toEqual(targetUri);
+            expect(hook.data.permissions.canIssue).toBeTruthy();
+        });
+    });
+
+    describe('deleteClaimHook', () => {
+        let claimUri: string;
+        let targetUri: string;
+        let hookId: string;
+
+        beforeEach(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+            await ClaimHook.delete({ detach: true, where: {} });
+            await Role.delete({ detach: true, where: {} });
+
+            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+            claimUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+            targetUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            });
+        });
+
+        afterAll(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+        });
+
+        it('should not allow you to delete Claim Hooks without full auth', async () => {
+            await expect(
+                noAuthClient.claimHook.deleteClaimHook({ id: hookId })
+            ).rejects.toMatchObject({
+                code: 'UNAUTHORIZED',
+            });
+            await expect(
+                userA.clients.partialAuth.claimHook.deleteClaimHook({ id: hookId })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        it('should allow you to delete Claim Hooks', async () => {
+            await expect(
+                userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId })
+            ).resolves.not.toThrow();
+        });
+
+        it('should stop updating permissions when deleted', async () => {
+            const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+                uri: targetUri,
+            });
+
+            await userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId });
+
+            expect(oldPermissions.canIssue).toBeFalsy();
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                claimUri,
+                true
+            );
+
+            const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+                uri: targetUri,
+            });
+
+            expect(newPermissions.canIssue).toBeFalsy();
+        });
+    });
+});

--- a/tests/e2e/tests/claim-hooks.spec.ts
+++ b/tests/e2e/tests/claim-hooks.spec.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'vitest';
+
+import { NetworkLearnCardFromSeed } from '@learncard/init';
+
+import { getLearnCardForUser, USERS } from './helpers/learncard.helpers';
+import { testUnsignedBoost } from './helpers/credential.helpers';
+
+let a: NetworkLearnCardFromSeed['returnValue'];
+let b: NetworkLearnCardFromSeed['returnValue'];
+let c: NetworkLearnCardFromSeed['returnValue'];
+
+describe('Claim Hooks', () => {
+    let claimUri: string;
+    let targetUri: string;
+
+    beforeEach(async () => {
+        a = await getLearnCardForUser('a');
+        b = await getLearnCardForUser('b');
+        c = await getLearnCardForUser('c');
+
+        claimUri = await a.invoke.createBoost(testUnsignedBoost);
+        targetUri = await a.invoke.createBoost(testUnsignedBoost);
+    });
+
+    test('Users can create claim hooks that automatically update permissions for different boosts', async () => {
+        await a.invoke.createClaimHook({
+            type: 'GRANT_PERMISSIONS',
+            data: {
+                claimUri,
+                targetUri,
+                permissions: { canIssue: true },
+            },
+        });
+
+        const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+        expect(oldPermissions.canIssue).toBeFalsy();
+
+        const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+        await b.invoke.acceptCredential(sentUri);
+
+        const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+        expect(newPermissions.canIssue).toBeTruthy();
+    });
+
+    test("Claim Hooks stop updating permissions after they're deleted", async () => {
+        const claimHookUri = await a.invoke.createClaimHook({
+            type: 'GRANT_PERMISSIONS',
+            data: {
+                claimUri,
+                targetUri,
+                permissions: { canIssue: true },
+            },
+        });
+
+        const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+        expect(oldPermissions.canIssue).toBeFalsy();
+
+        await a.invoke.deleteClaimHook(claimHookUri);
+
+        const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+        await b.invoke.acceptCredential(sentUri);
+
+        const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+        expect(newPermissions.canIssue).toBeFalsy();
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
[LC-740] Leader Merit Badge Permissions Bug?
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
In order to facilitate proper permissions for scouts, we need a way to update someone's permissions for a
different boost up the parent tree when claiming a child boost

#### 🥴 TL; RL:
Adds Claim Hooks that allow you to update permissions for an arbitrary boost when claiming a boost

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- New node: `ClaimHook`
- New relationships: `hookFor`, `target`, `roleToGrant`
    - `(c: ClaimHook)-[:HOOK_FOR]->(b:Boost)`
    - `(c: ClaimHook)-[:TARGET]->(b:Boost)`
    - `(c: ClaimHook)-[:ROLE_TO_GRANT]->(r:Role)`
- New router: `claimHook`
    - New routes `createClaimHook`, `getClaimHooksForBoost`, `deleteClaimHook`
        - `createClaimHook(input: { hook: ClaimHook }) => string`
            - Creates a claim hook attached to a specified boost, returning the URI of the new claim hook
        - `getClaimHooksForBoost(input: { uri: string; query?: ClaimHookQuery; ...paginationOptions }) => PaginatedClaimHooks`
            - Gets all claim hooks attached to a given boost
        - `deleteClaimHook(input: { uri: string }) => boolean`
            - Deletes a claim hook by passing in its URI
- New plugin methods: `createClaimHook`, `getClaimHooksForBoost`, `deleteClaimHook` 
    - See above routes
- Claim Hooks are made to be extensible so that in the future we can easily add more types of claim hooks for arbitrary stuff to happen when claiming a boost
- There is a permissions check so you can only make a claim hook that grants permissions that you yourself are allowed to grant

#### 🛠 Important tradeoffs made:
I wanted to write more tests for things like pagination, same claim/target, multiple claim hooks, etc, but I didn't because I wanted to get this out faster!

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
Run the network test suite, as well as E2E tests!
```bash
cd services/learn-card-network/brain-service
pnpm test
```

```bash
cd tests/e2e
pnpm test:e2e
```
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote tests for the basic lifecycle of claim hooks both in the service directly, as well as E2E

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
