### PR TITLE
LC-815 - Skip Notification 

### DIFF
--- a/.changeset/purple-beers-retire.md
+++ b/.changeset/purple-beers-retire.md
@@ -1,0 +1,6 @@
+---
+"@learncard/network-plugin": patch
+"@learncard/network-brain-service": patch
+---
+
+LC-815 - Skip Notification 

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -602,7 +602,12 @@ export const getLearnCardNetworkPlugin = async (
 
                 return client.boost.deleteBoost.mutate({ uri });
             },
-            sendBoost: async (_learnCard, profileId, boostUri, options = { encrypt: true }) => {
+            sendBoost: async (
+                _learnCard,
+                profileId,
+                boostUri,
+                options = { encrypt: true, skipNotification: false }
+            ) => {
                 if (!userData) throw new Error('Please make an account first!');
 
                 const result = await _learnCard.invoke.resolveFromLCN(boostUri);
@@ -643,6 +648,10 @@ export const getLearnCardNetworkPlugin = async (
                         profileId,
                         uri: boostUri,
                         credential: vc,
+                        options: {
+                            skipNotification:
+                                typeof options === 'object' && options.skipNotification,
+                        },
                     });
                 }
 
@@ -652,7 +661,14 @@ export const getLearnCardNetworkPlugin = async (
                     .getDIDObject()
                     .createDagJWE(vc, [userData.did, targetProfile.did, lcnDid]);
 
-                return client.boost.sendBoost.mutate({ profileId, uri: boostUri, credential });
+                return client.boost.sendBoost.mutate({
+                    profileId,
+                    uri: boostUri,
+                    credential,
+                    options: {
+                        skipNotification: typeof options === 'object' && options.skipNotification,
+                    },
+                });
             },
 
             registerSigningAuthority: async (_learnCard, endpoint, name, _did) => {

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -237,7 +237,13 @@ export type LearnCardNetworkPluginMethods = {
     sendBoost: (
         profileId: string,
         boostUri: string,
-        options?: boolean | { encrypt?: boolean; overideFn?: (boost: UnsignedVC) => UnsignedVC }
+        options?:
+            | boolean
+            | {
+                  encrypt?: boolean;
+                  overideFn?: (boost: UnsignedVC) => UnsignedVC;
+                  skipNotification?: boolean;
+              }
     ) => Promise<string>;
 
     registerSigningAuthority: (endpoint: string, name: string, did: string) => Promise<boolean>;

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -111,12 +111,17 @@ export const boostsRouter = t.router({
                 profileId: z.string(),
                 uri: z.string(),
                 credential: VCValidator.or(JWEValidator),
+                options: z
+                    .object({
+                        skipNotification: z.boolean().default(false).optional(),
+                    })
+                    .optional(),
             })
         )
         .output(z.string())
         .mutation(async ({ ctx, input }) => {
             const { profile } = ctx.user;
-            const { profileId, credential, uri } = input;
+            const { profileId, credential, uri, options } = input;
 
             if (process.env.NODE_ENV !== 'test') {
                 console.log('🚀 BEGIN - Send Boost', JSON.stringify(input));
@@ -150,13 +155,16 @@ export const boostsRouter = t.router({
                 });
             }
 
+            let skipNotification = profile.profileId === targetProfile.profileId;
+            if (options?.skipNotification) skipNotification = options?.skipNotification;
+
             return sendBoost(
                 profile,
                 targetProfile,
                 boost,
                 credential,
                 ctx.domain,
-                profile.profileId === targetProfile.profileId
+                skipNotification
             );
         }),
 


### PR DESCRIPTION
# Overview

**[CHECKOUT THIS BRANCH](https://github.com/WeLibraryOS/learncardapp/pull/680)**

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

[LC-815](https://welibrary.atlassian.net/browse/LC-815)

#### 📚 What is the context and goal of this PR?

Currently, when a child is added to a family, they receive a credential that is immediately claimed. However, a notification is also sent when the credential is issued. If the user views this notification and clicks "Claim," they end up with duplicate credentials.

This PR resolves the issue by suppressing the notification when a child is added to a family, preventing unnecessary duplicate claims.

1. updates `sendBoost` route, adds `options` to the `input` parameter

```javascript

.input(
   z.object({
      ...
      options: z
         .object({
            skipNotification: z.boolean().default(false).optional(),
          }).optional(),
       })
)
```


#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [X] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

1. Run LearnCardApp with docker
2. Connect to LearnCard locally thru Lib in the LearnCardApp repo & [checkout this branch](https://github.com/WeLibraryOS/learncardapp/pull/680)

```json

"@learncard/ceramic-plugin": "link:./lib/LearnCard/packages/plugins/ceramic",
"@learncard/chapi-plugin": "link:./lib/LearnCard/packages/plugins/chapi",
"@learncard/core": "link:./lib/LearnCard/packages/learn-card-core",
"@learncard/did-web-plugin": "link:./lib/LearnCard/packages/plugins/did-web-plugin",
"@learncard/didkit-plugin": "link:./lib/LearnCard/packages/plugins/didkit",
"@learncard/init": "link:./lib/LearnCard/packages/learn-card-init",
"@learncard/network-plugin": "link:./lib/LearnCard/packages/plugins/learn-card-network",
"@learncard/react": "link:./lib/LearnCard/packages/react-learn-card",
"@learncard/types": "link:./lib/LearnCard/packages/learn-card-types",

```

3. Create a family with at least 1 child 
4. Switch to the child account 
   - confirm you have a family credential 
   - confirm you are not sent a notification 

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [X] My code follows **style guidelines** (eslint / prettier)
- [X] I have **manually tested** common end-2-end cases
- [X] I have **reviewed** my code
- [X] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [X] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [X] Code is backwards compatible
- [X] There is **not** a "Do Not Merge" label on this PR
- [X] I have thoughtfully considered the security implications of this change.
- [X] This change does not expose new public facing endpoints that do not have authentication
