### PR TITLE
[LC-796] ADD_ADMIN Claim Hook

### DIFF
--- a/.changeset/twelve-buses-cover.md
+++ b/.changeset/twelve-buses-cover.md
@@ -1,0 +1,7 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/types': patch
+'@learncard/network-plugin': patch
+---
+
+Add ADD_ADMIN Claim Hook

--- a/.changeset/twelve-buses-cover.md
+++ b/.changeset/twelve-buses-cover.md
@@ -4,4 +4,9 @@
 '@learncard/network-plugin': patch
 ---
 
-Add ADD_ADMIN Claim Hook
+Add ADD_ADMIN Claim Hook type that automatically grants admin privileges when claiming a boost. This enables:
+
+- Automatic admin role assignment for target boosts when claiming a source boost
+- Requires admin permissions on both source and target boosts to create hook
+- Cascading deletion when either boost is removed
+- Validation of admin permissions hierarchy during hook creation

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ node_modules
 *.sw?
 
 .nx-cache/
+.aider*

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -146,7 +146,7 @@ export const BoostPermissionsQueryValidator = z
     .partial();
 export type BoostPermissionsQuery = z.infer<typeof BoostPermissionsQueryValidator>;
 
-export const ClaimHookTypeValidator = z.enum(['GRANT_PERMISSIONS']);
+export const ClaimHookTypeValidator = z.enum(['GRANT_PERMISSIONS', 'ADD_ADMIN']);
 export type ClaimHookType = z.infer<typeof ClaimHookTypeValidator>;
 
 export const ClaimHookValidator = z.discriminatedUnion('type', [
@@ -157,6 +157,10 @@ export const ClaimHookValidator = z.discriminatedUnion('type', [
             targetUri: z.string(),
             permissions: BoostPermissionsValidator.partial(),
         }),
+    }),
+    z.object({
+        type: z.literal(ClaimHookTypeValidator.Values.ADD_ADMIN),
+        data: z.object({ claimUri: z.string(), targetUri: z.string() }),
     }),
 ]);
 export type ClaimHook = z.infer<typeof ClaimHookValidator>;

--- a/services/learn-card-network/brain-service/src/helpers/claim-hooks.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/claim-hooks.helpers.ts
@@ -3,8 +3,9 @@ import { QueryBuilder } from 'neogma';
 import { CredentialInstance, Credential, Boost, Profile, ClaimHook, Role } from '@models';
 import { ProfileType } from 'types/profile';
 import { clearDidWebCacheForChildProfileManagers } from '@accesslayer/boost/relationships/update';
+import { getAdminRole } from '@accesslayer/role/read';
 
-export const processClaimHooks = async (
+const processPermissionsClaimHooks = async (
     profile: ProfileType,
     credential: CredentialInstance
 ): Promise<void> => {
@@ -19,7 +20,7 @@ export const processClaimHooks = async (
                 },
                 { identifier: 'boost', model: Boost },
                 { ...ClaimHook.getRelationshipByAlias('hookFor'), direction: 'in' },
-                { identifier: 'claimHook', model: ClaimHook },
+                { identifier: 'claimHook', model: ClaimHook, where: { type: 'GRANT_PERMISSIONS' } },
                 ClaimHook.getRelationshipByAlias('target'),
                 { identifier: 'targetBoost', model: Boost },
             ],
@@ -42,6 +43,55 @@ export const processClaimHooks = async (
             ],
         })
         .run();
+};
+
+const processAdminClaimHooks = async (
+    profile: ProfileType,
+    credential: CredentialInstance
+): Promise<void> => {
+    const adminRole = await getAdminRole();
+    await new QueryBuilder()
+
+        .match({
+            related: [
+                { identifier: 'credential', model: Credential, where: { id: credential.id } },
+                {
+                    ...Credential.getRelationshipByAlias('instanceOf'),
+                    identifier: 'instanceOf',
+                    direction: 'out',
+                },
+                { identifier: 'boost', model: Boost },
+                { ...ClaimHook.getRelationshipByAlias('hookFor'), direction: 'in' },
+                { identifier: 'claimHook', model: ClaimHook, where: { type: 'ADD_ADMIN' } },
+                ClaimHook.getRelationshipByAlias('target'),
+                { identifier: 'targetBoost', model: Boost },
+            ],
+        })
+        .with('boost, claimHook, targetBoost')
+        .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })
+        .with('claimHook, targetBoost, profile')
+        .create({
+            related: [
+                { identifier: 'profile' },
+                {
+                    ...Boost.getRelationshipByAlias('hasRole'),
+                    properties: { roleId: adminRole.id },
+                    direction: 'out',
+                },
+                { identifier: 'targetBoost' },
+            ],
+        })
+        .run();
+};
+
+export const processClaimHooks = async (
+    profile: ProfileType,
+    credential: CredentialInstance
+): Promise<void> => {
+    await Promise.all([
+        processPermissionsClaimHooks(profile, credential),
+        processAdminClaimHooks(profile, credential),
+    ]);
 
     try {
         const vc = JSON.parse(credential.credential);

--- a/services/learn-card-network/brain-service/src/routes/claim-hooks.ts
+++ b/services/learn-card-network/brain-service/src/routes/claim-hooks.ts
@@ -105,9 +105,55 @@ export const claimHooksRouter = t.router({
                 return claimHook.id;
             }
 
+            if (hook.type === 'ADD_ADMIN') {
+                const {
+                    data: { claimUri, targetUri },
+                    type,
+                } = hook;
+                const claimBoost = await getBoostByUri(claimUri);
+                const targetBoost = await getBoostByUri(targetUri);
+
+                if (!claimBoost) {
+                    throw new TRPCError({
+                        code: 'NOT_FOUND',
+                        message: 'Could not find claim boost',
+                    });
+                }
+
+                if (!targetBoost) {
+                    throw new TRPCError({
+                        code: 'NOT_FOUND',
+                        message: 'Could not find target boost',
+                    });
+                }
+
+                if (!(await isProfileBoostAdmin(profile, claimBoost))) {
+                    throw new TRPCError({
+                        code: 'UNAUTHORIZED',
+                        message: 'Profile does not have admin rights over claim boost',
+                    });
+                }
+
+                if (!(await isProfileBoostAdmin(profile, targetBoost))) {
+                    throw new TRPCError({
+                        code: 'UNAUTHORIZED',
+                        message: 'Profile does not have permission to create this Claim Hook',
+                    });
+                }
+
+                const claimHook = await createClaimHook({ type });
+
+                await Promise.all([
+                    addClaimHookForBoost(claimBoost, claimHook),
+                    addClaimHookTarget(targetBoost, claimHook),
+                ]);
+
+                return claimHook.id;
+            }
+
             throw new TRPCError({
                 code: 'BAD_REQUEST',
-                message: `Unknown Claim Hook Type: ${hook.type}`,
+                message: `Unknown Claim Hook Type: ${(hook as any).type}`,
             });
         }),
 

--- a/services/learn-card-network/brain-service/test/claim-hooks.spec.ts
+++ b/services/learn-card-network/brain-service/test/claim-hooks.spec.ts
@@ -18,208 +18,36 @@ describe('Claim Hooks', () => {
         userE = await getUser('e'.repeat(64));
     });
 
-    describe('createClaimhook', () => {
-        let claimUri: string;
-        let targetUri: string;
+    let claimUri: string;
+    let targetUri: string;
 
-        beforeEach(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
-            await ClaimHook.delete({ detach: true, where: {} });
-            await Role.delete({ detach: true, where: {} });
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await ClaimHook.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
 
-            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
-            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+        await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+        await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
 
-            claimUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
-            targetUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
+        claimUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
         });
-
-        afterAll(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
-        });
-
-        it('should not allow you to create a Claim Hook without full auth', async () => {
-            await expect(
-                noAuthClient.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).rejects.toMatchObject({
-                code: 'UNAUTHORIZED',
-            });
-            await expect(
-                userA.clients.partialAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-        });
-
-        it('should allow you to create a Claim Hook', async () => {
-            await expect(
-                userA.clients.fullAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).resolves.not.toThrow();
-        });
-
-        it('should run the claim hook when claiming the claim boost', async () => {
-            await userA.clients.fullAuth.claimHook.createClaimHook({
-                hook: {
-                    type: 'GRANT_PERMISSIONS',
-                    data: {
-                        claimUri,
-                        targetUri,
-                        permissions: { canIssue: true },
-                    },
-                },
-            });
-
-            const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
-                uri: targetUri,
-            });
-
-            expect(oldPermissions.canIssue).toBeFalsy();
-
-            await sendBoost(
-                { profileId: 'usera', user: userA },
-                { profileId: 'userb', user: userB },
-                claimUri,
-                true
-            );
-
-            const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
-                uri: targetUri,
-            });
-
-            expect(newPermissions.canIssue).toBeTruthy();
-        });
-
-        it('should only allow admins to create claim hooks', async () => {
-            await userA.clients.fullAuth.boost.addBoostAdmin({
-                profileId: 'userb',
-                uri: targetUri,
-            });
-
-            await expect(
-                userB.clients.fullAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-
-            await userA.clients.fullAuth.boost.addBoostAdmin({ profileId: 'userb', uri: claimUri });
-
-            await expect(
-                userB.clients.fullAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).resolves.not.toThrow();
-        });
-
-        it('should restrict grantable permissions based on the users permissions', async () => {
-            await userA.clients.fullAuth.boost.addBoostAdmin({
-                profileId: 'userb',
-                uri: claimUri,
-            });
-
-            await expect(
-                userB.clients.fullAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-
-            await userA.clients.fullAuth.boost.updateOtherBoostPermissions({
-                profileId: 'userb',
-                uri: targetUri,
-                updates: { canIssue: true, canManagePermissions: true },
-            });
-
-            await expect(
-                userB.clients.fullAuth.claimHook.createClaimHook({
-                    hook: {
-                        type: 'GRANT_PERMISSIONS',
-                        data: {
-                            claimUri,
-                            targetUri,
-                            permissions: { canIssue: true },
-                        },
-                    },
-                })
-            ).resolves.not.toThrow();
+        targetUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
         });
     });
 
-    describe('getClaimHooksForBoost', () => {
-        let claimUri: string;
-        let targetUri: string;
-        let hookId: string;
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+    });
 
-        beforeEach(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
-            await ClaimHook.delete({ detach: true, where: {} });
-            await Role.delete({ detach: true, where: {} });
-
-            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
-            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
-
-            claimUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
-            targetUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
-
-            hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
+    it('should not allow you to create a Claim Hook without full auth', async () => {
+        await expect(
+            noAuthClient.claimHook.createClaimHook({
                 hook: {
                     type: 'GRANT_PERMISSIONS',
                     data: {
@@ -228,129 +56,345 @@ describe('Claim Hooks', () => {
                         permissions: { canIssue: true },
                     },
                 },
-            });
+            })
+        ).rejects.toMatchObject({
+            code: 'UNAUTHORIZED',
+        });
+        await expect(
+            userA.clients.partialAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+
+    it('should allow you to create a Claim Hook', async () => {
+        await expect(
+            userA.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).resolves.not.toThrow();
+    });
+
+    it('should run the claim hook when claiming the claim boost', async () => {
+        await userA.clients.fullAuth.claimHook.createClaimHook({
+            hook: {
+                type: 'GRANT_PERMISSIONS',
+                data: {
+                    claimUri,
+                    targetUri,
+                    permissions: { canIssue: true },
+                },
+            },
         });
 
-        afterAll(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
+        const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+            uri: targetUri,
         });
 
-        it('should not allow you to get Claim Hooks without full auth', async () => {
-            await expect(
-                noAuthClient.claimHook.getClaimHooksForBoost({ uri: claimUri })
-            ).rejects.toMatchObject({
-                code: 'UNAUTHORIZED',
-            });
-            await expect(
-                userA.clients.partialAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
-            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        expect(oldPermissions.canIssue).toBeFalsy();
+
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            claimUri,
+            true
+        );
+
+        const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+            uri: targetUri,
         });
 
-        it('should allow you to get Claim Hooks', async () => {
-            await expect(
-                userA.clients.fullAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
-            ).resolves.not.toThrow();
+        expect(newPermissions.canIssue).toBeTruthy();
+    });
+
+    it('should only allow admins to create claim hooks', async () => {
+        await userA.clients.fullAuth.boost.addBoostAdmin({
+            profileId: 'userb',
+            uri: targetUri,
         });
 
-        it('should return full info about claim hooks', async () => {
-            const hooks = await userA.clients.fullAuth.claimHook.getClaimHooksForBoost({
-                uri: claimUri,
-            });
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
 
-            expect(hooks.records).toHaveLength(1);
+        await userA.clients.fullAuth.boost.addBoostAdmin({
+            profileId: 'userb',
+            uri: claimUri,
+        });
 
-            const hook = hooks.records[0]!;
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).resolves.not.toThrow();
+    });
 
-            expect(hook.id).toEqual(hookId);
-            expect(hook.type).toEqual('GRANT_PERMISSIONS');
-            expect(hook.createdAt).toBeDefined();
-            expect(hook.updatedAt).toBeDefined();
-            expect(hook.data.claimUri).toEqual(claimUri);
-            expect(hook.data.targetUri).toEqual(targetUri);
-            expect(hook.data.permissions.canIssue).toBeTruthy();
+    it('should restrict grantable permissions based on the users permissions', async () => {
+        await userA.clients.fullAuth.boost.addBoostAdmin({
+            profileId: 'userb',
+            uri: claimUri,
+        });
+
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+        await userA.clients.fullAuth.boost.updateOtherBoostPermissions({
+            profileId: 'userb',
+            uri: targetUri,
+            updates: { canIssue: true, canManagePermissions: true },
+        });
+
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'GRANT_PERMISSIONS',
+                    data: {
+                        claimUri,
+                        targetUri,
+                        permissions: { canIssue: true },
+                    },
+                },
+            })
+        ).resolves.not.toThrow();
+    });
+
+    it('should only allow current admins to add admin claim hooks', async () => {
+        await userA.clients.fullAuth.boost.addBoostAdmin({ profileId: 'userb', uri: claimUri });
+
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'ADD_ADMIN',
+                    data: { claimUri, targetUri },
+                },
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+        await userA.clients.fullAuth.boost.updateOtherBoostPermissions({
+            profileId: 'userb',
+            uri: targetUri,
+            updates: { canIssue: true, canManagePermissions: true },
+        });
+
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'ADD_ADMIN',
+                    data: { claimUri, targetUri },
+                },
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+        await userA.clients.fullAuth.boost.addBoostAdmin({ profileId: 'userb', uri: targetUri });
+
+        await expect(
+            userB.clients.fullAuth.claimHook.createClaimHook({
+                hook: {
+                    type: 'ADD_ADMIN',
+                    data: { claimUri, targetUri },
+                },
+            })
+        ).resolves.not.toThrow();
+    });
+});
+
+describe('getClaimHooksForBoost', () => {
+    let claimUri: string;
+    let targetUri: string;
+    let hookId: string;
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await ClaimHook.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+
+        await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+        await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+        claimUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        targetUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+
+        hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
+            hook: {
+                type: 'GRANT_PERMISSIONS',
+                data: {
+                    claimUri,
+                    targetUri,
+                    permissions: { canIssue: true },
+                },
+            },
         });
     });
 
-    describe('deleteClaimHook', () => {
-        let claimUri: string;
-        let targetUri: string;
-        let hookId: string;
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+    });
 
-        beforeEach(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
-            await ClaimHook.delete({ detach: true, where: {} });
-            await Role.delete({ detach: true, where: {} });
+    it('should not allow you to get Claim Hooks without full auth', async () => {
+        await expect(
+            noAuthClient.claimHook.getClaimHooksForBoost({ uri: claimUri })
+        ).rejects.toMatchObject({
+            code: 'UNAUTHORIZED',
+        });
+        await expect(
+            userA.clients.partialAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
 
-            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
-            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+    it('should allow you to get Claim Hooks', async () => {
+        await expect(
+            userA.clients.fullAuth.claimHook.getClaimHooksForBoost({ uri: claimUri })
+        ).resolves.not.toThrow();
+    });
 
-            claimUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
-            targetUri = await userA.clients.fullAuth.boost.createBoost({
-                credential: testUnsignedBoost,
-            });
+    it('should return full info about claim hooks', async () => {
+        const hooks = await userA.clients.fullAuth.claimHook.getClaimHooksForBoost({
+            uri: claimUri,
+        });
 
-            hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
-                hook: {
-                    type: 'GRANT_PERMISSIONS',
-                    data: {
-                        claimUri,
-                        targetUri,
-                        permissions: { canIssue: true },
-                    },
+        expect(hooks.records).toHaveLength(1);
+
+        const hook = hooks.records[0]!;
+
+        expect(hook.id).toEqual(hookId);
+        expect(hook.type).toEqual('GRANT_PERMISSIONS');
+
+        // Annoying TS stuff...
+        if (hook.type !== 'GRANT_PERMISSIONS') {
+            throw new Error('This error should never be thrown...');
+        }
+
+        expect(hook.createdAt).toBeDefined();
+        expect(hook.updatedAt).toBeDefined();
+        expect(hook.data.claimUri).toEqual(claimUri);
+        expect(hook.data.targetUri).toEqual(targetUri);
+        expect(hook.data.permissions.canIssue).toBeTruthy();
+    });
+});
+
+describe('deleteClaimHook', () => {
+    let claimUri: string;
+    let targetUri: string;
+    let hookId: string;
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await ClaimHook.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+
+        await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+        await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+
+        claimUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        targetUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+
+        hookId = await userA.clients.fullAuth.claimHook.createClaimHook({
+            hook: {
+                type: 'GRANT_PERMISSIONS',
+                data: {
+                    claimUri,
+                    targetUri,
+                    permissions: { canIssue: true },
                 },
-            });
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+    });
+
+    it('should not allow you to delete Claim Hooks without full auth', async () => {
+        await expect(noAuthClient.claimHook.deleteClaimHook({ id: hookId })).rejects.toMatchObject({
+            code: 'UNAUTHORIZED',
+        });
+        await expect(
+            userA.clients.partialAuth.claimHook.deleteClaimHook({ id: hookId })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+
+    it('should allow you to delete Claim Hooks', async () => {
+        await expect(
+            userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId })
+        ).resolves.not.toThrow();
+    });
+
+    it('should stop updating permissions when deleted', async () => {
+        const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+            uri: targetUri,
         });
 
-        afterAll(async () => {
-            await Profile.delete({ detach: true, where: {} });
-            await Credential.delete({ detach: true, where: {} });
-            await Boost.delete({ detach: true, where: {} });
+        await userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId });
+
+        expect(oldPermissions.canIssue).toBeFalsy();
+
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            claimUri,
+            true
+        );
+
+        const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+            uri: targetUri,
         });
 
-        it('should not allow you to delete Claim Hooks without full auth', async () => {
-            await expect(
-                noAuthClient.claimHook.deleteClaimHook({ id: hookId })
-            ).rejects.toMatchObject({
-                code: 'UNAUTHORIZED',
-            });
-            await expect(
-                userA.clients.partialAuth.claimHook.deleteClaimHook({ id: hookId })
-            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-        });
-
-        it('should allow you to delete Claim Hooks', async () => {
-            await expect(
-                userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId })
-            ).resolves.not.toThrow();
-        });
-
-        it('should stop updating permissions when deleted', async () => {
-            const oldPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
-                uri: targetUri,
-            });
-
-            await userA.clients.fullAuth.claimHook.deleteClaimHook({ id: hookId });
-
-            expect(oldPermissions.canIssue).toBeFalsy();
-
-            await sendBoost(
-                { profileId: 'usera', user: userA },
-                { profileId: 'userb', user: userB },
-                claimUri,
-                true
-            );
-
-            const newPermissions = await userB.clients.fullAuth.boost.getBoostPermissions({
-                uri: targetUri,
-            });
-
-            expect(newPermissions.canIssue).toBeFalsy();
-        });
+        expect(newPermissions.canIssue).toBeFalsy();
     });
 });

--- a/tests/e2e/tests/claim-hooks.spec.ts
+++ b/tests/e2e/tests/claim-hooks.spec.ts
@@ -22,49 +22,114 @@ describe('Claim Hooks', () => {
         targetUri = await a.invoke.createBoost(testUnsignedBoost);
     });
 
-    test('Users can create claim hooks that automatically update permissions for different boosts', async () => {
-        await a.invoke.createClaimHook({
-            type: 'GRANT_PERMISSIONS',
-            data: {
-                claimUri,
-                targetUri,
-                permissions: { canIssue: true },
-            },
+    describe('GRANT_PERMISSIONS', () => {
+        test('Users can create claim hooks that automatically update permissions for different boosts', async () => {
+            await a.invoke.createClaimHook({
+                type: 'GRANT_PERMISSIONS',
+                data: {
+                    claimUri,
+                    targetUri,
+                    permissions: { canIssue: true },
+                },
+            });
+
+            const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(oldPermissions.canIssue).toBeFalsy();
+
+            const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+            await b.invoke.acceptCredential(sentUri);
+
+            const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(newPermissions.canIssue).toBeTruthy();
         });
 
-        const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+        test("Claim Hooks stop updating permissions after they're deleted", async () => {
+            const claimHookUri = await a.invoke.createClaimHook({
+                type: 'GRANT_PERMISSIONS',
+                data: {
+                    claimUri,
+                    targetUri,
+                    permissions: { canIssue: true },
+                },
+            });
 
-        expect(oldPermissions.canIssue).toBeFalsy();
+            const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
 
-        const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
-        await b.invoke.acceptCredential(sentUri);
+            expect(oldPermissions.canIssue).toBeFalsy();
 
-        const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+            await a.invoke.deleteClaimHook(claimHookUri);
 
-        expect(newPermissions.canIssue).toBeTruthy();
+            const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+            await b.invoke.acceptCredential(sentUri);
+
+            const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(newPermissions.canIssue).toBeFalsy();
+        });
     });
 
-    test("Claim Hooks stop updating permissions after they're deleted", async () => {
-        const claimHookUri = await a.invoke.createClaimHook({
-            type: 'GRANT_PERMISSIONS',
-            data: {
-                claimUri,
-                targetUri,
-                permissions: { canIssue: true },
-            },
+    describe('ADD_ADMIN', () => {
+        test('Users can create claim hooks that automatically add admins for different boosts', async () => {
+            await a.invoke.createClaimHook({
+                type: 'ADD_ADMIN',
+                data: { claimUri, targetUri },
+            });
+
+            const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(oldPermissions.canIssue).toBeFalsy();
+
+            const oldAdmins = await a.invoke.getBoostAdmins(targetUri);
+            expect(oldAdmins.records).toHaveLength(1);
+            expect(
+                oldAdmins.records.some(admin => admin.profileId === USERS.b.profileId)
+            ).toBeFalsy();
+
+            const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+            await b.invoke.acceptCredential(sentUri);
+
+            const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(newPermissions.canIssue).toBeTruthy();
+            expect(newPermissions.role).toEqual('admin');
+
+            const admins = await a.invoke.getBoostAdmins(targetUri);
+
+            expect(admins.records).toHaveLength(2);
+            expect(
+                admins.records.some(admin => admin.profileId === USERS.b.profileId)
+            ).toBeTruthy();
         });
 
-        const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+        test("Claim Hooks stop adding admins after they're deleted", async () => {
+            const claimHookUri = await a.invoke.createClaimHook({
+                type: 'ADD_ADMIN',
+                data: { claimUri, targetUri },
+            });
 
-        expect(oldPermissions.canIssue).toBeFalsy();
+            const oldPermissions = await b.invoke.getBoostPermissions(targetUri);
+            expect(oldPermissions.canIssue).toBeFalsy();
 
-        await a.invoke.deleteClaimHook(claimHookUri);
+            const oldAdmins = await a.invoke.getBoostAdmins(targetUri);
+            expect(oldAdmins.records).toHaveLength(1);
+            expect(
+                oldAdmins.records.some(admin => admin.profileId === USERS.b.profileId)
+            ).toBeFalsy();
 
-        const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
-        await b.invoke.acceptCredential(sentUri);
+            await a.invoke.deleteClaimHook(claimHookUri);
 
-        const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+            const sentUri = await a.invoke.sendBoost(USERS.b.profileId, claimUri);
+            await b.invoke.acceptCredential(sentUri);
 
-        expect(newPermissions.canIssue).toBeFalsy();
+            const newPermissions = await b.invoke.getBoostPermissions(targetUri);
+
+            expect(newPermissions.canIssue).toBeFalsy();
+
+            const admins = await a.invoke.getBoostAdmins(targetUri);
+            expect(admins.records).toHaveLength(1);
+            expect(admins.records.some(admin => admin.profileId === USERS.b.profileId)).toBeFalsy();
+        });
     });
 });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-796] On full family page: I don't see myself as a member after joining as a parent

#### 📚 What is the context and goal of this PR?
We need a way to automatically add someone as a boost admin when they claim a boost

#### 🥴 TL; RL:
Adds the `ADD_ADMIN` hook

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
(Breakdown written by Aider with Deepseek R1 😄)
Add ADD_ADMIN Claim Hook type that automatically grants admin privileges when claiming a boost. This enables:

- Automatic admin role assignment for target boosts when claiming a source boost
- Requires admin permissions on both source and target boosts to create hook
- Cascading deletion when either boost is removed
- Validation of admin permissions hierarchy during hook creation
#### 🛠 Important tradeoffs made:
None!

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run both the unit tests in the brain service and the end to end tests!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
I wrote a unit test for making sure you are an admin of both the target and claim boost, as well as end to end tests verifying what it does!

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
