### PR TITLE
LC-823 - Allow deleting live boosts + Prevent deleting boosts with children

### DIFF
--- a/.changeset/clean-clouds-push.md
+++ b/.changeset/clean-clouds-push.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+LC-823 - Allow deleting live boosts + Prevent deleting boosts with children

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -1355,11 +1355,14 @@ export const boostsRouter = t.router({
                 });
             }
 
-            if (!isDraftBoost(boost)) {
+            const childCount = await countBoostChildren(boost, {
+                query: {},
+                numberOfGenerations: 1,
+            });
+            if (childCount > 0) {
                 throw new TRPCError({
                     code: 'FORBIDDEN',
-                    message:
-                        'Published Boosts can not be deleted. Only Draft Boosts can be deleted.',
+                    message: 'Cannot delete boost with children',
                 });
             }
 

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -1739,14 +1739,36 @@ describe('Boosts', () => {
             );
         });
 
-        it('should prevent you from deleting a published boost', async () => {
+        it('should allow deleting a published boost', async () => {
             const boosts = await userA.clients.fullAuth.boost.getPaginatedBoosts();
             const boost = boosts.records[0]!;
             const uri = boost.uri;
 
             const beforeDeleteLength = (await userA.clients.fullAuth.boost.getPaginatedBoosts())
                 .records.length;
-            await expect(userA.clients.fullAuth.boost.deleteBoost({ uri })).rejects.toThrow();
+            await expect(userA.clients.fullAuth.boost.deleteBoost({ uri })).resolves.not.toThrow();
+
+            expect((await userA.clients.fullAuth.boost.getPaginatedBoosts()).records).toHaveLength(
+                beforeDeleteLength - 1
+            );
+        });
+
+        it('should not allow deleting a boost with children', async () => {
+            const boosts = await userA.clients.fullAuth.boost.getPaginatedBoosts();
+            const boost = boosts.records[0]!;
+            const uri = boost.uri;
+
+            await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri: uri,
+                boost: { credential: testVc, status: BoostStatus.enum.DRAFT },
+            });
+
+            const beforeDeleteLength = (await userA.clients.fullAuth.boost.getPaginatedBoosts())
+                .records.length;
+            await expect(userB.clients.fullAuth.boost.deleteBoost({ uri })).rejects.toMatchObject({
+                code: 'UNAUTHORIZED',
+            });
+
             expect((await userA.clients.fullAuth.boost.getPaginatedBoosts()).records).toHaveLength(
                 beforeDeleteLength
             );

--- a/tests/e2e/tests/boosts.spec.ts
+++ b/tests/e2e/tests/boosts.spec.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from 'vitest';
+
+import { getLearnCardForUser, LearnCard, USERS } from './helpers/learncard.helpers';
+
+let a: LearnCard;
+let b: LearnCard;
+
+describe('Boosts', () => {
+    beforeEach(async () => {
+        a = await getLearnCardForUser('a');
+        b = await getLearnCardForUser('b');
+    });
+
+    test('Users can create and send boosts', async () => {
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+
+        // Create a boost
+        const boostUri = await a.invoke.createBoost(unsignedVc);
+        expect(boostUri).toBeDefined();
+
+        // Get the boost
+        const boost = await a.invoke.getBoost(boostUri);
+        expect(boost).toBeDefined();
+
+        // Send the boost to another user
+        const sentBoostUri = await a.invoke.sendBoost(USERS.b.profileId, boostUri);
+        expect(sentBoostUri).toBeDefined();
+
+        // Check that user b received the boost
+        const receivedCredentials = await b.invoke.getIncomingCredentials();
+        expect(receivedCredentials.length).toBeGreaterThan(0);
+
+        // Find the received boost
+        const receivedBoost = receivedCredentials.find(cred => cred.uri === sentBoostUri);
+        expect(receivedBoost).toBeDefined();
+    });
+
+    test('Users can delete a published boost', async () => {
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+
+        // Create a boost
+        const boostUri = await a.invoke.createBoost(unsignedVc);
+        expect(boostUri).toBeDefined();
+
+        // Get all boosts before deletion
+        const boostsBefore = await a.invoke.getPaginatedBoosts();
+        const countBefore = boostsBefore.records.length;
+
+        // Delete the boost
+        const result = await a.invoke.deleteBoost(boostUri);
+        expect(result).toBeTruthy();
+
+        // Verify the boost was deleted
+        const boostsAfter = await a.invoke.getPaginatedBoosts();
+        expect(boostsAfter.records).toHaveLength(countBefore - 1);
+
+        // Trying to get the deleted boost should return undefined or fail
+        try {
+            const deletedBoost = await a.invoke.getBoost(boostUri);
+            // If getBoost doesn't throw an error, the result should be undefined
+            expect(deletedBoost).toBeUndefined();
+        } catch (error) {
+            // If getBoost throws an error, it's also acceptable
+            expect(error).toBeDefined();
+        }
+    });
+
+    test('Users cannot delete a published boost with children', async () => {
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+
+        // Create a parent boost
+        const parentBoostUri = await a.invoke.createBoost(unsignedVc);
+        expect(parentBoostUri).toBeDefined();
+
+        // Create a child boost
+        const childBoostUri = await a.invoke.createChildBoost(parentBoostUri, unsignedVc);
+        expect(childBoostUri).toBeDefined();
+
+        // Get all boosts before deletion attempt
+        const boostsBefore = await a.invoke.getPaginatedBoosts();
+        const countBefore = boostsBefore.records.length;
+
+        // Try to delete the parent boost (should fail because it has children)
+        try {
+            await a.invoke.deleteBoost(parentBoostUri);
+            // If we reach here, the test should fail because deletion should not succeed
+            expect(true).toBe(false); // This line should not be reached
+        } catch (error) {
+            // Deletion should fail with an appropriate error
+            expect(error).toBeDefined();
+        }
+
+        // Verify the parent boost was not deleted
+        const boostsAfter = await a.invoke.getPaginatedBoosts();
+        expect(boostsAfter.records).toHaveLength(countBefore);
+
+        // The parent boost should still be accessible
+        const parentBoost = await a.invoke.getBoost(parentBoostUri);
+        expect(parentBoost).toBeDefined();
+
+        // The child boost should still be accessible
+        const childBoost = await a.invoke.getBoost(childBoostUri);
+        expect(childBoost).toBeDefined();
+    });
+
+    test('Users can verify parent-child relationships between boosts', async () => {
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+
+        // Create a parent boost
+        const parentBoostUri = await a.invoke.createBoost(unsignedVc);
+
+        // Create a child boost
+        const childBoostUri = await a.invoke.createChildBoost(parentBoostUri, unsignedVc);
+
+        // Get the child boost's parents
+        const parents = await a.invoke.getBoostParents(childBoostUri);
+        expect(parents.records).toHaveLength(1);
+        expect(parents.records[0].uri).toEqual(parentBoostUri);
+
+        // Get the parent boost's children
+        const children = await a.invoke.getBoostChildren(parentBoostUri);
+        expect(children.records).toHaveLength(1);
+        expect(children.records[0].uri).toEqual(childBoostUri);
+    });
+
+    test('Users can delete a child boost without affecting the parent', async () => {
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+
+        // Create a parent boost
+        const parentBoostUri = await a.invoke.createBoost(unsignedVc);
+
+        // Create a child boost
+        const childBoostUri = await a.invoke.createChildBoost(parentBoostUri, unsignedVc);
+
+        // Get all boosts before deletion
+        const boostsBefore = await a.invoke.getPaginatedBoosts();
+        const countBefore = boostsBefore.records.length;
+
+        // Delete the child boost
+        const result = await a.invoke.deleteBoost(childBoostUri);
+        expect(result).toBeTruthy();
+
+        // Verify the child boost was deleted
+        const boostsAfter = await a.invoke.getPaginatedBoosts();
+        expect(boostsAfter.records).toHaveLength(countBefore - 1);
+
+        // The parent boost should still be accessible
+        const parentBoost = await a.invoke.getBoost(parentBoostUri);
+        expect(parentBoost).toBeDefined();
+
+        // Get the parent boost's children - should be empty
+        const children = await a.invoke.getBoostChildren(parentBoostUri);
+        expect(children.records).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

This PR enables 

1. deleting boosts that are already live
2. prevents deleting boosts with children

> 
### Note: This is only pt.1 of supporting revocation 

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [X] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [X] My code follows **style guidelines** (eslint / prettier)
- [X] I have **manually tested** common end-2-end cases
- [X] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [X] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [X] Code is backwards compatible
- [X] There is **not** a "Do Not Merge" label on this PR
- [ ] I have thoughtfully considered the security implications of this change.
- [X] This change does not expose new public facing endpoints that do not have authentication
