### PR TITLE
🚑🚨 [LC-899] Fix: URIs in HTTP routes

### DIFF
--- a/.changeset/clean-steaks-float.md
+++ b/.changeset/clean-steaks-float.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+🚑🚨 [LC-899] Fix: URIs in HTTP routes

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -215,7 +215,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/create/child/{parentUri}',
+                path: '/boost/create/child',
                 tags: ['Boosts'],
                 summary: 'Creates a boost',
                 description: 'This route creates a boost',
@@ -310,7 +310,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost',
+                path: '/boost/all',
                 tags: ['Boosts'],
                 summary: 'Get boosts',
                 deprecated: true,
@@ -402,7 +402,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/boost/recipients/{uri}',
+                path: '/boost/recipients',
                 tags: ['Boosts'],
                 summary: 'Get boost recipients',
                 deprecated: true,
@@ -443,7 +443,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/recipients/paginated/{uri}',
+                path: '/boost/recipients/paginated',
                 tags: ['Boosts'],
                 summary: 'Get boost recipients',
                 description: 'This endpoint gets the recipients of a particular boost',
@@ -491,7 +491,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/boost/recipients/{uri}/count',
+                path: '/boost/recipients/count',
                 tags: ['Boosts'],
                 summary: 'Get boost recipients count',
                 description: 'This endpoint counts the recipients of a particular boost',
@@ -516,7 +516,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/children-profile-managers/{uri}',
+                path: '/boost/children-profile-managers',
                 tags: ['Boosts', 'Profile Managers'],
                 summary: 'Get Profile Managers that are a child of a boost',
                 description: 'Get Profile Managers that are a child of a boost',
@@ -562,7 +562,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/children/{uri}',
+                path: '/boost/children',
                 tags: ['Boosts'],
                 summary: 'Get boost children',
                 description: 'This endpoint gets the children of a particular boost',
@@ -614,7 +614,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/children/{uri}/count',
+                path: '/boost/children/count',
                 tags: ['Boosts'],
                 summary: 'Count boost children',
                 description: 'This endpoint counts the children of a particular boost',
@@ -645,7 +645,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/siblings/{uri}',
+                path: '/boost/siblings',
                 tags: ['Boosts'],
                 summary: 'Get boost siblings',
                 description: 'This endpoint gets the siblings of a particular boost',
@@ -691,7 +691,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/siblings/{uri}/count',
+                path: '/boost/siblings/count',
                 tags: ['Boosts'],
                 summary: 'Count boost siblings',
                 description: 'This endpoint counts the siblings of a particular boost',
@@ -721,7 +721,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/family/{uri}',
+                path: '/boost/family',
                 tags: ['Boosts'],
                 summary: 'Get familial boosts',
                 description:
@@ -786,7 +786,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/family/{uri}/count',
+                path: '/boost/family/count',
                 tags: ['Boosts'],
                 summary: 'Count familial boosts',
                 description:
@@ -826,7 +826,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/parents/{uri}',
+                path: '/boost/parents',
                 tags: ['Boosts'],
                 summary: 'Get boost parents',
                 description: 'This endpoint gets the parents of a particular boost',
@@ -878,7 +878,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/parents/{uri}/count',
+                path: '/boost/parents/count',
                 tags: ['Boosts'],
                 summary: 'Count boost parents',
                 description: 'This endpoint counts the parents of a particular boost',
@@ -909,7 +909,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/{uri}',
+                path: '/boost',
                 tags: ['Boosts'],
                 summary: 'Update a boost',
                 description: 'This route updates a boost',
@@ -978,7 +978,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/admins/{uri}',
+                path: '/boost/admins',
                 tags: ['Boosts'],
                 summary: 'Get boost admins',
                 description: 'This route returns the admins for a boost',
@@ -1026,7 +1026,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/add-admin/{uri}',
+                path: '/boost/add-admin',
                 tags: ['Boosts'],
                 summary: 'Add a Boost admin',
                 description: 'This route adds a new admin for a boost',
@@ -1079,7 +1079,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/remove-admin/{uri}',
+                path: '/boost/remove-admin',
                 tags: ['Boosts'],
                 summary: 'Remove a Boost admin',
                 description: 'This route removes an  admin from a boost',
@@ -1138,7 +1138,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/boost/permissions/{uri}',
+                path: '/boost/permissions',
                 tags: ['Boosts'],
                 summary: 'Get boost permissions',
                 description: 'This endpoint gets permission metadata about a boost',
@@ -1169,7 +1169,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/boost/permissions/{uri}/{profileId}',
+                path: '/boost/permissions/{profileId}',
                 tags: ['Boosts'],
                 summary: 'Get boost permissions for someone else',
                 description:
@@ -1216,7 +1216,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/permissions/{uri}',
+                path: '/boost/permissions',
                 tags: ['Boosts'],
                 summary: 'Update boost permissions',
                 description:
@@ -1293,7 +1293,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/permissions/{uri}/{profileId}',
+                path: '/boost/permissions/{profileId}',
                 tags: ['Boosts'],
                 summary: "Update other profile's boost permissions",
                 description:
@@ -1382,7 +1382,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'DELETE',
-                path: '/boost/{uri}',
+                path: '/boost',
                 tags: ['Boosts'],
                 summary: 'Delete a boost',
                 description: 'This route deletes a boost',
@@ -1478,7 +1478,7 @@ export const boostsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/boost/{boostUri}/claim/{challenge}',
+                path: '/boost/claim',
                 tags: ['Boosts'],
                 summary: 'Claim a boost using a claim link',
                 description: 'Claims a boost using a claim link, including a challenge',

--- a/services/learn-card-network/brain-service/src/routes/contracts.ts
+++ b/services/learn-card-network/brain-service/src/routes/contracts.ts
@@ -185,7 +185,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/consent-flow-contract/{uri}',
+                path: '/consent-flow-contract',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Get Consent Flow Contracts',
                 description: 'Gets Consent Flow Contract Details',
@@ -286,7 +286,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'DELETE',
-                path: '/consent-flow-contract/{uri}',
+                path: '/consent-flow-contract',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Delete a Consent Flow Contract',
                 description: 'This route deletes a Consent Flow Contract',
@@ -323,7 +323,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/{uri}/data',
+                path: '/consent-flow-contract/data',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Get the data that has been consented for a contract',
                 description: 'This route grabs all the data that has been consented for a contract',
@@ -382,7 +382,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/data/{did}',
+                path: '/consent-flow-contract/data',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Get the data that has been consented by a did',
                 description: 'This route grabs all the data that has been consented by a did',
@@ -478,7 +478,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/write/{contractUri}/{did}',
+                path: '/consent-flow-contract/write',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Writes a boost credential to a did that has consented to a contract',
                 description: 'Writes a boost credential to a did that has consented to a contract',
@@ -769,7 +769,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/consent/{contractUri}',
+                path: '/consent-flow-contract/consent',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Consent To Contract',
                 description: 'Consents to a Contract with a hard set of terms',
@@ -903,7 +903,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/consent/update/{uri}',
+                path: '/consent-flow-contract/consent/update',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Updates Contract Terms',
                 description: 'Updates the terms for a consented contract',
@@ -961,7 +961,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'DELETE',
-                path: '/consent-flow-contract/consent/withdraw/{uri}',
+                path: '/consent-flow-contract/consent/withdraw',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Deletes Contract Terms',
                 description: 'Withdraws consent by deleting Contract Terms',
@@ -1002,7 +1002,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/consent/history/{uri}',
+                path: '/consent-flow-contract/consent/history',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Gets Transaction History',
                 description:
@@ -1073,7 +1073,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/consent-flow-contract/verify/{uri}',
+                path: '/consent-flow-contract/verify',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Verifies that a profile has consented to a contract',
                 description: 'Withdraws consent by deleting Contract Terms',
@@ -1110,7 +1110,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/sync/{termsUri}',
+                path: '/consent-flow-contract/sync',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Sync credentials to a contract',
                 description: 'Syncs credentials to a contract that the profile has consented to',
@@ -1206,7 +1206,7 @@ export const contractsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/consent-flow-contract/{termsUri}/credentials',
+                path: '/consent-flow-contract/credentials',
                 tags: ['Consent Flow Contracts'],
                 summary: 'Get credentials issued via a contract',
                 description: 'Gets all credentials that were issued via a contract',

--- a/services/learn-card-network/brain-service/src/routes/credentials.ts
+++ b/services/learn-card-network/brain-service/src/routes/credentials.ts
@@ -66,7 +66,7 @@ export const credentialsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/credential/accept/{uri}',
+                path: '/credential/accept',
                 tags: ['Credentials'],
                 summary: 'Accept a Credential',
                 description: 'This endpoint accepts a credential',
@@ -180,7 +180,7 @@ export const credentialsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'DELETE',
-                path: '/credential/{uri}',
+                path: '/credential',
                 tags: ['Credentials'],
                 summary: 'Delete a credential',
                 description: 'This endpoint deletes a credential',

--- a/services/learn-card-network/brain-service/src/routes/presentations.ts
+++ b/services/learn-card-network/brain-service/src/routes/presentations.ts
@@ -54,7 +54,7 @@ export const presentationsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'POST',
-                path: '/presentation/accept/{uri}',
+                path: '/presentation/accept',
                 tags: ['Presentations'],
                 summary: 'Accept a Presentation',
                 description: 'This endpoint accepts a presentation',
@@ -159,7 +159,7 @@ export const presentationsRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'DELETE',
-                path: '/presentation/{uri}',
+                path: '/presentation',
                 tags: ['Presentations'],
                 summary: 'Delete a presentation',
                 description: 'This endpoint deletes a presentation',

--- a/services/learn-card-network/brain-service/src/routes/profiles.ts
+++ b/services/learn-card-network/brain-service/src/routes/profiles.ts
@@ -1032,7 +1032,7 @@ export const profilesRouter = t.router({
             openapi: {
                 protect: true,
                 method: 'GET',
-                path: '/profile/signing-authority/get/{endpoint}/{name}',
+                path: '/profile/signing-authority/get',
                 tags: ['Profiles'],
                 summary: 'Get Signing Authority for user',
                 description:


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
[LC-899](https://welibrary.atlassian.net/browse/LC-899)

#### 📚 What is the context and goal of this PR?

This PR updates our OpenAPI HTTP endpoints to accept uri values as query parameters instead of path parameters. The goal is to ensure robust and reliable handling of resource identifiers (URIs) that may contain special characters, such as /, :, or others, which can cause issues with path-based routing and URL encoding/decoding. This change improves interoperability, reduces 404 errors, and aligns our API with best practices for handling complex identifiers.

For example, here is a request to get a ConsentFlow contract using HTTP. It returns a 404, even though this contract URI does exist (and returns correctly using tRPC):

<img width="1435" alt="Screenshot 2025-04-22 at 4 51 59 PM" src="https://github.com/user-attachments/assets/2a1f41e3-badf-473d-a767-5192c272718d" />


#### 🥴 TL; RL:

Path parameters cannot safely contain slashes (/), colons (:), or other reserved URL characters—even when encoded—because most HTTP routers split on / before decoding.

This led to 404 errors and broken endpoint behavior when URIs included slashes or similar characters.

Moving uri to a query parameter ensures the entire identifier is received and decoded correctly by the backend, eliminating these issues.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- All endpoints that previously accepted a uri as a path parameter (e.g., /boost/{uri}) now accept it as a query parameter (e.g., /boost?uri=...).
- No changes are required for tRPC or internal calls using JSON bodies.

Example request before:
```GET /api/boost/lc%3Anetwork%3Anetwork.learncard.com%2Ftrpc%3Aboost%3A...```

Example request after:
``GET /api/boost?uri=lc:network:network.learncard.com/trpc:boost:...```

All OpenAPI docs and endpoint definitions should automatically update

#### 🛠 Important tradeoffs made:

**Pros:**
- Fully supports URIs with any characters, including slashes and colons.
- Prevents 404 and routing errors due to path splitting on /.
- Simplifies client-side encoding: only a single encodeURIComponent is needed.
- Aligns with OpenAPI and REST best practices for passing complex identifiers.

**Cons:**
- Slightly less "RESTful" in terms of pure resource-oriented URLs, but this is outweighed by the practical benefits.
- Some clients or documentation may need to be updated to use query parameters instead of path parameters.


#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

- Run locally using docker compose. 
- Run CLI and connect learncard to local LCN. [Generate an API Auth Token.](https://docs.learncard.com/learn-card-sdk/learncard-network/learncard-network-api/auth-grants-and-api-tokens)
- Open up the `/docs` OpenAPI route. 
- Add API Auth token as Bearer authorization token.
- Interact with updated endpoints that previously required passing URI in path param. Use query param instead. Verify they work correctly!

#### 📱 🖥 Which devices would you like help testing on?


#### 🧪 Code Coverage
- Ideally, we should write some HTTP specific tests—which would require setting up an Auth Grant and API Token in our tests.


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [ ] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-899]: https://welibrary.atlassian.net/browse/LC-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ