### PR TITLE
[LC-894] Multiple Contract Issuers

### DIFF
--- a/.changeset/large-hairs-tap.md
+++ b/.changeset/large-hairs-tap.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Add support for adding/removing autoboosts

--- a/.changeset/smart-islands-double.md
+++ b/.changeset/smart-islands-double.md
@@ -1,0 +1,5 @@
+---
+'@learncard/learn-cloud-service': patch
+---
+
+Fix bug when trying to update a credential record with a different did that you own

--- a/.changeset/wicked-crabs-compete.md
+++ b/.changeset/wicked-crabs-compete.md
@@ -1,0 +1,7 @@
+---
+"@learncard/types": patch
+"@learncard/network-brain-service": patch
+"@workspace/e2e-tests": patch
+---
+
+[LC-894] Multiple Contract Issuers

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -318,6 +318,7 @@ export const ConsentFlowContractDetailsValidator = z.object({
     updatedAt: z.string(),
     expiresAt: z.string().optional(),
     autoBoosts: z.string().array().optional(),
+    writers: z.array(LCNProfileValidator).optional(),
 });
 export type ConsentFlowContractDetails = z.infer<typeof ConsentFlowContractDetailsValidator>;
 export type ConsentFlowContractDetailsInput = z.input<typeof ConsentFlowContractDetailsValidator>;
@@ -382,6 +383,7 @@ export const ConsentFlowTermsValidator = z.object({
             personal: z.record(z.boolean()).default({}),
         })
         .default({}),
+    deniedWriters: z.array(z.string()).optional(),
 });
 export type ConsentFlowTerms = z.infer<typeof ConsentFlowTermsValidator>;
 export type ConsentFlowTermsInput = z.input<typeof ConsentFlowTermsValidator>;

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -720,6 +720,21 @@ export const getLearnCardNetworkPlugin = async (
                 return client.contracts.createConsentFlowContract.mutate(contract);
             },
 
+            addAutoBoostsToContract: async (_learnCard, contractUri, autoboosts) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.contracts.addAutoBoostsToContract.mutate({ contractUri, autoboosts });
+            },
+
+            removeAutoBoostsFromContract: async (_learnCard, contractUri, boostUris) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.contracts.removeAutoBoostsFromContract.mutate({
+                    contractUri,
+                    boostUris,
+                });
+            },
+
             getContract: async (_learnCard, uri) => {
                 return client.contracts.getConsentFlowContract.query({ uri });
             },

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -283,8 +283,14 @@ export type LearnCardNetworkPluginMethods = {
         description?: string;
         image?: string;
         expiresAt?: string;
+        writers?: string[];
         autoboosts?: AutoBoostConfig[];
     }) => Promise<string>;
+    addAutoBoostsToContract: (
+        contractUri: string,
+        autoboosts: AutoBoostConfig[]
+    ) => Promise<boolean>;
+    removeAutoBoostsFromContract: (contractUri: string, boostUris: string[]) => Promise<boolean>;
     getContract: (uri: string) => Promise<ConsentFlowContractDetails>;
     getContracts: (
         options?: Partial<PaginationOptionsType> & { query?: ConsentFlowContractQuery }
@@ -342,7 +348,7 @@ export type LearnCardNetworkPluginMethods = {
     ) => Promise<PaginatedContractCredentials>;
 
     verifyConsent: (uri: string, profileId: string) => Promise<boolean>;
-    
+
     syncCredentialsToContract: (
         termsUri: string,
         categories: Record<string, string[]>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15584,6 +15584,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-duration@1.0.4:
     resolution: {integrity: sha512-eUXYNSY7DL53vqfTosggWkvyIW3bhAcqBDIlolgNYlZhianXTrCL50rlUJWD1eRqkIxMppXTfiFbp+9SjpPrgA==}

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/manageAutoboosts.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/manageAutoboosts.ts
@@ -1,0 +1,92 @@
+import { TRPCError } from '@trpc/server';
+import { AutoBoostConfig } from '@learncard/types';
+import { ConsentFlowContract } from '../../../models/ConsentFlowContract';
+import { QueryBuilder, BindParam } from 'neogma';
+import { getIdFromUri } from '@helpers/uri.helpers';
+import { getBoostByUri } from '@accesslayer/boost/read';
+import { getSigningAuthorityForUserByName } from '@accesslayer/signing-authority/relationships/read';
+import { ProfileType } from 'types/profile';
+import { getAutoBoostsForContract } from './read';
+import { Boost } from '@models';
+
+/**
+ * Adds multiple autoboosts to a contract, identified by its ID.
+ * Ensures the signing authority belongs to the profile performing the action (owner or writer).
+ */
+export const addAutoBoostsToContractDb = async (
+    contractId: string,
+    autoboosts: AutoBoostConfig[],
+    actorProfile: ProfileType,
+    domain: string
+): Promise<void> => {
+    const existingAutoBoosts = await getAutoBoostsForContract(contractId, domain);
+
+    await Promise.all(
+        autoboosts.map(async autoboost => {
+            if (existingAutoBoosts.includes(autoboost.boostUri)) return;
+
+            const boost = await getBoostByUri(autoboost.boostUri);
+
+            if (!boost || !boost.id) {
+                console.warn(`Boost not found or invalid for AutoBoost: ${autoboost.boostUri}`);
+                return;
+            }
+
+            // Pass actorProfile, assume underlying function handles ProfileType or expects .did
+            const saForActor = await getSigningAuthorityForUserByName(
+                actorProfile,
+                autoboost.signingAuthority.endpoint,
+                autoboost.signingAuthority.name
+            );
+
+            if (!saForActor) {
+                throw new TRPCError({
+                    code: 'FORBIDDEN',
+                    message: `Signing authority '${autoboost.signingAuthority.name}' at endpoint '${autoboost.signingAuthority.endpoint}' is not registered to the acting profile (${actorProfile.did}) or could not be found.`,
+                });
+            }
+
+            await ConsentFlowContract.relateTo({
+                alias: 'autoReceive',
+                where: { source: { id: contractId }, target: { id: boost.id } },
+                properties: {
+                    signingAuthorityEndpoint: autoboost.signingAuthority.endpoint,
+                    signingAuthorityName: autoboost.signingAuthority.name,
+                    issuer: actorProfile.profileId,
+                },
+            });
+        })
+    );
+};
+
+/**
+ * Removes specified autoboosts (by boost URI) from a contract, identified by its ID.
+ */
+export const removeAutoBoostsFromContractDb = async (
+    contractId: string,
+    boostUris: string[],
+    domain: string
+): Promise<void> => {
+    const existingAutoBoosts = await getAutoBoostsForContract(contractId, domain);
+    const urisToDelete = boostUris.filter(uri => existingAutoBoosts.includes(uri));
+    const idsToDelete = urisToDelete.map(uri => getIdFromUri(uri));
+
+    await new QueryBuilder(new BindParam({ boostIds: idsToDelete }))
+        .match({
+            related: [
+                {
+                    identifier: 'source',
+                    model: ConsentFlowContract,
+                    where: { id: contractId },
+                },
+                {
+                    ...ConsentFlowContract.getRelationshipByAlias('autoReceive'),
+                    identifier: 'autoReceive',
+                },
+                { identifier: 'target', model: Boost },
+            ],
+        })
+        .where('target.id IN $boostIds')
+        .delete({ detach: true, identifiers: ['autoReceive'] })
+        .run();
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
@@ -549,3 +549,21 @@ export const getAutoBoostsForContract = async (
 
     return results.records.map(record => getBoostUri(record.get('boost').properties.id, domain));
 };
+
+export const getWritersForContract = async (contract: DbContractType): Promise<ProfileType[]> => {
+    const results = await new QueryBuilder()
+        .match({
+            related: [
+                { identifier: 'contract', model: ConsentFlowContract, where: { id: contract.id } },
+                `-[:${ConsentFlowContract.getRelationshipByAlias('createdBy').name}|:${ConsentFlowContract.getRelationshipByAlias('canWrite').name
+                }]-`,
+                { identifier: 'profile', model: Profile },
+            ],
+        })
+        .return('profile')
+        .run();
+
+    return results.records.map(record =>
+        inflateObject<ProfileType>(record.get('profile').properties)
+    );
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/update.ts
@@ -16,6 +16,7 @@ import { getBoostUri, sendBoost } from '@helpers/boost.helpers';
 import { getDidWeb } from '@helpers/did.helpers';
 import { getSigningAuthorityForUserByName } from '@accesslayer/signing-authority/relationships/read';
 import { issueCredentialWithSigningAuthority } from '@helpers/signingAuthority.helpers';
+import { getProfileByProfileId } from '@accesslayer/profile/read';
 
 export const reconsentTerms = async (
     relationship: {
@@ -83,103 +84,112 @@ export const reconsentTerms = async (
 
     if (autoBoostsResult.length > 0) {
         // For each auto-boost, issue it to the consenter
-        for (const boostRel of autoBoostsResult) {
-            try {
-                const boost = boostRel.target;
+        await Promise.all(
+            autoBoostsResult.map(async boostRel => {
+                try {
+                    const boost = boostRel.target;
 
-                // Get the signing authority information from the relationship
-                const signingAuthorityEndpoint =
-                    boostRel.relationship?.signingAuthorityEndpoint || 'default';
-                const signingAuthorityName =
-                    boostRel.relationship?.signingAuthorityName || 'default';
+                    // Get the signing authority information from the relationship
+                    const signingAuthorityEndpoint =
+                        boostRel.relationship?.signingAuthorityEndpoint || 'default';
+                    const signingAuthorityName =
+                        boostRel.relationship?.signingAuthorityName || 'default';
 
-                // Get the contract owner's signing authority
-                const contractOwnerSigningAuthority = await getSigningAuthorityForUserByName(
-                    relationship.contractOwner,
-                    signingAuthorityEndpoint,
-                    signingAuthorityName
-                );
+                    const issuer =
+                        (boostRel.relationship?.issuer &&
+                            (await getProfileByProfileId(boostRel.relationship.issuer))) ||
+                        relationship.contractOwner;
 
-                if (!contractOwnerSigningAuthority) {
-                    console.error(
-                        `Signing authority "${signingAuthorityName}" at endpoint "${signingAuthorityEndpoint}" not found for contract owner`
+                    if (terms.deniedWriters?.includes(issuer.profileId)) return;
+
+                    // Get the contract owner's signing authority
+                    const contractOwnerSigningAuthority = await getSigningAuthorityForUserByName(
+                        issuer,
+                        signingAuthorityEndpoint,
+                        signingAuthorityName
                     );
-                    continue;
-                }
 
-                // Get boost instance
-                const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC | VC;
+                    if (!contractOwnerSigningAuthority) {
+                        console.error(
+                            `Signing authority "${signingAuthorityName}" at endpoint "${signingAuthorityEndpoint}" not found for contract owner`
+                        );
+                        return;
+                    }
 
-                // Set the issuer and subject
-                boostCredential.issuer = { id: contractOwnerSigningAuthority.relationship.did };
+                    // Get boost instance
+                    const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC | VC;
 
-                boostCredential.boostId = getBoostUri(boost.dataValues.id, domain);
+                    // Set the issuer and subject
+                    boostCredential.issuer = { id: contractOwnerSigningAuthority.relationship.did };
 
-                if (Array.isArray(boostCredential.credentialSubject)) {
-                    boostCredential.credentialSubject = boostCredential.credentialSubject.map(
-                        subject => ({
-                            ...subject,
-                            id: getDidWeb(domain, relationship.consenter.profileId),
-                        })
-                    );
-                } else {
-                    boostCredential.credentialSubject.id = getDidWeb(
+                    boostCredential.boostId = getBoostUri(boost.dataValues.id, domain);
+
+                    if (Array.isArray(boostCredential.credentialSubject)) {
+                        boostCredential.credentialSubject = boostCredential.credentialSubject.map(
+                            subject => ({
+                                ...subject,
+                                id: getDidWeb(domain, relationship.consenter.profileId),
+                            })
+                        );
+                    } else {
+                        boostCredential.credentialSubject.id = getDidWeb(
+                            domain,
+                            relationship.consenter.profileId
+                        );
+                    }
+
+                    // Issue the credential using contract owner's signing authority
+                    const vc = await issueCredentialWithSigningAuthority(
+                        issuer,
+                        boostCredential,
+                        contractOwnerSigningAuthority,
                         domain,
-                        relationship.consenter.profileId
+                        false
                     );
+
+                    // Create transaction to record the boost issuance
+                    const boostTransaction = {
+                        id: uuid(),
+                        action: 'write',
+                        date: new Date().toISOString(),
+                    } as const satisfies ConsentFlowTransactionType;
+
+                    // Create the transaction in the database
+                    await new QueryBuilder()
+                        .match({
+                            model: ConsentFlowTerms,
+                            where: { id: relationship.terms.id },
+                            identifier: 'terms',
+                        })
+                        .create({
+                            related: [
+                                {
+                                    identifier: 'boostTransaction',
+                                    model: ConsentFlowTransaction,
+                                    properties: boostTransaction,
+                                },
+                                ConsentFlowTransaction.getRelationshipByAlias('isFor'),
+                                { identifier: 'terms' },
+                            ],
+                        })
+                        .run();
+
+                    // Send the boost to the consenter
+                    await sendBoost({
+                        from: relationship.contractOwner,
+                        to: relationship.consenter,
+                        boost: boostRel.target,
+                        credential: vc,
+                        domain,
+                        skipNotification: true,
+                        autoAcceptCredential: false,
+                        contractTerms: relationship.terms,
+                    });
+                } catch (error) {
+                    console.error('Error processing auto-boost:', error);
                 }
-
-                // Issue the credential using contract owner's signing authority
-                const vc = await issueCredentialWithSigningAuthority(
-                    relationship.contractOwner,
-                    boostCredential,
-                    contractOwnerSigningAuthority,
-                    domain,
-                    false
-                );
-
-                // Create transaction to record the boost issuance
-                const boostTransaction = {
-                    id: uuid(),
-                    action: 'write',
-                    date: new Date().toISOString(),
-                } as const satisfies ConsentFlowTransactionType;
-
-                // Create the transaction in the database
-                await new QueryBuilder()
-                    .match({
-                        model: ConsentFlowTerms,
-                        where: { id: relationship.terms.id },
-                        identifier: 'terms',
-                    })
-                    .create({
-                        related: [
-                            {
-                                identifier: 'boostTransaction',
-                                model: ConsentFlowTransaction,
-                                properties: boostTransaction,
-                            },
-                            ConsentFlowTransaction.getRelationshipByAlias('isFor'),
-                            { identifier: 'terms' },
-                        ],
-                    })
-                    .run();
-
-                // Send the boost to the consenter
-                await sendBoost({
-                    from: relationship.contractOwner,
-                    to: relationship.consenter,
-                    boost: boostRel.target,
-                    credential: vc,
-                    domain,
-                    skipNotification: true,
-                    autoAcceptCredential: false,
-                    contractTerms: relationship.terms,
-                });
-            } catch (error) {
-                console.error('Error processing auto-boost:', error);
-            }
-        }
+            })
+        );
     }
 
     await addNotificationToQueue({
@@ -269,100 +279,110 @@ export const updateTerms = async (
 
     if (autoBoosts.length > 0) {
         // For each auto-boost, issue it to the consenter
-        for (const boost of autoBoosts) {
-            try {
-                // Get the signing authority information from the relationship
-                const signingAuthorityEndpoint =
-                    boost.relationship?.signingAuthorityEndpoint || 'default';
-                const signingAuthorityName = boost.relationship?.signingAuthorityName || 'default';
+        await Promise.all(
+            autoBoosts.map(async boost => {
+                try {
+                    // Get the signing authority information from the relationship
+                    const signingAuthorityEndpoint =
+                        boost.relationship?.signingAuthorityEndpoint || 'default';
+                    const signingAuthorityName =
+                        boost.relationship?.signingAuthorityName || 'default';
 
-                // Get the contract owner's signing authority
-                const contractOwnerSigningAuthority = await getSigningAuthorityForUserByName(
-                    relationship.contractOwner,
-                    signingAuthorityEndpoint,
-                    signingAuthorityName
-                );
+                    const issuer =
+                        (boost.relationship?.issuer &&
+                            (await getProfileByProfileId(boost.relationship.issuer))) ||
+                        relationship.contractOwner;
 
-                if (!contractOwnerSigningAuthority) {
-                    console.error(
-                        `Signing authority "${signingAuthorityName}" at endpoint "${signingAuthorityEndpoint}" not found for contract owner`
+                    if (terms.deniedWriters?.includes(issuer.profileId)) return;
+
+                    // Get the contract owner's signing authority
+                    const contractOwnerSigningAuthority = await getSigningAuthorityForUserByName(
+                        issuer,
+                        signingAuthorityEndpoint,
+                        signingAuthorityName
                     );
-                    continue;
-                }
 
-                // Get boost instance
-                const boostCredential = JSON.parse(boost.target.boost) as UnsignedVC | VC;
+                    if (!contractOwnerSigningAuthority) {
+                        console.error(
+                            `Signing authority "${signingAuthorityName}" at endpoint "${signingAuthorityEndpoint}" not found for contract owner`
+                        );
+                        return;
+                    }
 
-                // Set the issuer and subject
-                boostCredential.issuer = { id: contractOwnerSigningAuthority.relationship.did };
+                    // Get boost instance
+                    const boostCredential = JSON.parse(boost.target.boost) as UnsignedVC | VC;
 
-                boostCredential.boostId = getBoostUri(boost.target.id, domain);
+                    // Set the issuer and subject
+                    boostCredential.issuer = { id: contractOwnerSigningAuthority.relationship.did };
 
-                if (Array.isArray(boostCredential.credentialSubject)) {
-                    boostCredential.credentialSubject = boostCredential.credentialSubject.map(
-                        subject => ({
-                            ...subject,
-                            id: getDidWeb(domain, relationship.consenter.profileId),
-                        })
-                    );
-                } else {
-                    boostCredential.credentialSubject.id = getDidWeb(
+                    boostCredential.boostId = getBoostUri(boost.target.id, domain);
+
+                    if (Array.isArray(boostCredential.credentialSubject)) {
+                        boostCredential.credentialSubject = boostCredential.credentialSubject.map(
+                            subject => ({
+                                ...subject,
+                                id: getDidWeb(domain, relationship.consenter.profileId),
+                            })
+                        );
+                    } else {
+                        boostCredential.credentialSubject.id = getDidWeb(
+                            domain,
+                            relationship.consenter.profileId
+                        );
+                    }
+
+                    // Issue the credential using contract owner's signing authority
+                    const vc = await issueCredentialWithSigningAuthority(
+                        issuer,
+                        boostCredential,
+                        contractOwnerSigningAuthority,
                         domain,
-                        relationship.consenter.profileId
+                        false
                     );
+
+                    // Create transaction to record the boost issuance
+                    const boostTransaction = {
+                        id: uuid(),
+                        action: 'write',
+                        date: new Date().toISOString(),
+                    } as const satisfies ConsentFlowTransactionType;
+
+                    // Create the transaction in the database
+                    await new QueryBuilder()
+                        .match({
+                            model: ConsentFlowTerms,
+                            where: { id: relationship.terms.id },
+                            identifier: 'terms',
+                        })
+                        .create({
+                            related: [
+                                {
+                                    identifier: 'boostTransaction',
+                                    model: ConsentFlowTransaction,
+                                    properties: boostTransaction,
+                                },
+                                ConsentFlowTransaction.getRelationshipByAlias('isFor'),
+                                { identifier: 'terms' },
+                            ],
+                        })
+                        .run();
+
+                    // Send the boost to the consenter
+                    await sendBoost({
+                        from: relationship.contractOwner,
+                        to: relationship.consenter,
+                        boost: boost.target,
+                        credential: vc,
+                        domain,
+                        skipNotification: false,
+                        autoAcceptCredential: true,
+                        contractTerms: relationship.terms,
+                    });
+                } catch (error) {
+                    console.error('Error processing auto-boost:', error);
                 }
-
-                // Issue the credential using contract owner's signing authority
-                const vc = await issueCredentialWithSigningAuthority(
-                    relationship.contractOwner,
-                    boostCredential,
-                    contractOwnerSigningAuthority,
-                    domain,
-                    false
-                );
-
-                // Create transaction to record the boost issuance
-                const boostTransaction = {
-                    id: uuid(),
-                    action: 'write',
-                    date: new Date().toISOString(),
-                } as const satisfies ConsentFlowTransactionType;
-
-                // Create the transaction in the database
-                await new QueryBuilder()
-                    .match({
-                        model: ConsentFlowTerms,
-                        where: { id: relationship.terms.id },
-                        identifier: 'terms',
-                    })
-                    .create({
-                        related: [
-                            {
-                                identifier: 'boostTransaction',
-                                model: ConsentFlowTransaction,
-                                properties: boostTransaction,
-                            },
-                            ConsentFlowTransaction.getRelationshipByAlias('isFor'),
-                            { identifier: 'terms' },
-                        ],
-                    })
-                    .run();
-
-                // Send the boost to the consenter
-                await sendBoost({
-                    from: relationship.contractOwner,
-                    to: relationship.consenter,
-                    boost: boost.target,
-                    credential: vc,
-                    domain,
-                    skipNotification: false,
-                    autoAcceptCredential: true,
-                    contractTerms: relationship.terms,
-                });
-            } catch (error) {
-                console.error('Error processing auto-boost:', error);
-            }
-        }
+            })
+        );
     }
 
     await addNotificationToQueue({

--- a/services/learn-card-network/brain-service/src/helpers/consentflow.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/consentflow.helpers.ts
@@ -1,0 +1,52 @@
+import { DbContractType } from 'types/consentflowcontract';
+import { getWritersForContract } from '@accesslayer/consentflowcontract/relationships/read';
+import { getProfileIdFromString } from './did.helpers';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Resolves and validates a list of denied writer identifiers against the actual writers of a contract.
+ *
+ * @param contract - The consent flow contract Neo4j object.
+ * @param deniedWriters - An array of strings, each potentially a profile ID, did:web, or did:key.
+ * @param domain - The application domain, used for resolving did:web.
+ * @returns A promise that resolves to an array of validated denied writer profile IDs.
+ * @throws Throws a TRPCError if validation fails (identifier not found, more denied than actual writers, denied writer not an actual writer).
+ */
+export const resolveAndValidateDeniedWriters = async (
+    contract: DbContractType,
+    deniedWriters: string[] | undefined | null,
+    domain: string
+): Promise<string[]> => {
+    if (!deniedWriters || deniedWriters.length === 0) return [];
+
+    const writers = await getWritersForContract(contract);
+
+    if (deniedWriters.length > writers.length) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'There are more denied writers than writers in the contract',
+        });
+    }
+
+    const resolvedDeniedWriters = (await Promise.all(
+        deniedWriters.map(async writer => {
+            return getProfileIdFromString(writer, domain);
+        })
+    )) as string[];
+
+    if (resolvedDeniedWriters.some(id => !id)) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Could not find profile(s) for denied writer(s)',
+        });
+    }
+
+    if (resolvedDeniedWriters.some(id => !writers.some(writer => writer.profileId === id))) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'There are denied writers that are not writers in the contract',
+        });
+    }
+
+    return resolvedDeniedWriters;
+};

--- a/services/learn-card-network/brain-service/src/models/ConsentFlowContract.ts
+++ b/services/learn-card-network/brain-service/src/models/ConsentFlowContract.ts
@@ -10,8 +10,8 @@ export type ConsentFlowRelationships = {
     autoReceive: ModelRelatedNodesI<
         typeof Boost,
         BoostInstance,
-        { signingAuthorityEndpoint: string; signingAuthorityName: string },
-        { signingAuthorityEndpoint: string; signingAuthorityName: string }
+        { signingAuthorityEndpoint: string; signingAuthorityName: string; issuer?: string },
+        { signingAuthorityEndpoint: string; signingAuthorityName: string; issuer?: string }
     >;
     canWrite: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
 };
@@ -49,6 +49,10 @@ export const ConsentFlowContract = ModelFactory<FlatDbContractType, ConsentFlowR
                     signingAuthorityName: {
                         property: 'signingAuthorityName',
                         schema: { type: 'string', required: true },
+                    },
+                    issuer: {
+                        property: 'issuer',
+                        schema: { type: 'string', required: false },
                     },
                 },
             },

--- a/services/learn-card-network/brain-service/src/models/ConsentFlowContract.ts
+++ b/services/learn-card-network/brain-service/src/models/ConsentFlowContract.ts
@@ -13,6 +13,7 @@ export type ConsentFlowRelationships = {
         { signingAuthorityEndpoint: string; signingAuthorityName: string },
         { signingAuthorityEndpoint: string; signingAuthorityName: string }
     >;
+    canWrite: ModelRelatedNodesI<typeof Profile, ProfileInstance>;
 };
 
 export type ConsentFlowInstance = NeogmaInstance<FlatDbContractType, ConsentFlowRelationships>;
@@ -51,6 +52,7 @@ export const ConsentFlowContract = ModelFactory<FlatDbContractType, ConsentFlowR
                     },
                 },
             },
+            canWrite: { model: Profile, direction: 'out', name: 'CAN_WRITE' },
         },
         primaryKeyField: 'id',
     },

--- a/services/learn-card-network/brain-service/src/models/ConsentFlowTerms.ts
+++ b/services/learn-card-network/brain-service/src/models/ConsentFlowTerms.ts
@@ -25,6 +25,7 @@ export const ConsentFlowTerms = ModelFactory<FlatDbTermsType, ConsentFlowTermsRe
             updatedAt: { type: 'string', required: false },
             expiresAt: { type: 'string', required: false },
             oneTime: { type: 'boolean', required: false },
+            deniedWriters: { type: 'string[]', required: false },
         } as any,
         relationships: {
             createdBy: { model: Profile, direction: 'out', name: 'CREATED_BY' },

--- a/services/learn-card-network/learn-cloud-service/src/accesslayer/credential-record/update.ts
+++ b/services/learn-card-network/learn-cloud-service/src/accesslayer/credential-record/update.ts
@@ -5,14 +5,14 @@ import { EncryptedCredentialRecord } from '@learncard/types';
 import { getCredentialRecordCollection } from '.';
 
 export const updateCredentialRecord = async (
-    did: string,
+    did: string | string[],
     id: string,
     updates: Partial<EncryptedCredentialRecord>
 ): Promise<number | false> => {
     try {
         return (
-            await getCredentialRecordCollection().updateOne(
-                { did, id },
+            await getCredentialRecordCollection().updateMany(
+                { did: Array.isArray(did) ? { $in: did } : did, id },
                 { $set: { modified: new Date(), ...updates } }
             )
         ).modifiedCount;

--- a/tests/e2e/tests/consentflow.spec.ts
+++ b/tests/e2e/tests/consentflow.spec.ts
@@ -14,13 +14,15 @@ import { VC } from '@learncard/types';
 let a: LearnCard;
 let b: LearnCard;
 let c: LearnCard;
+let d: LearnCard;
 
 describe('ConsentFlow E2E Tests', () => {
     beforeEach(async () => {
-        // Initialize LearnCards for three different users
+        // Initialize LearnCards for four different users
         a = await getLearnCardForUser('a');
         b = await getLearnCardForUser('b');
         c = await getLearnCardForUser('c');
+        d = await getLearnCardForUser('d');
     });
 
     describe('Contract Creation and Management', () => {
@@ -350,47 +352,39 @@ describe('ConsentFlow E2E Tests', () => {
         });
 
         it('should allow writing a credential via signing authority HTTP route', async () => {
-            const learnCard = await getLearnCard(crypto.randomBytes(32).toString('hex'));
-            await learnCard.invoke.createServiceProfile({
-                profileId: 'rando',
-                displayName: 'Random User',
-                bio: '',
-                shortBio: '',
-            });
-            const sa = await learnCard.invoke.createSigningAuthority('test-sa');
+            const sa = await a.invoke.createSigningAuthority('test-sa');
             expect(sa).toBeDefined();
-            await learnCard.invoke.registerSigningAuthority(sa.endpoint, sa.name, sa.did);
-            const saResult = await learnCard.invoke.getRegisteredSigningAuthority(
-                sa.endpoint,
-                sa.name
-            );
+            await a.invoke.registerSigningAuthority(sa.endpoint, sa.name, sa.did);
+            const saResult = await a.invoke.getRegisteredSigningAuthority(sa.endpoint, sa.name);
             expect(saResult).toBeDefined();
             const signingAuthority = {
                 endpoint: saResult.signingAuthority.endpoint,
                 name: saResult.relationship.name,
             };
 
-            const grantId = await learnCard.invoke.addAuthGrant({
+            const grantId = await a.invoke.addAuthGrant({
                 status: 'active',
                 id: 'test',
                 name: 'test',
                 challenge: 'auth-grant:test-challenge',
                 createdAt: new Date().toISOString(),
-                scope: 'contracts:write',
+                scope: 'contracts-data:write',
             });
-            const token = await learnCard.invoke.getAPITokenForAuthGrant(grantId);
+            const token = await a.invoke.getAPITokenForAuthGrant(grantId);
 
-            const newBoostUri = await learnCard.invoke.createBoost(testUnsignedBoost, {
+            const newBoostUri = await a.invoke.createBoost(testUnsignedBoost, {
                 category: 'Achievement',
                 name: 'Test Achievement',
             });
 
-            const payload = { boostUri: newBoostUri, signingAuthority };
+            const payload = {
+                boostUri: newBoostUri,
+                signingAuthority,
+                did: b.id.did(),
+                contractUri,
+            };
             const response = await fetch(
-                `http://localhost:4000/api/consent-flow-contract/write/via-signing-authority/${contractUri.replace(
-                    '/',
-                    '%2F'
-                )}/${b.id.did()}`,
+                `http://localhost:4000/api/consent-flow-contract/write/via-signing-authority`,
                 {
                     method: 'POST',
                     headers: {
@@ -714,6 +708,376 @@ describe('ConsentFlow E2E Tests', () => {
             expect(userBData.credentials.categories.Achievement).toEqual(
                 expect.arrayContaining(allCredentials)
             );
+        });
+    });
+
+    describe('Contract Writer Permissions', () => {
+        it('should allow credential writing by approved writers', async () => {
+            const writerContractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'Approved Writer Contract',
+                writers: [USERS.c.profileId],
+            });
+
+            // User B consents to the contract
+            const termsUri = await b.invoke.consentToContract(writerContractUri, {
+                terms: normalFullTerms,
+            });
+
+            // User C (approved writer) issues a boost and credential
+            const boostUri = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Approved Writer Boost',
+            });
+
+            const credential = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUri,
+            });
+
+            const credentialUri = await c.invoke.writeCredentialToContract(
+                b.id.did(),
+                writerContractUri,
+                credential,
+                boostUri
+            );
+
+            expect(credentialUri).toBeDefined();
+            expect(typeof credentialUri).toBe('string');
+
+            // Verify User B can retrieve the credential
+            const credentials = await b.invoke.getCredentialsForContract(termsUri);
+            expect(credentials.records.length).toBeGreaterThan(0);
+            const record = credentials.records[0];
+            expect(record.category).toBe('Achievement');
+        });
+
+        it('should reject credential writing by non-writers', async () => {
+            const contractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'No Writer Contract',
+            });
+
+            // User B consents
+            await b.invoke.consentToContract(contractUri, { terms: normalFullTerms });
+
+            // User D (not a writer) attempts to write
+            const boostUri = await d.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Non-writer Boost',
+            });
+
+            const credential = await d.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: d.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUri,
+            });
+
+            await expect(
+                d.invoke.writeCredentialToContract(b.id.did(), contractUri, credential, boostUri)
+            ).rejects.toThrow();
+        });
+
+        it('should reject credential writing by writers listed in deniedWriters', async () => {
+            const deniedContractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'Denied Writer Contract',
+                writers: [USERS.c.profileId],
+            });
+
+            // User B consents and explicitly denies User C
+            await b.invoke.consentToContract(deniedContractUri, {
+                terms: { ...normalFullTerms, deniedWriters: [USERS.c.profileId] },
+            });
+
+            // User C attempts to write
+            const boostUri = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Denied Writer Boost',
+            });
+
+            const credential = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUri,
+            });
+
+            await expect(
+                c.invoke.writeCredentialToContract(
+                    b.id.did(),
+                    deniedContractUri,
+                    credential,
+                    boostUri
+                )
+            ).rejects.toThrow();
+        });
+
+        it('should allow credential writing by multiple approved writers', async () => {
+            const multiWriterContractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'Multi Writer Contract',
+                writers: [USERS.c.profileId, USERS.d.profileId],
+            });
+
+            // User B consents to the contract
+            const termsUri = await b.invoke.consentToContract(multiWriterContractUri, {
+                terms: normalFullTerms,
+            });
+
+            /* -------------------- Writer C -------------------- */
+            const boostUriC = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Multi Writer Boost C',
+            });
+
+            const credentialC = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriC,
+            });
+
+            const credentialUriC = await c.invoke.writeCredentialToContract(
+                b.id.did(),
+                multiWriterContractUri,
+                credentialC,
+                boostUriC
+            );
+
+            expect(credentialUriC).toBeDefined();
+
+            /* -------------------- Writer D -------------------- */
+            const boostUriD = await d.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Multi Writer Boost D',
+            });
+
+            const credentialD = await d.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: d.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriD,
+            });
+
+            const credentialUriD = await d.invoke.writeCredentialToContract(
+                b.id.did(),
+                multiWriterContractUri,
+                credentialD,
+                boostUriD
+            );
+
+            expect(credentialUriD).toBeDefined();
+
+            // Verify that User B received at least 2 credentials for the contract
+            const credentials = await b.invoke.getCredentialsForContract(termsUri);
+            expect(credentials.records.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('should reject credential writing by multiple denied writers', async () => {
+            const multiDeniedContractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'Multi Denied Writer Contract',
+                writers: [USERS.c.profileId, USERS.d.profileId],
+            });
+
+            // User B consents and denies both writers
+            await b.invoke.consentToContract(multiDeniedContractUri, {
+                terms: {
+                    ...normalFullTerms,
+                    deniedWriters: [USERS.c.profileId, USERS.d.profileId],
+                },
+            });
+
+            /* -------------------- Writer C Attempt -------------------- */
+            const boostUriC = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Denied Writer Boost C',
+            });
+
+            const credentialC = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriC,
+            });
+
+            await expect(
+                c.invoke.writeCredentialToContract(
+                    b.id.did(),
+                    multiDeniedContractUri,
+                    credentialC,
+                    boostUriC
+                )
+            ).rejects.toThrow();
+
+            /* -------------------- Writer D Attempt -------------------- */
+            const boostUriD = await d.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Denied Writer Boost D',
+            });
+
+            const credentialD = await d.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: d.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriD,
+            });
+
+            await expect(
+                d.invoke.writeCredentialToContract(
+                    b.id.did(),
+                    multiDeniedContractUri,
+                    credentialD,
+                    boostUriD
+                )
+            ).rejects.toThrow();
+        });
+
+        it('should enforce deniedWriters after terms are updated', async () => {
+            const updateDeniedContractUri = await a.invoke.createContract({
+                contract: normalContract,
+                name: 'Update Denied Writer Contract',
+                writers: [USERS.c.profileId, USERS.d.profileId],
+            });
+
+            // User B consents without denied writers
+            const termsUri = await b.invoke.consentToContract(updateDeniedContractUri, {
+                terms: normalFullTerms,
+            });
+
+            /* --------- Writer C initially allowed --------- */
+            const initialBoostUri = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Initial Writer Boost C',
+            });
+
+            const initialCredential = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: initialBoostUri,
+            });
+
+            const initialCredentialUri = await c.invoke.writeCredentialToContract(
+                b.id.did(),
+                updateDeniedContractUri,
+                initialCredential,
+                initialBoostUri
+            );
+            expect(initialCredentialUri).toBeDefined();
+
+            /* --------- Update terms to deny Writer C --------- */
+            await b.invoke.updateContractTerms(termsUri, {
+                terms: { ...normalFullTerms, deniedWriters: [USERS.c.profileId] },
+            });
+
+            // Writer C should now be rejected
+            const deniedBoostUri = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Post Deny Boost C',
+            });
+
+            const deniedCredential = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: deniedBoostUri,
+            });
+
+            await expect(
+                c.invoke.writeCredentialToContract(
+                    b.id.did(),
+                    updateDeniedContractUri,
+                    deniedCredential,
+                    deniedBoostUri
+                )
+            ).rejects.toThrow();
+
+            /* --------- Writer D should still be allowed --------- */
+            const boostUriD = await d.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Allowed Writer Boost D',
+            });
+
+            const credentialD = await d.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: d.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriD,
+            });
+
+            const credentialUriD = await d.invoke.writeCredentialToContract(
+                b.id.did(),
+                updateDeniedContractUri,
+                credentialD,
+                boostUriD
+            );
+            expect(credentialUriD).toBeDefined();
+
+            /* --------- Remove denied writers --------- */
+            await b.invoke.updateContractTerms(termsUri, {
+                terms: { ...normalFullTerms, deniedWriters: [] },
+            });
+
+            const boostUriC2 = await c.invoke.createBoost(testUnsignedBoost, {
+                category: 'Achievement',
+                name: 'Post Undeny Boost C',
+            });
+
+            const credentialC2 = await c.invoke.issueCredential({
+                ...testUnsignedBoost,
+                issuer: c.id.did(),
+                credentialSubject: {
+                    ...testUnsignedBoost.credentialSubject,
+                    id: b.id.did(),
+                },
+                boostId: boostUriC2,
+            });
+
+            const contracts = await b.invoke.getConsentedContracts();
+            const updatedTerms = contracts.records.find(record => record.uri === termsUri);
+
+            const credentialUriC2 = await c.invoke.writeCredentialToContract(
+                b.id.did(),
+                updateDeniedContractUri,
+                credentialC2,
+                boostUriC2
+            );
+            expect(credentialUriC2).toBeDefined();
         });
     });
 });

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
-        "lib": [
-            "es2022"
-        ],
+        "lib": ["es2022", "dom"],
         "module": "esnext",
         "moduleResolution": "node",
         "resolveJsonModule": true,
@@ -26,11 +24,6 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true
     },
-    "include": [
-        "test"
-    ],
-    "exclude": [
-        "./dist/**/*",
-        "./node_modules/**/*"
-    ]
+    "include": ["tests/**/*"],
+    "exclude": ["./dist/**/*", "./node_modules/**/*"]
 }


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
[LC-894] Supporting creating a ConsentFlow where multiple accounts have ability to use contract to write credentials
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Supporting creating a ConsentFlow where multiple accounts have ability to use contract to write credentials

#### 🥴 TL; RL:

This PR adds multiple writers to a consent flow contract.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Added `resolveAndValidateDeniedWriters` helper to `src/helpers/consentflow.helpers.ts`.
- Refactored `updateConsentedContractTerms` route to consume the helper.
- Hardened error-handling & validation messages.
- Fixed type mismatches and ESLint formatting across touched files.
- Updates terms to include `deniedWriters` field.
- Updates `contract` type to include `deniedWriters` field.

#### 🛠 Important tradeoffs made:

- Moved inline validation logic into a shared helper for maintainability.  
- Adjusted some TRPC error codes for consistency with existing patterns.

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. `cd services/learn-card-network/brain-service && pnpm test` – all tests should pass.  
1. `cd tests/e2e && pnpm test:e2e` – all tests should pass.  

#### 📱 🖥 Which devices would you like help testing on?

#### 🧪 Code Coverage

Unit/E2E tests cover the new helper and route edge-cases.

# Documentation

#### 📜 Gitbook

#### 📊 Storybook

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication


[LC-894]: https://welibrary.atlassian.net/browse/LC-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
This PR introduces functionality for managing denied writers in consent flow contracts and handling auto-boosts with respect to these denied writers. Here's a concise summary:

Purpose: Implement denied writers functionality and auto-boost filtering in consent flow contracts.

Main changes:
- Add support for specifying and managing denied writers in contract terms
- Implement filtering of auto-boosts based on denied writers during consent and terms updates
- Update credential writing logic to respect denied writers permissions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
