### PR TITLE
[LC-1003] Do not Allow Accepting a Credential/Presentation More Than Once

### DIFF
--- a/.changeset/rare-clubs-wash.md
+++ b/.changeset/rare-clubs-wash.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-service': patch
+---
+
+Do not allow receiving a credential or presentation more than once

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/read.ts
@@ -53,6 +53,21 @@ export const getCredentialOwner = async (
     return inflateObject<ProfileType>(owner.dataValues as any);
 };
 
+export const getCredentialReceivedByProfile = async (
+    credentialId: string,
+    profile: ProfileType
+): Promise<boolean> => {
+    const relationships = await Credential.findRelationships({
+        alias: 'credentialReceived',
+        where: {
+            source: { id: credentialId },
+            target: { profileId: profile.profileId },
+        },
+    });
+
+    return relationships.length > 0;
+};
+
 /**
  * Gets credentials that were issued via a specific contract terms relationship
  *

--- a/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/read.ts
@@ -41,3 +41,20 @@ export const getPresentationOwner = async (
 
     return inflateObject<ProfileType>(owner.dataValues as any);
 };
+
+export const getPresentationReceivedByProfile = async (
+    presentationId: string,
+    profile: ProfileType
+): Promise<boolean> => {
+    const { Presentation } = await import('@models');
+    
+    const relationships = await Presentation.findRelationships({
+        alias: 'presentationReceived',
+        where: {
+            source: { id: presentationId },
+            target: { profileId: profile.profileId },
+        },
+    });
+
+    return relationships.length > 0;
+};

--- a/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/presentation/relationships/read.ts
@@ -1,5 +1,5 @@
 import { inflateObject } from '@helpers/objects.helpers';
-import { PresentationInstance, Profile, ProfileRelationships } from '@models';
+import { Presentation, PresentationInstance, Profile, ProfileRelationships } from '@models';
 import { ProfileType } from 'types/profile';
 
 export const getPresentationSentToProfile = async (
@@ -46,8 +46,6 @@ export const getPresentationReceivedByProfile = async (
     presentationId: string,
     profile: ProfileType
 ): Promise<boolean> => {
-    const { Presentation } = await import('@models');
-    
     const relationships = await Presentation.findRelationships({
         alias: 'presentationReceived',
         where: {

--- a/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/credential.helpers.ts
@@ -7,7 +7,7 @@ import {
     createSentCredentialRelationship,
     setDefaultClaimedRole,
 } from '@accesslayer/credential/relationships/create';
-import { getCredentialSentToProfile } from '@accesslayer/credential/relationships/read';
+import { getCredentialSentToProfile, getCredentialReceivedByProfile } from '@accesslayer/credential/relationships/read';
 import { constructUri, getUriParts } from './uri.helpers';
 import { addNotificationToQueue } from './notifications.helpers';
 import { ProfileType } from 'types/profile';
@@ -62,6 +62,15 @@ export const acceptCredential = async (
         throw new TRPCError({
             code: 'NOT_FOUND',
             message: 'Pending Credential not found',
+        });
+    }
+
+    // Check if credential has already been received by this profile
+    const alreadyReceived = await getCredentialReceivedByProfile(id, profile);
+    if (alreadyReceived) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Credential has already been received',
         });
     }
 

--- a/services/learn-card-network/brain-service/src/helpers/presentation.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/presentation.helpers.ts
@@ -6,7 +6,7 @@ import {
     createReceivedPresentationRelationship,
     createSentPresentationRelationship,
 } from '@accesslayer/presentation/relationships/create';
-import { getPresentationSentToProfile } from '@accesslayer/presentation/relationships/read';
+import { getPresentationSentToProfile, getPresentationReceivedByProfile } from '@accesslayer/presentation/relationships/read';
 import { constructUri, getUriParts } from './uri.helpers';
 import { addNotificationToQueue } from './notifications.helpers';
 import { ProfileType } from 'types/profile';
@@ -56,6 +56,15 @@ export const acceptPresentation = async (profile: ProfileType, uri: string): Pro
         throw new TRPCError({
             code: 'NOT_FOUND',
             message: 'Pending Presentation not found',
+        });
+    }
+
+    // Check if presentation has already been received by this profile
+    const alreadyReceived = await getPresentationReceivedByProfile(id, profile);
+    if (alreadyReceived) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Presentation has already been received',
         });
     }
 

--- a/services/learn-card-network/brain-service/test/credentials.spec.ts
+++ b/services/learn-card-network/brain-service/test/credentials.spec.ts
@@ -102,6 +102,26 @@ describe('Credentials', () => {
                 userB.clients.fullAuth.credential.acceptCredential({ uri })
             ).resolves.not.toThrow();
         });
+
+        it('should not allow accepting the same credential twice', async () => {
+            const uri = await userA.clients.fullAuth.credential.sendCredential({
+                profileId: 'userb',
+                credential: testVc,
+            });
+
+            // First acceptance should succeed
+            await expect(
+                userB.clients.fullAuth.credential.acceptCredential({ uri })
+            ).resolves.not.toThrow();
+
+            // Second acceptance should fail
+            await expect(
+                userB.clients.fullAuth.credential.acceptCredential({ uri })
+            ).rejects.toMatchObject({
+                code: 'BAD_REQUEST',
+                message: expect.stringContaining('already been received'),
+            });
+        });
     });
 
     describe('receivedCredentials', () => {

--- a/services/learn-card-network/brain-service/test/presentations.spec.ts
+++ b/services/learn-card-network/brain-service/test/presentations.spec.ts
@@ -107,6 +107,26 @@ describe('Presentations', () => {
                 userB.clients.fullAuth.presentation.acceptPresentation({ uri })
             ).resolves.not.toThrow();
         });
+
+        it('should not allow accepting the same presentation twice', async () => {
+            const uri = await userA.clients.fullAuth.presentation.sendPresentation({
+                profileId: 'userb',
+                presentation: testVp,
+            });
+
+            // First acceptance should succeed
+            await expect(
+                userB.clients.fullAuth.presentation.acceptPresentation({ uri })
+            ).resolves.not.toThrow();
+
+            // Second acceptance should fail
+            await expect(
+                userB.clients.fullAuth.presentation.acceptPresentation({ uri })
+            ).rejects.toMatchObject({
+                code: 'BAD_REQUEST',
+                message: expect.stringContaining('already been received'),
+            });
+        });
     });
 
     describe('receivedPresentations', () => {

--- a/tests/e2e/tests/presentations.spec.ts
+++ b/tests/e2e/tests/presentations.spec.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'vitest';
+
+import { getLearnCardForUser } from './helpers/learncard.helpers';
+
+let a: NetworkLearnCardFromSeed['returnValue'];
+let b: NetworkLearnCardFromSeed['returnValue'];
+
+describe('Presentations', () => {
+    beforeEach(async () => {
+        a = await getLearnCardForUser('a');
+        b = await getLearnCardForUser('b');
+    });
+
+    test('Users can send/receive presentations via LCN', async () => {
+        // Create a test credential first
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+        const vc = await a.invoke.issueCredential(unsignedVc);
+
+        // Create a presentation with the credential
+        const unsignedVp = await a.invoke.newPresentation(vc);
+        const vp = await a.invoke.issuePresentation(unsignedVp);
+
+        const uri = await a.invoke.sendPresentation('testb', vp);
+
+        const incomingPresentations = await b.invoke.getIncomingPresentations();
+
+        expect(incomingPresentations).toHaveLength(1);
+        expect(incomingPresentations[0].uri).toEqual(uri);
+
+        const resolvedVp = await b.read.get(incomingPresentations[0].uri);
+
+        expect(resolvedVp).toEqual(vp);
+
+        await b.invoke.acceptPresentation(uri);
+
+        expect(await a.invoke.getSentPresentations()).toHaveLength(1);
+        expect(await b.invoke.getReceivedPresentations()).toHaveLength(1);
+        expect(await b.invoke.getIncomingPresentations()).toHaveLength(0);
+    });
+
+    test('Users cannot accept the same presentation twice', async () => {
+        // Create a test credential first
+        const unsignedVc = a.invoke.getTestVc(b.id.did());
+        const vc = await a.invoke.issueCredential(unsignedVc);
+
+        // Create a presentation with the credential
+        const unsignedVp = await a.invoke.newPresentation(vc);
+        const vp = await a.invoke.issuePresentation(unsignedVp);
+
+        const uri = await a.invoke.sendPresentation('testb', vp);
+
+        // First acceptance should succeed
+        await expect(b.invoke.acceptPresentation(uri)).resolves.not.toThrow();
+
+        // Verify the presentation is now in received presentations
+        const receivedPresentations = await b.invoke.getReceivedPresentations();
+        expect(receivedPresentations).toHaveLength(1);
+
+        // Second acceptance should fail
+        await expect(b.invoke.acceptPresentation(uri)).rejects.toThrow(/already been received/);
+
+        // Verify that received presentations count hasn't changed
+        const receivedPresentationsAfter = await b.invoke.getReceivedPresentations();
+        expect(receivedPresentationsAfter).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1003] Do not allow accepting a credential twice

#### 📚 What is the context and goal of this PR?
Right now, if someone sends you a credential, you can accept it multiple times. This is a bug.

#### 🥴 TL; RL:
Fixes that so that you can only accept it once.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
- Run the unit tests (`cd services/learn-card-network/brain-service && pnpm test`)
- Run the E2E tests (`cd tests/e2e && pnpm test:e2e`)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->
Added both unit tests and E2E tests =)

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1003]: https://welibrary.atlassian.net/browse/LC-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
The purpose and impact of these changes is to prevent users from accepting the same credential or presentation multiple times.

Main changes:
- Added checks to verify if a credential/presentation has already been received before accepting
- Implemented new functions to query if a credential/presentation has been received by a profile
- Added test cases to ensure users cannot accept the same credential/presentation twice

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
