### PR TITLE
feat: implement Claim Boosts as a VC-API workflow

### DIFF
--- a/.changeset/eight-owls-pump.md
+++ b/.changeset/eight-owls-pump.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+feat: implement Claim Boosts as a VC-API workflow

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 7.37.4(eslint@8.57.1)
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+        version: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.7.0
@@ -79,16 +79,16 @@ importers:
         version: 0.5.5
       ts-jest:
         specifier: ^29.0.5
-        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2)
+        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2)
       tslib:
         specifier: ^2.5.0
         version: 2.8.1
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.2)(vite@5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0))
+        version: 4.3.2(typescript@5.6.2)(vite@5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0))
       vitest:
         specifier: ^1.4.0
-        version: 1.6.1(@types/node@22.13.14)(happy-dom@14.12.3)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
+        version: 1.6.1(@types/node@18.19.83)(happy-dom@14.12.3)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
 
   docs:
     dependencies:
@@ -751,7 +751,7 @@ importers:
         version: 17.0.45
       aqu:
         specifier: 0.4.3
-        version: 0.4.3(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(@types/node@17.0.45)(babel-jest@29.7.0(@babel/core@7.26.10))(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+        version: 0.4.3(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(@types/node@17.0.45)(babel-jest@29.7.0(@babel/core@7.26.10))(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       esbuild:
         specifier: ^0.17.17
         version: 0.17.19
@@ -1953,6 +1953,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.191
         version: 4.17.16
+      base64url:
+        specifier: ^3.0.1
+        version: 3.0.1
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -2439,7 +2442,7 @@ importers:
         version: 10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8)
       '@metamask/eslint-config-jest':
         specifier: ^10.0.0
-        version: 10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2))(eslint@8.57.1)
+        version: 10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2))(eslint@8.57.1)
       '@metamask/eslint-config-nodejs':
         specifier: ^8.0.0
         version: 8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.57.1))(eslint@8.57.1)
@@ -9147,6 +9150,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
 
   base@0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
@@ -25676,41 +25683,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 18.19.83
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -26353,11 +26325,11 @@ snapshots:
 
   '@metamask/detect-provider@1.2.0': {}
 
-  '@metamask/eslint-config-jest@10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2))(eslint@8.57.1)':
+  '@metamask/eslint-config-jest@10.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2))(eslint@8.57.1)':
     dependencies:
       '@metamask/eslint-config': 10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8)
       eslint: 8.57.1
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2)
+      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2)
 
   '@metamask/eslint-config-nodejs@8.0.0(@metamask/eslint-config@10.0.0(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-jsdoc@39.9.1(eslint@8.57.1))(eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8))(eslint@8.57.1)(prettier@2.8.8))(eslint-plugin-node@11.1.0(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
@@ -30431,7 +30403,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  aqu@0.4.3(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(@types/node@17.0.45)(babel-jest@29.7.0(@babel/core@7.26.10))(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
+  aqu@0.4.3(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(@types/node@17.0.45)(babel-jest@29.7.0(@babel/core@7.26.10))(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)):
     dependencies:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
@@ -30451,13 +30423,13 @@ snapshots:
       fs-extra: 10.1.0
       github-username: 6.0.0
       inquirer: 7.3.3
-      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))
+      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))
       lodash: 4.17.21
       ora: 5.4.1
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-jest: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.15.18)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2)
+      ts-jest: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.15.18)(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2)
       typescript: 5.6.2
       webpack-merge: 5.10.0
       yup: 0.32.11
@@ -31030,13 +31002,13 @@ snapshots:
 
   axios@0.25.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
   axios@1.8.4:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.3.7)
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -31303,6 +31275,8 @@ snapshots:
   base58-universal@2.0.0: {}
 
   base64-js@1.5.1: {}
+
+  base64url@3.0.1: {}
 
   base@0.11.2:
     dependencies:
@@ -31886,7 +31860,7 @@ snapshots:
 
   centra@2.7.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
@@ -32587,13 +32561,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
+  create-jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -32609,21 +32583,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -34154,13 +34113,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2):
+  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
-      jest: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -36105,7 +36064,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -36996,16 +36955,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
+  jest-cli@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      create-jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -37025,25 +36984,6 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -37174,7 +37114,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
+  jest-config@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)):
     dependencies:
       '@babel/core': 7.26.10
       '@jest/test-sequencer': 29.7.0
@@ -37200,7 +37140,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 17.0.45
-      ts-node: 10.9.2(@types/node@22.13.14)(typescript@5.6.2)
+      ts-node: 10.9.2(@types/node@18.19.83)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -37263,68 +37203,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.83
       ts-node: 10.9.2(@types/node@18.19.83)(typescript@5.6.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
-    dependencies:
-      '@babel/core': 7.26.10
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.83
-      ts-node: 10.9.2(@types/node@22.13.14)(typescript@5.6.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
-    dependencies:
-      '@babel/core': 7.26.10
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.13.14
-      ts-node: 10.9.2(@types/node@22.13.14)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -37852,22 +37730,22 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
+      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -37955,12 +37833,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
+  jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest-cli: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -37973,18 +37851,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -45156,6 +45022,27 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.10)
       esbuild: 0.15.18
 
+  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.15.18)(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.1
+      type-fest: 4.38.0
+      typescript: 5.6.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.10
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.10)
+      esbuild: 0.15.18
+
   ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.15.18)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       bs-logger: 0.2.6
@@ -45177,33 +45064,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.10)
       esbuild: 0.15.18
 
-  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.15.18)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2):
+  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.1
-      type-fest: 4.38.0
-      typescript: 5.6.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.10
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      esbuild: 0.15.18
-
-  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2)))(typescript@5.6.2):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.14)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.6.2))
+      jest: 29.7.0(@types/node@18.19.83)(ts-node@10.9.2(@types/node@18.19.83)(typescript@5.6.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -45991,13 +45857,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.1(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
+  vite-node@1.6.1(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
+      vite: 5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -46009,13 +45875,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.6.2)(vite@5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.2)(vite@5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.6.2)
     optionalDependencies:
-      vite: 5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
+      vite: 5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -46043,6 +45909,18 @@ snapshots:
       less: 4.2.2
       terser: 5.39.0
 
+  vite@5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.3
+      rollup: 4.37.0
+    optionalDependencies:
+      '@types/node': 18.19.83
+      fsevents: 2.3.3
+      less: 4.2.2
+      lightningcss: 1.27.0
+      terser: 5.39.0
+
   vite@5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
     dependencies:
       esbuild: 0.21.5
@@ -46063,7 +45941,7 @@ snapshots:
     optionalDependencies:
       vite: 5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
 
-  vitest@1.6.1(@types/node@22.13.14)(happy-dom@14.12.3)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
+  vitest@1.6.1(@types/node@18.19.83)(happy-dom@14.12.3)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -46082,11 +45960,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.15(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
-      vite-node: 1.6.1(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
+      vite: 5.4.15(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
+      vite-node: 1.6.1(@types/node@18.19.83)(less@4.2.2)(lightningcss@1.27.0)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.83
       happy-dom: 14.12.3
       jsdom: 20.0.3
     transitivePeerDependencies:

--- a/services/learn-card-network/brain-service/package.json
+++ b/services/learn-card-network/brain-service/package.json
@@ -61,6 +61,7 @@
         "@sentry/serverless": "7.61.0",
         "@trpc/server": "^11.3.0",
         "@types/lodash": "^4.14.191",
+        "base64url": "^3.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",

--- a/services/learn-card-network/brain-service/src/app.ts
+++ b/services/learn-card-network/brain-service/src/app.ts
@@ -10,6 +10,7 @@ import { utilitiesRouter, UtilitiesRouter } from '@routes/utilities';
 import { contractsRouter, ContractsRouter } from '@routes/contracts';
 import { didMetadataRouter, DidMetadataRouter } from '@routes/did-metadata';
 import { authGrantsRouter, AuthGrantsRouter } from '@routes/auth-grants';
+import { workflowsRouter, WorkflowsRouter } from '@routes/workflows';
 
 export { createContext } from '@routes';
 
@@ -25,6 +26,7 @@ export const appRouter = t.router<{
     contracts: ContractsRouter;
     didMetadata: DidMetadataRouter;
     authGrants: AuthGrantsRouter;
+    workflows: WorkflowsRouter;
 }>({
     boost: boostsRouter,
     claimHook: claimHooksRouter,
@@ -37,6 +39,7 @@ export const appRouter = t.router<{
     contracts: contractsRouter,
     didMetadata: didMetadataRouter,
     authGrants: authGrantsRouter,
+    workflows: workflowsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/learn-card-network/brain-service/src/routes/workflows.ts
+++ b/services/learn-card-network/brain-service/src/routes/workflows.ts
@@ -320,7 +320,7 @@ async function handlePresentationForClaim(
         if (Array.isArray(boostCredential.credentialSubject)) {
             boostCredential.credentialSubject = boostCredential.credentialSubject.map(subject => ({
                 ...subject,
-                id: subject.did,
+                id: subject.did || subject.id || holderDid,
             }));
         } else {
             boostCredential.credentialSubject.id = holderDid;

--- a/services/learn-card-network/brain-service/src/routes/workflows.ts
+++ b/services/learn-card-network/brain-service/src/routes/workflows.ts
@@ -1,0 +1,334 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { v4 as uuid } from 'uuid';
+
+import {
+    VPValidator,
+    VP,
+    UnsignedVPValidator,
+    UnsignedVC,
+    VCValidator,
+} from '@learncard/types';
+
+import { t, openRoute } from '@routes';
+
+import { getBoostByUri } from '@accesslayer/boost/read';
+import { getBoostOwner } from '@accesslayer/boost/relationships/read';
+import { getSigningAuthorityForUserByName } from '@accesslayer/signing-authority/relationships/read';
+
+import {
+    isClaimLinkAlreadySetForBoost,
+    setValidClaimLinkForBoost,
+    getClaimLinkSAInfoForBoost,
+    useClaimLinkForBoost,
+} from '@cache/claim-links';
+
+import {
+    issueClaimLinkBoost,
+    getBoostUri,
+    isDraftBoost,
+    sendBoost,
+} from '@helpers/boost.helpers';
+import { getEmptyLearnCard } from '@helpers/learnCard.helpers';
+import { getDidWeb } from '@helpers/did.helpers';
+import { getProfileByDid } from '@accesslayer/profile/read';
+
+// Zod schema for the participate in exchange input
+const participateInExchangeInput = z.object({
+    localWorkflowId: z.string(),
+    localExchangeId: z.string(),
+    body: z.union([
+        // Type 1: A body containing the VP for the challenge-response step
+        z.object({
+            verifiablePresentation: VPValidator,
+        }),
+        // Type 2: An empty body for the initiation step
+        z.object({}).optional(),
+    ]).default({}),
+});
+
+// Response schema for the initiation step (VPR)
+const VerifiablePresentationRequestValidator = z.object({
+    query: z.object({
+        type: z.string(),
+        credentialQuery: z.array(z.object({
+            required: z.boolean().optional(),
+            reason: z.string().optional(),
+        })).optional(),
+    }),
+    challenge: z.string(),
+    domain: z.string(),
+});
+
+// Response schema for the claim step (VP containing the issued VC)
+const ParticipateExchangeClaimResponseValidator = UnsignedVPValidator.extend({
+    verifiableCredential: VCValidator.array(),
+});
+
+export const workflowsRouter = t.router({
+    participateInExchange: openRoute
+        .meta({
+            openapi: {
+                method: 'POST',
+                path: '/workflows/{localWorkflowId}/exchanges/{localExchangeId}',
+                tags: ['Workflows', 'VC-API'],
+                summary: 'Participate in an Exchange',
+                description: 'VC-API endpoint for participating in credential exchanges. Supports both exchange initiation and credential claiming.',
+            },
+        })
+        .input(participateInExchangeInput)
+        .output(
+            z.union([
+                VerifiablePresentationRequestValidator,
+                ParticipateExchangeClaimResponseValidator,
+            ])
+        )
+        .mutation(async ({ ctx, input }) => {
+            const { localWorkflowId, localExchangeId, body } = input;
+            const { domain } = ctx;
+
+            if (process.env.NODE_ENV !== 'test') {
+                console.log('🚀 BEGIN - Participate in Exchange', JSON.stringify(input));
+            }
+
+            // Check if this is an initiation request (empty body) or presentation request (contains VP)
+            const isInitiation = !body || !('verifiablePresentation' in body);
+
+            if (isInitiation) {
+                // Scenario 1: Exchange Initiation
+                return handleExchangeInitiation(localWorkflowId, localExchangeId, domain);
+            } else {
+                // Scenario 2: Presentation for Claim
+                return handlePresentationForClaim(
+                    localWorkflowId,
+                    localExchangeId,
+                    body.verifiablePresentation,
+                    domain
+                );
+            }
+        }),
+});
+
+async function handleExchangeInitiation(
+    localWorkflowId: string,
+    localExchangeId: string,
+    domain: string
+) {
+    // Validate that the localExchangeId (boost ID) is valid and available
+    const boost = await getBoostByUri(localExchangeId);
+
+    if (!boost) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Exchange not found or not available for claiming',
+        });
+    }
+
+    if (isDraftBoost(boost)) {
+        throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Draft boosts cannot be claimed via exchange',
+        });
+    }
+
+    // Generate a cryptographically secure challenge
+    const challenge = uuid();
+
+    // Check if challenge is already in use (shouldn't happen with UUID but be safe)
+    if (await isClaimLinkAlreadySetForBoost(localExchangeId, challenge)) {
+        throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Challenge collision detected, please retry',
+        });
+    }
+
+    // Store exchange state in Redis
+    // We need a default signing authority setup for this workflow
+    const boostOwner = await getBoostOwner(boost);
+    if (!boostOwner) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Boost owner not found',
+        });
+    }
+
+    // For VC-API workflow, we need to check if the boost owner has a signing authority available
+    // Since we can't prompt for it in this step, we'll need to store a placeholder and validate later
+    // Store the exchange state with minimal info - the actual signing authority lookup happens during claim
+    await setValidClaimLinkForBoost(localExchangeId, challenge, {
+        name: 'vc-api-exchange',
+        endpoint: domain,
+    }, {
+        ttlSeconds: 300, // 5 minute expiry
+        totalUses: 1, // Single use for security
+    });
+
+    // Return VerifiablePresentationRequest
+    return {
+        query: {
+            type: 'VerifiablePresentationRequest',
+            credentialQuery: [{
+                required: false,
+                reason: 'Please present a credential to verify your identity and claim this boost',
+            }],
+        },
+        challenge,
+        domain,
+    };
+}
+
+async function handlePresentationForClaim(
+    localWorkflowId: string,
+    localExchangeId: string,
+    verifiablePresentation: VP,
+    domain: string
+) {
+    // Extract challenge from the VP (handle both single proof and proof array)
+    const challenge = Array.isArray(verifiablePresentation.proof)
+        ? verifiablePresentation.proof[0]?.challenge
+        : verifiablePresentation.proof?.challenge;
+    
+    if (!challenge) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Verifiable presentation must include challenge in proof',
+        });
+    }
+
+    // Retrieve exchange state from Redis
+    const claimLinkInfo = await getClaimLinkSAInfoForBoost(localExchangeId, challenge);
+    
+    if (!claimLinkInfo) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Exchange session not found or expired',
+        });
+    }
+
+    // Verify the presentation
+    const learnCard = await getEmptyLearnCard();
+    const verificationResult = await learnCard.invoke.verifyPresentation(verifiablePresentation, {
+        challenge,
+        domain,
+    });
+
+    if (verificationResult.errors.length > 0 || !verificationResult.checks.includes('proof')) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Verifiable presentation verification failed',
+        });
+    }
+
+    // Extract holder DID from the VP
+    const holderDid = verifiablePresentation.holder;
+    
+    if (!holderDid) {
+        throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Verifiable presentation must include holder DID',
+        });
+    }
+
+    // Get the holder profile by DID
+    const holderProfile = await getProfileByDid(holderDid);
+    
+    if (!holderProfile) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Holder profile not found. Please create a profile first.',
+        });
+    }
+
+    // Get boost and validate it's still available
+    const boost = await getBoostByUri(localExchangeId);
+    
+    if (!boost) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Boost not found',
+        });
+    }
+
+    if (isDraftBoost(boost)) {
+        throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Draft boosts cannot be claimed',
+        });
+    }
+
+    // Get boost owner and their signing authority
+    const boostOwner = await getBoostOwner(boost);
+    
+    if (!boostOwner) {
+        throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Boost owner not found',
+        });
+    }
+
+    try {
+        // For VC-API workflow, we'll create the credential directly and use sendBoost
+        // This avoids the complexity of signing authorities for the VC-API exchange
+        const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC;
+        const boostURI = getBoostUri(boost.dataValues?.id, domain);
+
+        // Create the credential with proper subject and issuer
+        const credentialToIssue = {
+            ...boostCredential,
+            issuer: { id: getDidWeb(domain, boostOwner.profileId) },
+            issuanceDate: new Date().toISOString(),
+            credentialSubject: Array.isArray(boostCredential.credentialSubject)
+                ? boostCredential.credentialSubject.map(subject => ({
+                    ...subject,
+                    id: holderDid,
+                }))
+                : {
+                    ...boostCredential.credentialSubject,
+                    id: holderDid,
+                },
+        };
+
+        // Add boostId for BoostCredentials
+        if (credentialToIssue?.type?.includes('BoostCredential')) {
+            credentialToIssue.boostId = boostURI;
+        }
+
+        // Use sendBoost to issue and store the credential
+        const issuedCredentialUri = await sendBoost({
+            from: boostOwner,
+            to: holderProfile,
+            boost,
+            credential: credentialToIssue,
+            domain,
+            skipNotification: true,
+            autoAcceptCredential: true,
+        });
+
+        // Mark the challenge as used
+        await useClaimLinkForBoost(localExchangeId, challenge);
+
+        // Return VP containing the issued credential
+        // We'll use the same credential structure we just created for sendBoost
+        const responseVP = {
+            '@context': ['https://www.w3.org/2018/credentials/v1'],
+            type: ['VerifiablePresentation'],
+            holder: holderDid,
+            verifiableCredential: [credentialToIssue],
+        };
+
+        if (process.env.NODE_ENV !== 'test') {
+            console.log('🚀 VC-API Exchange Complete - Credential Issued', issuedCredentialUri);
+        }
+
+        return responseVP;
+
+    } catch (error) {
+        console.error('Failed to issue credential via VC-API exchange:', error);
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to issue credential for exchange',
+        });
+    }
+}
+
+export type WorkflowsRouter = typeof workflowsRouter;

--- a/services/learn-card-network/brain-service/src/routes/workflows.ts
+++ b/services/learn-card-network/brain-service/src/routes/workflows.ts
@@ -27,7 +27,6 @@ import {
 } from '@helpers/boost.helpers';
 import { getEmptyLearnCard, getLearnCard } from '@helpers/learnCard.helpers';
 import { issueCredentialWithSigningAuthority } from '@helpers/signingAuthority.helpers';
-import { getProfileByDid } from '@accesslayer/profile/read';
 
 // Zod schema for the participate in exchange input
 const participateInExchangeInput = z.object({


### PR DESCRIPTION
Implements the VC-API "Participate in an Exchange" endpoint to provide a standardized way for holders to claim Verifiable Credentials from boosts.

## Changes
- Add new workflowsRouter with participateInExchange endpoint
- Support two-step VC-API exchange flow: initiation and credential claim
- Exchange initiation returns VerifiablePresentationRequest with challenge
- Presentation verification issues credential and returns VP response
- Use Redis-based challenge management and existing boost claim logic
- Handle both single proof and proof array patterns in VP verification
- Integrate with existing sendBoost functionality for credential issuance

## Endpoint
`POST /workflows/{localWorkflowId}/exchanges/{localExchangeId}`

Fixes #698

🤖 Generated with [Claude Code](https://claude.ai/code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement VC-API workflow endpoints for claiming Boost credentials through a two-step authentication exchange process.

Main changes:
- Created new workflows router with participateInExchange mutation supporting VC-API credential exchange protocol
- Added base64url dependency for encoding/decoding exchange identifiers containing boost URIs
- Implemented two-phase credential exchange with DID authentication and verifiable presentation verification
- Integrated with existing claim-links cache system for challenge validation and boost issuance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
