### PR TITLE
[LC-1086] Anyone Can Make Children

### DIFF
--- a/.changeset/silly-aliens-tease.md
+++ b/.changeset/silly-aliens-tease.md
@@ -1,0 +1,18 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+'@learncard/types': patch
+---
+
+Introduces a new optional boolean `allowAnyoneToCreateChildren` on Boost nodes.
+
+When set to `true` on a parent boost:
+
+-   Any profile can create child boosts without possessing the `canCreateChildren` role permission.
+-   The permission gate (`canProfileCreateChildBoost`) now short-circuits when this flag is detected.
+
+This change updates:
+
+-   Boost schema & shared types (`@learncard/types`)
+-   Brain-service model & access-layer logic (`@learncard/network-brain-service`)
+-   Unit and E2E tests to cover the new behaviour.

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -221,6 +221,7 @@ export const BoostValidator = z.object({
     autoConnectRecipients: z.boolean().optional(),
     meta: z.record(z.any()).optional(),
     claimPermissions: BoostPermissionsValidator.optional(),
+    allowAnyoneToCreateChildren: z.boolean().optional(),
 });
 export type Boost = z.infer<typeof BoostValidator>;
 

--- a/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts
@@ -361,7 +361,8 @@ export const canProfileViewBoost = async (
         .with('COLLECT(parents) + COLLECT(target) AS boosts')
         .match({ identifier: 'profile', model: Profile, where: { profileId: profile.profileId } })
         .where(
-            `ANY(boost IN boosts WHERE EXISTS((profile)-[:${Boost.getRelationshipByAlias('hasRole').name
+            `ANY(boost IN boosts WHERE EXISTS((profile)-[:${
+                Boost.getRelationshipByAlias('hasRole').name
             }]-(boost)))`
         );
     const result = await query.return('count(profile) AS count, boosts').run();
@@ -374,6 +375,9 @@ export const canProfileCreateChildBoost = async (
     parentBoost: BoostInstance,
     childBoost: Omit<BoostType, 'boost' | 'id'>
 ) => {
+    // If the parent boost explicitly allows anyone to create children, bypass further checks
+    if (parentBoost.allowAnyoneToCreateChildren) return true;
+
     const query = new QueryBuilder()
         .match({ model: Boost, where: { id: parentBoost.id }, identifier: 'targetBoost' })
         .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })

--- a/services/learn-card-network/brain-service/src/models/Boost.ts
+++ b/services/learn-card-network/brain-service/src/models/Boost.ts
@@ -37,6 +37,7 @@ export const Boost = ModelFactory<FlatBoostType, BoostRelationships>(
             autoConnectRecipients: { type: 'boolean', required: false },
             boost: { type: 'string', required: true },
             status: { type: 'string', enum: BoostStatus.options, required: false },
+            allowAnyoneToCreateChildren: { type: 'boolean', required: false },
         },
         primaryKeyField: 'id',
         relationships: {

--- a/tests/e2e/tests/boosts.spec.ts
+++ b/tests/e2e/tests/boosts.spec.ts
@@ -204,4 +204,31 @@ describe('Boosts', () => {
 
         expect(incomingCredentials.some(cred => cred.uri === sentBoostUri)).toBe(true);
     });
+
+    test('Any user can create child boost if flag set on parent', async () => {
+        // User A creates a parent boost with the universal-child flag
+        // @ts-ignore – allow universal child flag not yet in typed SDK
+        const parentBoostUri = await a.invoke.createBoost(testUnsignedBoost, {
+            allowAnyoneToCreateChildren: true,
+        });
+        expect(parentBoostUri).toBeDefined();
+
+        // User B attempts to create a child boost of A's boost – should succeed without role
+        const childBoostUri = await b.invoke.createChildBoost(parentBoostUri, testUnsignedBoost);
+        expect(childBoostUri).toBeDefined();
+
+        // Verify relationship exists
+        const parents = await b.invoke.getBoostParents(childBoostUri);
+        expect(parents.records.some(record => record.uri === parentBoostUri)).toBe(true);
+
+        const secondChildBoostUri = await b.invoke.createBoost(testUnsignedBoost);
+
+        await b.invoke.makeBoostParent({
+            parentUri: parentBoostUri,
+            childUri: secondChildBoostUri,
+        });
+
+        const secondChildParents = await b.invoke.getBoostParents(secondChildBoostUri);
+        expect(secondChildParents.records.some(record => record.uri === parentBoostUri)).toBe(true);
+    });
 });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
[LC-1086] Add "allowAnyoneToCreateChildren" flag to Boost model to bypass role-based child-creation checks

#### 📚 What is the context and goal of this PR?

Introduce a new Boost-level flag `allowAnyoneToCreateChildren` that, when set, bypasses role-based permission checks and lets **any** profile create child boosts. This enables more open, community-driven boost hierarchies without manual role assignment.

#### 🥴 TL; RL:

* Added optional `allowAnyoneToCreateChildren` boolean to Boost schema & shared types
* Permission gate `canProfileCreateChildBoost` now short-circuits when flag is `true`
* Updated create/update flows, unit tests, and E2E test (`tests/e2e/tests/boosts.spec.ts`)
* Changesets updated (`silly-aliens-tease`) to publish patches to affected packages

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the unit tests and the E2E tests =)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1086]: https://welibrary.atlassian.net/browse/LC-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Introduces a boolean flag `allowAnyoneToCreateChildren` on Boost nodes to enable open child boost creation without requiring role permissions.

Main changes:
- Added `allowAnyoneToCreateChildren` boolean field to Boost schema and model
- Implemented permission gate bypass in `canProfileCreateChildBoost` function when flag is enabled
- Added E2E tests verifying users without role permissions can create child boosts

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
