### PR TITLE
Feat: Add Simple Signing Plugin to CLI

### DIFF
--- a/.changeset/moody-yaks-check.md
+++ b/.changeset/moody-yaks-check.md
@@ -1,0 +1,5 @@
+---
+"@learncard/cli": patch
+---
+
+Feat: Add Simple Signing Plugin to CLI

--- a/packages/learn-card-cli/package.json
+++ b/packages/learn-card-cli/package.json
@@ -15,6 +15,7 @@
         "@learncard/didkit-plugin": "workspace:^",
         "@learncard/init": "workspace:^",
         "@learncard/learn-cloud-plugin": "workspace:*",
+        "@learncard/simple-signing-plugin": "workspace:*",
         "@learncard/types": "workspace:*",
         "@rollup/plugin-json": "^4.1.0",
         "clipboardy": "^4.0.0",

--- a/packages/learn-card-cli/src/index.tsx
+++ b/packages/learn-card-cli/src/index.tsx
@@ -4,6 +4,7 @@ import dns from 'node:dns';
 import repl from 'pretty-repl';
 import { getTestCache } from '@learncard/core';
 import { initLearnCard, emptyLearnCard, learnCardFromSeed } from '@learncard/init';
+import { getSimpleSigningPlugin } from '@learncard/simple-signing-plugin';
 import types from '@learncard/types';
 import gradient from 'gradient-string';
 import figlet from 'figlet';
@@ -64,7 +65,7 @@ program
         globalThis.learnCardFromSeed = learnCardFromSeed;
         globalThis.initLearnCard = initLearnCard;
 
-        globalThis.learnCard = await initLearnCard({
+        const _learnCard = await initLearnCard({
             seed,
             network: true,
             allowRemoteContexts: true,
@@ -72,6 +73,11 @@ program
                 require.resolve('@learncard/didkit-plugin/dist/didkit/didkit_wasm_bg.wasm')
             ),
         });
+
+        globalThis.learnCard = await _learnCard.addPlugin(
+            await getSimpleSigningPlugin(_learnCard, 'https://api.learncard.app/trpc')
+        );
+
         globalThis.types = types;
         globalThis.getTestCache = getTestCache;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@learncard/learn-cloud-plugin':
         specifier: workspace:*
         version: link:../plugins/learn-cloud
+      '@learncard/simple-signing-plugin':
+        specifier: workspace:*
+        version: link:../plugins/simple-signing-plugin
       '@learncard/types':
         specifier: workspace:*
         version: link:../learn-card-types


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Make it easier for people to create / register signing authorities, using CLI

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [ ] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?


```
// Must create profile before creating / registering signing authorities
// Await learnCard.invoke.createProfile({ profileId, displayName, isServiceProfile: true })

// Retrieve managed signing authorities from LearnCard App
await learnCard.invoke.getSigningAuthorities()
// Create a signing authority with name “lca-sa” if it doesn’t exist in LearnCard App
const managedAuthority = await learnCard.invoke.createSigningAuthority(‘lca-sa’)

// Register signing authority with LearnCard Network, to authorize it to send credentials over the network to your managed “lca-sa” (it will set as primary if this is the first one)
await learnCard.invoke.registerSigningAuthority(managedAuthority.endpoint, managedAuthority.name, managedAuthority.did)

// Retrieve signing authorities registered with the LearnCard Network
await learnCard.invoke.getRegisteredSigningAuthorities()

// Set primary registered signing authority, so you can omit signing authority configuration from Universal Inbox issuance calls
await learnCard.invoke.setPrimaryRegisteredSigningAuthority(managedAuthority.endpoint, managedAuthority.name)
// Retrieve registered primary signing authority
await learnCard.invoke.getPrimaryRegisteredSigningAuthority()
```

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation


#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [ ] My code follows **style guidelines** (eslint / prettier)
- [ ] I have **manually tested** common end-2-end cases
- [ ] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [ ] Code is backwards compatible
- [ ] There is **not** a "Do Not Merge" label on this PR
- [ ] I have thoughtfully considered the security implications of this change.
- [ ] This change does not expose new public facing endpoints that do not have authentication
