### PR TITLE
[LC-1121] Long Loading Times/Neo4j Deadlock

### DIFF
--- a/.changeset/chilly-swans-teach.md
+++ b/.changeset/chilly-swans-teach.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-service': patch
+---
+
+Fix potential Neo4j Deadlock when creating a child boost


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1121] Open ai tutor just loads indefinitely or for a really long time) when starting a new session.

#### 📚 What is the context and goal of this PR?

When starting AI tutor it takes forever!

I _think_ this is happening because of a Neo4j Deadlock that can happen when creating a child boost.

#### 🥴 TL; RL:
We have this `Promise.all` call that does _two_ Neo4j queries at the same time, which could lead to a deadlock.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Moves those two calls to happen all in a single Neo4j Query! This actually speeds up the whole thing and removes the deadlock issue.

#### 🛠 Important tradeoffs made:
None =) This is just better.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Just run the test suite! If this broke anything, tests would catch it =)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1121]: https://welibrary.atlassian.net/browse/LC-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Neo4j deadlock in boost creation by replacing multiple async operations with a single atomic transaction.

Main changes:
- Replaced multiple Promise.all operations with single atomic transaction to prevent deadlocks
- Added Profile model import to support the consolidated transaction approach
- Implemented timestamp handling at transaction start for consistent relationship dating

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
