### PR TITLE
[LC-1173] defaultEnabled and autoboost permissions

### DIFF
--- a/.changeset/bumpy-suits-fetch.md
+++ b/.changeset/bumpy-suits-fetch.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/types': patch
+---
+
+Add defaultEnabled flags to contracts as a UI hint

--- a/.changeset/hip-pears-dig.md
+++ b/.changeset/hip-pears-dig.md
@@ -1,0 +1,5 @@
+---
+'@learncard/network-brain-service': patch
+---
+
+Do not issue autoboosts when the user has not given write permission for it!

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -310,17 +310,17 @@ export const ConsentFlowContractValidator = z.object({
         .object({
             anonymize: z.boolean().optional(),
             credentials: z
-                .object({ categories: z.record(z.object({ required: z.boolean() })).default({}) })
+                .object({ categories: z.record(z.object({ required: z.boolean(), defaultEnabled: z.boolean().optional() })).default({}) })
                 .default({}),
-            personal: z.record(z.object({ required: z.boolean() })).default({}),
+            personal: z.record(z.object({ required: z.boolean(), defaultEnabled: z.boolean().optional() })).default({}),
         })
         .default({}),
     write: z
         .object({
             credentials: z
-                .object({ categories: z.record(z.object({ required: z.boolean() })).default({}) })
+                .object({ categories: z.record(z.object({ required: z.boolean(), defaultEnabled: z.boolean().optional() })).default({}) })
                 .default({}),
-            personal: z.record(z.object({ required: z.boolean() })).default({}),
+            personal: z.record(z.object({ required: z.boolean(), defaultEnabled: z.boolean().optional() })).default({}),
         })
         .default({}),
 });

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/create.ts
@@ -190,6 +190,16 @@ export const consentToContract = async (
 
                     if (terms.deniedWriters?.includes(issuer.profileId)) return;
 
+                    const boostCategory = boost.target.category;
+                    if (boostCategory) {
+                        const categoryWritePermission =
+                            terms.write?.credentials?.categories?.[boostCategory];
+
+                        if (!categoryWritePermission) return;
+
+                        if (categoryWritePermission !== true) return;
+                    }
+
                     const contractOwnerSigningAuthority = await getSigningAuthorityForUserByName(
                         issuer,
                         signingAuthorityEndpoint,

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/update.ts
@@ -116,6 +116,18 @@ export const reconsentTerms = async (
                         return;
                     }
 
+                    const boostCategory = boost.dataValues.category;
+                    if (boostCategory) {
+                        const categoryWritePermission =
+                            terms.write?.credentials?.categories?.[boostCategory];
+
+                        // Category not found in write permissions - deny autoboost
+                        if (!categoryWritePermission) return;
+
+                        // Check if write permission is explicitly denied (false) or not granted (undefined)
+                        // Only issue autoboost if write permission is explicitly granted (true)
+                        if (categoryWritePermission !== true) return;
+                    }
                     // Get boost instance
                     const boostCredential = JSON.parse(boost.dataValues?.boost) as UnsignedVC | VC;
 
@@ -307,6 +319,18 @@ export const updateTerms = async (
                             `Signing authority "${signingAuthorityName}" at endpoint "${signingAuthorityEndpoint}" not found for contract owner`
                         );
                         return;
+                    }
+
+                    const boostCategory = boost.target.category;
+                    if (boostCategory) {
+                        const categoryWritePermission =
+                            terms.write?.credentials?.categories?.[boostCategory];
+
+                        if (!categoryWritePermission) return;
+
+                        // Check if write permission is explicitly denied (false) or not granted (undefined)
+                        // Only issue autoboost if write permission is explicitly granted (true)
+                        if (categoryWritePermission !== true) return;
                     }
 
                     // Get boost instance

--- a/services/learn-card-network/brain-service/test/consentflow.spec.ts
+++ b/services/learn-card-network/brain-service/test/consentflow.spec.ts
@@ -277,6 +277,51 @@ describe('Consent Flow Contracts', () => {
             // Verifying the image field
             expect(contract.image).toEqual(contractData.image);
         });
+
+        it('should allow setting and retrieving the defaultEnabled field for contract categories', async () => {
+            const contractWithDefaults: ConsentFlowContract = {
+                read: {
+                    personal: { 
+                        name: { required: false, defaultEnabled: true },
+                        email: { required: true, defaultEnabled: false }
+                    },
+                    credentials: {
+                        categories: {
+                            Achievement: { required: false, defaultEnabled: true },
+                            ID: { required: false, defaultEnabled: false }
+                        },
+                    },
+                },
+                write: {
+                    personal: {
+                        name: { required: false, defaultEnabled: true }
+                    },
+                    credentials: {
+                        categories: {
+                            Achievement: { required: true, defaultEnabled: false }
+                        },
+                    },
+                },
+            };
+
+            const contractUri = await userA.clients.fullAuth.contracts.createConsentFlowContract({
+                contract: contractWithDefaults,
+                name: 'Default Enabled Test Contract',
+            });
+
+            // Fetching the created contract
+            const contract = await userA.clients.fullAuth.contracts.getConsentFlowContract({
+                uri: contractUri,
+            });
+
+            // Verifying the defaultEnabled fields are preserved
+            expect(contract.contract.read.personal.name.defaultEnabled).toBe(true);
+            expect(contract.contract.read.personal.email.defaultEnabled).toBe(false);
+            expect(contract.contract.read.credentials.categories.Achievement.defaultEnabled).toBe(true);
+            expect(contract.contract.read.credentials.categories.ID.defaultEnabled).toBe(false);
+            expect(contract.contract.write.personal.name.defaultEnabled).toBe(true);
+            expect(contract.contract.write.credentials.categories.Achievement.defaultEnabled).toBe(false);
+        });
     });
 
     describe('getConsentFlowContracts', () => {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "test": "echo \"Skipping E2E tests in CI. Run test:e2e if you'd like to actually run this!\"",
         "test:e2e": "vitest",
+        "test:run": "vitest run",
         "logs": "docker compose logs -f"
     },
     "dependencies": {

--- a/tests/e2e/tests/consentflow.spec.ts
+++ b/tests/e2e/tests/consentflow.spec.ts
@@ -8,6 +8,7 @@ import {
     normalFullTerms,
     normalContract,
     normalNoTerms,
+    contractWithDefaults,
 } from './helpers/contract.helpers';
 import { VC } from '@learncard/types';
 
@@ -95,6 +96,47 @@ describe('ConsentFlow E2E Tests', () => {
                 // Expected to fail
                 expect(error).toBeDefined();
             }
+        });
+
+        it('should allow creating and retrieving a contract with defaultEnabled fields', async () => {
+            const contractName = `Default Enabled Contract ${Date.now()}`;
+            const contractUri = await a.invoke.createContract({
+                contract: contractWithDefaults,
+                name: contractName,
+                description: 'A contract for testing defaultEnabled fields',
+            });
+
+            expect(contractUri).toBeDefined();
+            expect(typeof contractUri).toBe('string');
+
+            // Retrieve the contract and verify defaultEnabled fields are preserved
+            const contract = await a.invoke.getContract(contractUri);
+
+            expect(contract).toBeDefined();
+            expect(contract.name).toBe(contractName);
+            expect(contract.description).toBe('A contract for testing defaultEnabled fields');
+
+            // Verify read section defaultEnabled fields
+            expect(contract.contract.read.personal.name?.defaultEnabled).toBe(true);
+            expect(contract.contract.read.personal.email?.defaultEnabled).toBe(false);
+            expect(contract.contract.read.personal.phone?.defaultEnabled).toBe(true);
+            expect(contract.contract.read.credentials.categories.Achievement?.defaultEnabled).toBe(true);
+            expect(contract.contract.read.credentials.categories.ID?.defaultEnabled).toBe(false);
+            expect(contract.contract.read.credentials.categories.Certificate?.defaultEnabled).toBe(false);
+
+            // Verify write section defaultEnabled fields
+            expect(contract.contract.write.personal.name?.defaultEnabled).toBe(true);
+            expect(contract.contract.write.personal.email?.defaultEnabled).toBe(false);
+            expect(contract.contract.write.credentials.categories.Achievement?.defaultEnabled).toBe(false);
+            expect(contract.contract.write.credentials.categories.Badge?.defaultEnabled).toBe(true);
+
+            // Verify required fields are still preserved alongside defaultEnabled
+            expect(contract.contract.read.personal.name?.required).toBe(false);
+            expect(contract.contract.read.personal.email?.required).toBe(true);
+            expect(contract.contract.read.credentials.categories.Achievement?.required).toBe(false);
+            expect(contract.contract.read.credentials.categories.Certificate?.required).toBe(true);
+            expect(contract.contract.write.credentials.categories.Achievement?.required).toBe(true);
+            expect(contract.contract.write.credentials.categories.Badge?.required).toBe(false);
         });
     });
 

--- a/tests/e2e/tests/helpers/contract.helpers.ts
+++ b/tests/e2e/tests/helpers/contract.helpers.ts
@@ -237,3 +237,32 @@ export const promiscuousTerms: ConsentFlowTerms = {
         },
     },
 };
+
+export const contractWithDefaults: ConsentFlowContract = {
+    read: {
+        personal: { 
+            name: { required: false, defaultEnabled: true },
+            email: { required: true, defaultEnabled: false },
+            phone: { required: false, defaultEnabled: true }
+        },
+        credentials: {
+            categories: {
+                Achievement: { required: false, defaultEnabled: true },
+                ID: { required: false, defaultEnabled: false },
+                Certificate: { required: true, defaultEnabled: false }
+            },
+        },
+    },
+    write: {
+        personal: {
+            name: { required: false, defaultEnabled: true },
+            email: { required: false, defaultEnabled: false }
+        },
+        credentials: {
+            categories: {
+                Achievement: { required: true, defaultEnabled: false },
+                Badge: { required: false, defaultEnabled: true }
+            },
+        },
+    },
+};


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1173] consentflow - get with Chris

#### 📚 What is the context and goal of this PR?


#### 🥴 TL; RL:
Adds a UI hint to enable parts of a contract without requiring them and fixes a security issue

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Previously you could issue autoboosts even if the user didn't give permission for that!

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the brain service tests and the E2E tests =)

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1173]: https://welibrary.atlassian.net/browse/LC-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add defaultEnabled UI hint flags to consent flow contracts and implement permission checks for autoboost issuance.
Main changes:
- Extended ConsentFlowContract schema with defaultEnabled flags for read/write permissions
- Added permission validation to prevent autoboost issuance without explicit write permissions
- Added tests to verify defaultEnabled flags and autoboost permission enforcement

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
