### PR TITLE
✨ feat: Git Environments + Staging CI/CD

### DIFF
--- a/.changeset/nice-ligers-wink.md
+++ b/.changeset/nice-ligers-wink.md
@@ -1,0 +1,6 @@
+---
+"@learncard/network-brain-service": patch
+"@learncard/learn-cloud-service": patch
+---
+
+🧹Chore: Update Git Actions to use Git Environments

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,33 @@
+name: 'Setup Node.js, pnpm, and Install Dependencies'
+description: 'A composite action to set up the environment for CI/CD jobs.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js 20.10
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.10.0
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 9
+        run_install: false
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - actions-use-git-envs
     workflow_dispatch:
         inputs:
             network-environment:
@@ -86,7 +85,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || fromJSON('["learn-cloud-network-api-staging"]') }}
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || (contains(github.event.head_commit.message, 'chore(release):') && fromJSON('["learn-cloud-network-api-production", "scout-network-api-production"]') || fromJSON('["learn-cloud-network-api-staging"]')) }}
         environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo
@@ -134,7 +133,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.learn-cloud-environment)) || fromJSON('["learn-cloud-storage-api-staging"]') }}
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.learn-cloud-environment)) || (contains(github.event.head_commit.message, 'chore(release):') && fromJSON('["learn-cloud-storage-api-production", "scout-storage-api-production"]') || fromJSON('["learn-cloud-storage-api-staging"]')) }}
         environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
                 RSA_PUBLIC_KEY: ${{ secrets.RSA_PUBLIC_KEY }}
                 JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
                 SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-                SENTRY_ENV: ${{ secrets.LEARN_CLOUD_SENTRY_ENV }}
+                SENTRY_ENV: ${{ secrets.SENTRY_ENV }}
                 SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
                 SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,35 @@ jobs:
 
             - name: Deploy Brain Service Lambda
               run: pnpm exec nx serverless-deploy network-brain-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
+              env:
+                # Variables
+                CLIENT_APP_DOMAIN_NAME: ${{ vars.CLIENT_APP_DOMAIN_NAME }}
+                POSTMARK_FROM_EMAIL: ${{ vars.POSTMARK_FROM_EMAIL }}
+                SERVERLESS_CACHE_INSTANCE_SIZE: ${{ vars.SERVERLESS_CACHE_INSTANCE_SIZE }}
+                SERVERLESS_HOSTED_ZONE_NAMES: ${{ vars.SERVERLESS_HOSTED_ZONE_NAMES }}
+                SERVERLESS_DOMAIN_NAME: ${{ vars.SERVERLESS_DOMAIN_NAME }}
+                SERVERLESS_REGION: ${{ vars.SERVERLESS_REGION }}
+                SERVERLESS_SERVICE_NAME: ${{ vars.SERVERLESS_SERVICE_NAME }}
+              
+                # Secrets
+                SEED: ${{ secrets.SEED }}
+                DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+                NOTIFICATIONS_SERVICE_WEBHOOK_URL: ${{ secrets.NOTIFICATIONS_SERVICE_WEBHOOK_URL }}
+                NEO4J_URI: ${{ secrets.NEO4J_URI }}
+                NEO4J_USERNAME: ${{ secrets.NEO4J_USERNAME }}
+                NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
+                POSTMARK_API_KEY: ${{ secrets.POSTMARK_API_KEY }}
+                MESSAGEBIRD_AUTH_TOKEN: ${{ secrets.MESSAGEBIRD_AUTH_TOKEN }}
+                MESSAGEBIRD_ORIGINATOR: ${{ secrets.MESSAGEBIRD_ORIGINATOR }}
+                SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+                SENTRY_ENV: ${{ secrets.SENTRY_ENV }}
+                SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+                SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+                SMART_RESUME_CLIENT_ID: ${{ secrets.SMART_RESUME_CLIENT_ID }}
+                SMART_RESUME_ACCESS_KEY: ${{ secrets.SMART_RESUME_ACCESS_KEY }}
+                SMART_RESUME_CONTRACT_URI: ${{ secrets.SMART_RESUME_CONTRACT_URI }}
+
 
     deploy-learn-cloud:
         name: Deploy ${{ matrix.environment }} Storage API
@@ -116,6 +145,30 @@ jobs:
 
             - name: Deploy LearnCloud Lambda
               run: pnpm exec nx serverless-deploy learn-cloud-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
+              env:
+                # Variables
+                SERVER_URL: ${{ vars.SERVER_URL }}
+                SERVERLESS_CACHE_INSTANCE_SIZE: ${{ vars.SERVERLESS_CACHE_INSTANCE_SIZE }}
+                SERVERLESS_HOSTED_ZONE_NAMES: ${{ vars.SERVERLESS_HOSTED_ZONE_NAMES }}
+                SERVERLESS_DOMAIN_NAME: ${{ vars.SERVERLESS_DOMAIN_NAME }}
+                SERVERLESS_REGION: ${{ vars.SERVERLESS_REGION }}
+                SERVERLESS_SERVICE_NAME: ${{ vars.SERVERLESS_SERVICE_NAME }}
+                
+                # Secrets
+                LEARN_CLOUD_SEED: ${{ secrets.LEARN_CLOUD_SEED }}
+                LEARN_CLOUD_MONGO_URI: ${{ secrets.LEARN_CLOUD_MONGO_URI }}
+                LEARN_CLOUD_MONGO_DB_NAME: ${{ secrets.LEARN_CLOUD_MONGO_DB_NAME }}
+                XAPI_ENDPOINT: ${{ secrets.XAPI_ENDPOINT }}
+                XAPI_USERNAME: ${{ secrets.XAPI_USERNAME }}
+                XAPI_PASSWORD: ${{ secrets.XAPI_PASSWORD }}
+                RSA_PRIVATE_KEY: ${{ secrets.RSA_PRIVATE_KEY }}
+                RSA_PUBLIC_KEY: ${{ secrets.RSA_PUBLIC_KEY }}
+                JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
+                SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+                SENTRY_ENV: ${{ secrets.LEARN_CLOUD_SENTRY_ENV }}
+                SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+                SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
     generate-sdk:
         name: Generate SDK Clients for LearnCloud Network API

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,17 +4,18 @@ on:
     push:
         branches:
             - main
+            - actions-use-git-envs
     workflow_dispatch:
         inputs:
             network-environment:
                 description: 'Choose Environment'
                 required: true
-                default: 'learn-card-network-api-staging'
+                default: 'learn-cloud-network-api-staging'
                 type: environment
             learn-cloud-environment:
                 description: 'Choose Environment'
                 required: true
-                default: 'learn-card-storage-api-staging'
+                default: 'learn-cloud-storage-api-staging'
                 type: environment
 
 
@@ -82,7 +83,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || fromJSON('["learn-cloud-network-api-production", "scout-network-api-production"]') }}
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || fromJSON('["learn-cloud-network-api-staging"]') }}
         environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo
@@ -101,7 +102,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.learn-cloud-environment)) || fromJSON('["learn-cloud-storage-api-production", "scout-storage-api-production"]') }}
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.learn-cloud-environment)) || fromJSON('["learn-cloud-storage-api-staging"]') }}
         environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,47 +12,10 @@ env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     AWS_DEFAULT_REGION: us-east-1
-    SEED: ${{ secrets.SEED }}
-    LEARN_CLOUD_SEED: ${{ secrets.LEARN_CLOUD_SEED }}
-    LEARN_CLOUD_MONGO_URI: ${{ secrets.LEARN_CLOUD_MONGO_URI }}
-    LEARN_CLOUD_MONGO_DB_NAME: ${{ secrets.LEARN_CLOUD_MONGO_DB_NAME }}
-    DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
-    CLIENT_APP_DOMAIN_NAME: ${{ vars.CLIENT_APP_DOMAIN_NAME }}
-    NOTIFICATIONS_SERVICE_WEBHOOK_URL: ${{ secrets.NOTIFICATIONS_SERVICE_WEBHOOK_URL }}
-    NEO4J_URI: ${{ secrets.NEO4J_URI }}
-    NEO4J_USERNAME: ${{ secrets.NEO4J_USERNAME }}
-    NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
-    POSTMARK_API_KEY: ${{ secrets.POSTMARK_API_KEY }}
-    POSTMARK_FROM_EMAIL: ${{ vars.POSTMARK_FROM_EMAIL }}
-    MESSAGEBIRD_AUTH_TOKEN: ${{ secrets.MESSAGEBIRD_AUTH_TOKEN }}
-    MESSAGEBIRD_ORIGINATOR: ${{ secrets.MESSAGEBIRD_ORIGINATOR }}
-    TRUSTED_ISSUERS_WHITELIST: ${{ secrets.TRUSTED_ISSUERS_WHITELIST }}
-    DCC_KNOWN_REGISTRIES_URL: ${{ secrets.DCC_KNOWN_REGISTRIES_URL }}
-    DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    DD_ENV: ${{ secrets.DD_ENV }}
-    DD_SERVICE: ${{ secrets.DD_SERVICE }}
-    DD_SITE: ${{ secrets.DD_SITE }}
-    DD_VERSION: ${{ secrets.DD_VERSION }}
-    SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    SENTRY_ENV: ${{ secrets.SENTRY_ENV }}
-    LEARN_CLOUD_SENTRY_ENV: ${{ secrets.LEARN_CLOUD_SENTRY_ENV }}
-    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-    SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-    SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-    SERVER_URL: ${{ secrets.SERVER_URL }}
-    XAPI_ENDPOINT: ${{ secrets.XAPI_ENDPOINT }}
-    XAPI_USERNAME: ${{ secrets.XAPI_USERNAME }}
-    XAPI_PASSWORD: ${{ secrets.XAPI_PASSWORD }}
-    JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
-    RSA_PUBLIC_KEY: ${{ secrets.RSA_PUBLIC_KEY }}
-    RSA_PRIVATE_KEY: ${{ secrets.RSA_PRIVATE_KEY }}
-    SMART_RESUME_CLIENT_ID: ${{ secrets.SMART_RESUME_CLIENT_ID }}
-    SMART_RESUME_ACCESS_KEY: ${{ secrets.SMART_RESUME_ACCESS_KEY }}
-    SMART_RESUME_CONTRACT_URI: ${{ secrets.SMART_RESUME_CONTRACT_URI }}
 
 jobs:
-    deploy:
-        name: Deploy
+    determine-affected:
+        name: Determine Affected Projects
         runs-on: ubuntu-latest
         outputs:
             affected: ${{ steps.affected.outputs.affected }}
@@ -67,32 +30,27 @@ jobs:
               run: |
                   git fetch --no-tags --prune --depth=5 origin main
 
-            - name: Setup Node.js 20.10
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 20.10.0
+            - name: Use Composite Setup Action
+              uses: ./.github/actions/setup
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@v2
-              id: pnpm-install
-              with:
-                  version: 9
-                  run_install: false
+            - name: Get Affected List
+              id: affected
+              run: |
+                  affected=$(pnpm exec nx print-affected --base=HEAD~1 --head=HEAD --select=projects)
+                  echo "affected=$affected" >> $GITHUB_OUTPUT
 
-            - name: Get pnpm store directory
-              id: pnpm-cache
-              run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+    test-affected:
+        name: Test Affected Projects
+        needs: determine-affected
+        if: needs.determine-affected.outputs.affected != ''
+        runs-on: ubuntu-latest
+        environment: ci-tests
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v3
 
-            - name: Setup pnpm cache
-              uses: actions/cache@v3
-              with:
-                  path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install dependencies
-              run: pnpm install --no-frozen-lockfile
+            - name: Use Composite Setup Action
+              uses: ./.github/actions/setup
 
             - name: Run tests
               uses: nick-fields/retry@v2
@@ -104,25 +62,47 @@ jobs:
                   SEED: ${{ secrets.SEED }}
                   LEARN_CLOUD_SEED: ${{ secrets.LEARN_CLOUD_SEED }}
 
-            - name: Get Affected List
-              id: affected
-              run: |
-                  affected=$(pnpm exec nx print-affected --base=HEAD~1 --head=HEAD --select=projects)
-                  echo "AFFECTED=$affected" >> $GITHUB_ENV       # for use in later steps of this job
-                  echo "affected=$affected" >> $GITHUB_OUTPUT     # for passing to other jobs
+    deploy-brain-service:
+        name: Deploy ${{ matrix.environment }} Network API 
+        needs: [determine-affected, test-affected]
+        if: contains(needs.determine-affected.outputs.affected, 'network-brain-service')
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                environment: [learn-cloud-network-api-production, scout-network-api-production]
+        environment: ${{ matrix.environment }}
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v3
+
+            - name: Use Composite Setup Action
+              uses: ./.github/actions/setup
 
             - name: Deploy Brain Service Lambda
-              if: contains(env.AFFECTED, 'network-brain-service')
-              run: pnpm exec nx serverless-deploy network-brain-service --stage production
+              run: pnpm exec nx serverless-deploy network-brain-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
+
+    deploy-learn-cloud:
+        name: Deploy ${{ matrix.environment }} Storage API
+        needs: [determine-affected, test-affected]
+        if: contains(needs.determine-affected.outputs.affected, 'learn-cloud-service')
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                environment: [learn-cloud-storage-api-production, scout-storage-api-production]
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v3
+
+            - name: Use Composite Setup Action
+              uses: ./.github/actions/setup
 
             - name: Deploy LearnCloud Lambda
-              if: contains(env.AFFECTED, 'learn-cloud-service')
-              run: pnpm exec nx serverless-deploy learn-cloud-service --stage production
+              run: pnpm exec nx serverless-deploy learn-cloud-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
 
     generate-sdk:
         name: Generate SDK Clients for LearnCloud Network API
-        needs: deploy
-        if: contains(needs.deploy.outputs.affected, 'network-brain-service')
+        needs: [determine-affected, deploy-brain-service]
+        if: contains(needs.determine-affected.outputs.affected, 'network-brain-service')
         uses: ./.github/workflows/open-api-generator.yml
         with:
-            affected: ${{ needs.deploy.outputs.affected }}
+            affected: ${{ needs.determine-affected.outputs.affected }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,9 @@ jobs:
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  fetch-depth: 0
 
             - name: Use Composite Setup Action
               uses: ./.github/actions/setup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,19 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch:
+        inputs:
+            network-environment:
+                description: 'Choose Environment'
+                required: true
+                default: 'learn-card-network-api-staging'
+                type: environment
+            learn-cloud-environment:
+                description: 'Choose Environment'
+                required: true
+                default: 'learn-card-storage-api-staging'
+                type: environment
+
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -69,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: [learn-cloud-network-api-production, scout-network-api-production]
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || fromJSON('["learn-cloud-network-api-production", "scout-network-api-production"]') }}
         environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo
@@ -88,7 +101,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                environment: [learn-cloud-storage-api-production, scout-storage-api-production]
+                environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.learn-cloud-environment)) || fromJSON('["learn-cloud-storage-api-production", "scout-storage-api-production"]') }}
+        environment: ${{ matrix.environment }}
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,15 +8,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  CI: true
-  LEARN_CLOUD_SEED: ${{ secrets.LEARN_CLOUD_SEED }}
-  LEARN_CLOUD_MONGO_URI: ${{ secrets.LEARN_CLOUD_MONGO_URI }}
-  LEARN_CLOUD_MONGO_DB_NAME: ${{ secrets.LEARN_CLOUD_MONGO_DB_NAME }}
-
 jobs:
   push-to-registry:
     name: Push Docker images to Docker Hub
+    environment: ci-tests
     if: | 
       github.event.pull_request.merged == true &&
       github.head_ref == 'changeset-release/main'
@@ -32,32 +27,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        id: pnpm-install
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+      - name: Use Composite Setup Action
+        uses: ./.github/actions/setup
 
       - name: Run tests
         uses: nick-fields/retry@v2

--- a/.github/workflows/maids.yml
+++ b/.github/workflows/maids.yml
@@ -16,6 +16,7 @@ jobs:
   maid-service:
     name: Maid-Service
     runs-on: ubuntu-latest
+    environment: ci-tests
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,48 +7,19 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  CI: true
-  LEARN_CLOUD_SEED: ${{ secrets.LEARN_CLOUD_SEED }}
-  LEARN_CLOUD_MONGO_URI: ${{ secrets.LEARN_CLOUD_MONGO_URI }}
-  LEARN_CLOUD_MONGO_DB_NAME: ${{ secrets.LEARN_CLOUD_MONGO_DB_NAME }}
-
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: ci-tests
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        id: pnpm-install
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+      - name: Use Composite Setup Action
+        uses: ./.github/actions/setup
 
       - name: Run tests
         uses: nick-fields/retry@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm publish -r
+          commit: chore(release): ${{ github.event.head_commit.message }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Test:
     runs-on: ubuntu-latest
-
+    environment: ci-tests
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -19,32 +19,8 @@ jobs:
         run: |
           git fetch --no-tags --prune --depth=5 origin main
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        id: pnpm-install
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+      - name: Use Composite Setup Action
+        uses: ./.github/actions/setup
 
       - name: Run tests
         uses: nick-fields/retry@v2

--- a/services/learn-card-network/brain-service/project.json
+++ b/services/learn-card-network/brain-service/project.json
@@ -31,6 +31,18 @@
         ]
     },
     "targets": {
+        "serverless-deploy": {
+            "executor": "nx:run-script",
+            "inputs": [
+                "source"
+            ],
+            "dependsOn": [
+                "^build"
+            ],
+            "options": {
+                "script": "serverless-deploy"
+            }
+        },
         "build": {
             "executor": "nx:run-script",
             "inputs": [

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -117,9 +117,9 @@ provider:
         REDIS_PORT:
             'Fn::GetAtt': [ElasticCacheCluster, RedisEndpoint.Port]
         NOTIFICATIONS_QUEUE_URL: ${construct:notifications-queue.queueUrl}
-        SMART_RESUME_CLIENT_ID: ${env:SMART_RESUME_CLIENT_ID}
-        SMART_RESUME_ACCESS_KEY: ${env:SMART_RESUME_ACCESS_KEY}
-        SMART_RESUME_CONTRACT_URI: ${env:SMART_RESUME_CONTRACT_URI}
+        SMART_RESUME_CLIENT_ID: ${env:SMART_RESUME_CLIENT_ID, ""}
+        SMART_RESUME_ACCESS_KEY: ${env:SMART_RESUME_ACCESS_KEY, ""}
+        SMART_RESUME_CONTRACT_URI: ${env:SMART_RESUME_CONTRACT_URI, ""}
     tracing:
         apiGateway: true
         lambda: true

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -42,9 +42,9 @@ custom:
 
         # References to 'dev' stage
         dev:
-            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'testnet.network.learncard.com.'}
-            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet.network.learncard.com'}
-            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet.network.learncard.com'}
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'network.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'staging.network.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'staging.network.learncard.com'}
 
     # Amazon Certificate Manager
     customCertificate:

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -1,6 +1,6 @@
 # serverless.yml
 
-service: lcn-brain-service
+service: ${env:SERVERLESS_SERVICE_NAME, 'lcn-brain-service'}
 
 frameworkVersion: '3'
 
@@ -21,7 +21,7 @@ constructs:
 
 custom:
     config:
-        CACHE_INSTANCE_SIZE: cache.t2.micro
+        CACHE_INSTANCE_SIZE: ${env:SERVERLESS_CACHE_INSTANCE_SIZE, 'cache.t2.micro'}
     esbuild:
         packager: pnpm
         plugins: esbuildPlugins.cjs
@@ -36,19 +36,21 @@ custom:
     domains:
         # References to 'prod' stage
         production:
-            domainName: network.learncard.com
-            certificateName: network.learncard.com
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'network.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'network.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'network.learncard.com'}
 
         # References to 'dev' stage
         dev:
-            domainName: testnet.network.learncard.com
-            certificateName: testnet.network.learncard.com
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'testnet.network.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet.network.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet.network.learncard.com'}
 
     # Amazon Certificate Manager
     customCertificate:
         # Route 53 Hosted Zone name
         # don't forget the dot on the end!
-        hostedZoneNames: 'network.learncard.com.'
+        hostedZoneNames: ${self:custom.domains.${self:provider.stage}.hostedZoneName}
 
         # Here we get our certificate name inside custom.domain.STAGE.certificateName
         # STAGE will be automatically filled with the value from "provider > stage"

--- a/services/learn-card-network/brain-service/src/constants/auth-grant.ts
+++ b/services/learn-card-network/brain-service/src/constants/auth-grant.ts
@@ -32,7 +32,7 @@
  * - Resource-wide: "authGrants:*"
  * - Multiple scopes: Space-separated list of scopes
  *   e.g., "authGrants:read contracts:write didMetadata:read"
- * - No access: ""
+ * - No access: "".
  */
 
 // Common scope bundles

--- a/services/learn-card-network/brain-service/src/constants/auth-grant.ts
+++ b/services/learn-card-network/brain-service/src/constants/auth-grant.ts
@@ -32,7 +32,7 @@
  * - Resource-wide: "authGrants:*"
  * - Multiple scopes: Space-separated list of scopes
  *   e.g., "authGrants:read contracts:write didMetadata:read"
- * - No access: ""
+ * - No access: "" 
  */
 
 // Common scope bundles

--- a/services/learn-card-network/brain-service/src/constants/auth-grant.ts
+++ b/services/learn-card-network/brain-service/src/constants/auth-grant.ts
@@ -32,7 +32,7 @@
  * - Resource-wide: "authGrants:*"
  * - Multiple scopes: Space-separated list of scopes
  *   e.g., "authGrants:read contracts:write didMetadata:read"
- * - No access: "" 
+ * - No access: ""
  */
 
 // Common scope bundles

--- a/services/learn-card-network/brain-service/src/constants/auth-grant.ts
+++ b/services/learn-card-network/brain-service/src/constants/auth-grant.ts
@@ -32,6 +32,7 @@
  * - Resource-wide: "authGrants:*"
  * - Multiple scopes: Space-separated list of scopes
  *   e.g., "authGrants:read contracts:write didMetadata:read"
+ * - No access: ""
  */
 
 // Common scope bundles

--- a/services/learn-card-network/brain-service/src/constants/auth-grant.ts
+++ b/services/learn-card-network/brain-service/src/constants/auth-grant.ts
@@ -19,6 +19,7 @@
  * - contracts-data
  * - didMetadata
  * - authGrants
+ * - inbox
  *
  * Actions include:
  * - read: Permission to view resources

--- a/services/learn-card-network/learn-cloud-service/project.json
+++ b/services/learn-card-network/learn-cloud-service/project.json
@@ -31,6 +31,18 @@
         ]
     },
     "targets": {
+        "serverless-deploy": {
+            "executor": "nx:run-script",
+            "inputs": [
+                "source"
+            ],
+            "dependsOn": [
+                "^build"
+            ],
+            "options": {
+                "script": "serverless-deploy"
+            }
+        },
         "build": {
             "executor": "nx:run-script",
             "inputs": [

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -1,6 +1,6 @@
 # serverless.yml
 
-service: learn-cloud-service
+service: ${env:SERVERLESS_SERVICE_NAME, 'learn-cloud-service'}
 
 frameworkVersion: '3'
 
@@ -14,7 +14,7 @@ plugins:
 
 custom:
     config:
-        CACHE_INSTANCE_SIZE: cache.t2.micro
+        CACHE_INSTANCE_SIZE: ${env:SERVERLESS_CACHE_INSTANCE_SIZE, 'cache.t2.micro'}
     esbuild:
         packager: pnpm
         plugins: esbuildPlugins.cjs
@@ -30,16 +30,16 @@ custom:
         # References to 'prod' stage
         production:
             # don't forget the dot on the end!
-            hostedZoneName: 'cloud.learncard.com.'
-            domainName: cloud.learncard.com
-            certificateName: cloud.learncard.com
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'cloud.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'cloud.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'cloud.learncard.com'}
 
         # References to 'dev' stage
         dev:
             # don't forget the dot on the end!
-            hostedZoneName: 'testnet-cloud.learncard.com.'
-            domainName: testnet-cloud.learncard.com
-            certificateName: testnet-cloud.learncard.com
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'testnet-cloud.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet-cloud.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet-cloud.learncard.com'}
 
     # Amazon Certificate Manager
     customCertificate:

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -98,7 +98,7 @@ provider:
         SERVER_URL: ${env:SERVER_URL, "https://cloud.learncard.com"}
         JWT_SIGNING_KEY: ${env:JWT_SIGNING_KEY, ""}
         SENTRY_DSN: ${env:SENTRY_DSN}
-        SENTRY_ENV: ${env:LEARN_CLOUD_SENTRY_ENV}
+        SENTRY_ENV: ${env:SENTRY_ENV}
         SENTRY_AUTH_TOKEN: ${env:SENTRY_AUTH_TOKEN}
         SENTRY_ORG: ${env:SENTRY_ORG}
         SENTRY_PROJECT: ${env:SENTRY_PROJECT}

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -37,9 +37,9 @@ custom:
         # References to 'dev' stage
         dev:
             # don't forget the dot on the end!
-            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'testnet-cloud.learncard.com.'}
-            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet-cloud.learncard.com'}
-            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'testnet-cloud.learncard.com'}
+            hostedZoneName: ${env:SERVERLESS_HOSTED_ZONE_NAMES, 'cloud.learncard.com.'}
+            domainName: ${env:SERVERLESS_DOMAIN_NAME, 'staging.cloud.learncard.com'}
+            certificateName: ${env:SERVERLESS_DOMAIN_NAME, 'staging.cloud.learncard.com'}
 
     # Amazon Certificate Manager
     customCertificate:

--- a/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
+++ b/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
@@ -1,2 +1,2 @@
-/** XAPI Endpoint. */
+/** XAPI Endpoint */
 export const XAPI_ENDPOINT = process.env.XAPI_ENDPOINT;

--- a/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
+++ b/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
@@ -1,2 +1,2 @@
-/** XAPI Endpoint */
+/** XAPI Endpoint. */
 export const XAPI_ENDPOINT = process.env.XAPI_ENDPOINT;

--- a/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
+++ b/services/learn-card-network/learn-cloud-service/src/constants/xapi.ts
@@ -1,1 +1,2 @@
+/** XAPI Endpoint */
 export const XAPI_ENDPOINT = process.env.XAPI_ENDPOINT;

--- a/services/learn-card-network/learn-cloud-service/src/mongo.ts
+++ b/services/learn-card-network/learn-cloud-service/src/mongo.ts
@@ -1,27 +1,41 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import dotenv from 'dotenv';
-import { MongoClient } from 'mongodb';
+import { Db, MongoClient } from 'mongodb';
 
 dotenv.config();
 
-const uri = process.env.__MONGO_URI__ || process.env.LEARN_CLOUD_MONGO_URI;
-const dbName = process.env.__MONGO_DB_NAME__ || process.env.LEARN_CLOUD_MONGO_DB_NAME;
+let getClient: () => MongoClient;
+let client: MongoClient;
+let mongodb: Db;
 
-if (!uri) throw new Error('No Mongo URI set!');
+if (process.env.CI) {
+	getClient = () => ({} as any);
+	client = {} as any;
+	mongodb = {} as any;
+} else {
+	const uri = process.env.__MONGO_URI__ || process.env.LEARN_CLOUD_MONGO_URI;
+	const dbName = process.env.__MONGO_DB_NAME__ || process.env.LEARN_CLOUD_MONGO_DB_NAME;
 
-export const getClient = () => {
-    return new MongoClient(uri, {
-        connectTimeoutMS: 180_000,
-        socketTimeoutMS: 180_000,
-        maxPoolSize: 5,
-        minPoolSize: 1,
-        maxIdleTimeMS: 180_000,
-        serverSelectionTimeoutMS: 180_000,
-    });
-};
+	if (!uri) throw new Error('No Mongo URI set!');
 
-export const client = getClient();
-export const mongodb = client.db(dbName);
+	getClient = () => {
+		return new MongoClient(uri, {
+			connectTimeoutMS: 180_000,
+			socketTimeoutMS: 180_000,
+			maxPoolSize: 5,
+			minPoolSize: 1,
+			maxIdleTimeMS: 180_000,
+			serverSelectionTimeoutMS: 180_000,
+		});
+	};
 
-client.on('error', error => console.log('Mongo error!', error));
+	client = getClient();
+	mongodb = client.db(dbName);
+
+	client.on('error', error => console.log('Mongo error!', error));
+}
+
+export { getClient, client, mongodb };
 
 export default mongodb;
+


### PR DESCRIPTION
### 📚 What is the context and goal of this PR?

This PR introduces a more sophisticated and automated deployment strategy to differentiate between staging and production environments. Previously, all pushes to `main` would trigger a deployment.

The goal is to create a seamless CI/CD flow where:

* Standard pushes to the `main` branch automatically deploy to `staging` for continuous integration and testing.
* Merging an official release PR (generated by the `release.yml` workflow) automatically triggers a deployment to our `production` environments.
* Manual deployments to any environment via `workflow_dispatch`.

### 🥴 TL;DR

The `deploy.yml` workflow now automatically deploys to `staging` on every push to `main`. It only deploys to `production` when a commit from our `release.yml` workflow (identified by a `chore(release):` prefix) is merged, creating a GitOps-style promotion pipeline.

### 💡 Feature Breakdown

This new deployment logic is achieved through two key changes:

1.  **Conditional Deployment Matrix in `deploy.yml`**
    The `strategy.matrix` for our deployment jobs now uses a conditional expression to select the correct environment. It checks the context of the trigger:
    * If it's a manual `workflow_dispatch` run, it uses the user-selected environment.
    * If it's a `push` to `main`, it inspects the commit message. If the message contains `chore(release):`, it targets the production environments; otherwise, it defaults to the staging environments.

    ```yaml
    # Example from deploy.yml
    strategy:
        matrix:
            environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.network-environment)) || (contains(github.event.head_commit.message, 'chore(release):') && fromJSON('["learn-cloud-network-api-production", "scout-network-api-production"]') || fromJSON('["learn-cloud-network-api-staging"]')) }}
    ```

2.  **Release Commit Convention in `release.yml`**
    The `release.yml` workflow, which handles versioning and publishing, has been updated. The `changesets/action` now adds a conventional commit prefix (`chore(release):`) to the commits it generates. This specific message is the key that triggers the production deployment logic in `deploy.yml`.

    ```yaml
    # From release.yml
    - name: Create Release Pull Request or Publish to npm
      uses: changesets/action@v1
      with:
        publish: pnpm publish -r
        commit: chore(release): Version Packages
    ```

### 🛠 Important tradeoffs made:

* **Dependency on Commit Convention:** The entire automated production deployment pipeline hinges on the `chore(release):` commit message prefix. This is a good convention but requires strict adherence. If a release is performed manually without this exact message, it will not be deployed to production automatically.
* **Increased Complexity:** The matrix logic in `deploy.yml` is now more powerful but also more complex. This adds a layer of abstraction that may require new contributors to take a moment to understand.

# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication
