### PR TITLE
[LC-1228] countBoostRecipientsWithChildren

### DIFF
--- a/.changeset/shaky-wings-cheer.md
+++ b/.changeset/shaky-wings-cheer.md
@@ -1,0 +1,6 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/network-plugin': patch
+---
+
+Add countBoostRecipientsWithChildren resolver

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -561,6 +561,24 @@ export const getLearnCardNetworkPlugin = async (
                     numberOfGenerations,
                 });
             },
+            countBoostRecipientsWithChildren: async (
+                _learnCard,
+                uri,
+                includeUnacceptedBoosts = true,
+                boostQuery,
+                profileQuery,
+                numberOfGenerations = 1
+            ) => {
+                if (!userData) throw new Error('Please make an account first!');
+
+                return client.boost.getBoostRecipientsWithChildrenCount.query({
+                    uri,
+                    includeUnacceptedBoosts,
+                    boostQuery,
+                    profileQuery,
+                    numberOfGenerations,
+                });
+            },
             countBoostRecipients: async (_learnCard, uri, includeUnacceptedBoosts = true) => {
                 if (!userData) throw new Error('Please make an account first!');
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -239,6 +239,13 @@ export type LearnCardNetworkPluginMethods = {
         profileQuery?: LCNProfileQuery,
         numberOfGenerations?: number
     ) => Promise<PaginatedBoostRecipientsWithChildrenType>;
+    countBoostRecipientsWithChildren: (
+        uri: string,
+        includeUnacceptedBoosts?: boolean,
+        boostQuery?: BoostQuery,
+        profileQuery?: LCNProfileQuery,
+        numberOfGenerations?: number
+    ) => Promise<number>;
     countBoostRecipients: (uri: string, includeUnacceptedBoosts?: boolean) => Promise<number>;
     getConnectedBoostRecipients: (
         uri: string,

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -51,6 +51,7 @@ import {
     countConnectedBoostRecipients,
     isProfileBoostAdmin,
     countBoostRecipients,
+    countBoostRecipientsWithChildren,
     isBoostParent,
     getBoostPermissions,
     canManageBoostPermissions,
@@ -751,6 +752,46 @@ export const boostsRouter = t.router({
                 records: records.slice(0, limit),
                 ...(newCursor && { cursor: newCursor }),
             };
+        }),
+
+    getBoostRecipientsWithChildrenCount: profileRoute
+        .meta({
+            openapi: {
+                protect: true,
+                method: 'POST',
+                path: '/boost/recipients-with-children/count',
+                tags: ['Boosts'],
+                summary: 'Count boost recipients with children',
+                description:
+                    'This endpoint counts distinct recipients of a boost and all its children boosts',
+            },
+            requiredScope: 'boosts:read',
+        })
+        .input(
+            z.object({
+                uri: z.string(),
+                includeUnacceptedBoosts: z.boolean().default(true),
+                numberOfGenerations: z.number().default(1),
+                boostQuery: BoostQueryValidator.optional(),
+                profileQuery: LCNProfileQueryValidator.optional(),
+            })
+        )
+        .output(z.number())
+        .query(async ({ input }) => {
+            const { uri, includeUnacceptedBoosts, numberOfGenerations, boostQuery, profileQuery } =
+                input;
+
+            const decodedUri = decodeURIComponent(uri);
+            const boost = await getBoostByUri(decodedUri);
+
+            if (!boost) throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
+
+            return countBoostRecipientsWithChildren(boost, {
+                includeUnacceptedBoosts,
+                numberOfGenerations,
+                boostQuery,
+                profileQuery,
+            });
         }),
 
     countBoostChildren: profileRoute

--- a/services/learn-card-network/brain-service/test/boost.countRecipientsWithChildren.spec.ts
+++ b/services/learn-card-network/brain-service/test/boost.countRecipientsWithChildren.spec.ts
@@ -1,0 +1,220 @@
+import { describe, it, beforeAll, beforeEach, afterAll, expect } from 'vitest';
+
+import { getUser } from './helpers/getClient';
+import { sendBoost, testUnsignedBoost } from './helpers/send';
+
+import { Profile, Boost, Credential, Role } from '@models';
+import { getBoostByUri } from '@accesslayer/boost/read';
+import { countBoostRecipientsWithChildren } from '@accesslayer/boost/relationships/read';
+
+let userA: Awaited<ReturnType<typeof getUser>>;
+let userB: Awaited<ReturnType<typeof getUser>>;
+let userC: Awaited<ReturnType<typeof getUser>>;
+let userD: Awaited<ReturnType<typeof getUser>>;
+
+/**
+ * Unit tests for access-layer countBoostRecipientsWithChildren
+ * Focused on generation limits, acceptance filtering, and query filtering
+ */
+
+describe('AccessLayer: countBoostRecipientsWithChildren', () => {
+    beforeAll(async () => {
+        userA = await getUser('a'.repeat(64));
+        userB = await getUser('b'.repeat(64));
+        userC = await getUser('c'.repeat(64));
+        userD = await getUser('d'.repeat(64));
+    });
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+
+        await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+        await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+        await userC.clients.fullAuth.profile.createProfile({ profileId: 'userc' });
+        await userD.clients.fullAuth.profile.createProfile({ profileId: 'userd' });
+    });
+
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+    });
+
+    it('returns 0 for boost with no recipients', async () => {
+        const uri = await userA.clients.fullAuth.boost.createBoost({ credential: testUnsignedBoost });
+        const boostInstance = (await getBoostByUri(uri))!;
+
+        const count = await countBoostRecipientsWithChildren(boostInstance, {});
+
+        expect(count).toBe(0);
+    });
+
+    it('counts recipients across child boosts', async () => {
+        const parentUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Parent',
+        });
+        const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri,
+            boost: { credential: testUnsignedBoost, category: 'Child' },
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, parentUri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userc', user: userC }, childUri);
+
+        const boostInstance = (await getBoostByUri(parentUri))!;
+
+        const count = await countBoostRecipientsWithChildren(boostInstance, {});
+        expect(count).toBe(2);
+    });
+
+    it('counts distinct recipients once when they receive multiple boosts', async () => {
+        const parentUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Parent',
+        });
+        const childUri1 = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri,
+            boost: { credential: testUnsignedBoost, category: 'Child1' },
+        });
+        const childUri2 = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri,
+            boost: { credential: testUnsignedBoost, category: 'Child2' },
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, parentUri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, childUri1);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, childUri2);
+
+        const boostInstance = (await getBoostByUri(parentUri))!;
+
+        const count = await countBoostRecipientsWithChildren(boostInstance, {});
+        expect(count).toBe(1);
+    });
+
+    it('respects numberOfGenerations parameter', async () => {
+        // 3-level hierarchy: parent -> child -> grandchild
+        const parentUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Parent',
+        });
+        const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri,
+            boost: { credential: testUnsignedBoost, category: 'Child' },
+        });
+        const grandchildUri = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri: childUri,
+            boost: { credential: testUnsignedBoost, category: 'Grandchild' },
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, parentUri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userc', user: userC }, childUri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userd', user: userD }, grandchildUri);
+
+        const boostInstance = (await getBoostByUri(parentUri))!;
+
+        // Only parent + 1 level (default = 1)
+        const count1 = await countBoostRecipientsWithChildren(boostInstance, { numberOfGenerations: 1 });
+        expect(count1).toBe(2);
+
+        // Include grandchild (2 levels)
+        const count2 = await countBoostRecipientsWithChildren(boostInstance, { numberOfGenerations: 2 });
+        expect(count2).toBe(3);
+    });
+
+    it('includes or excludes unaccepted boosts based on includeUnacceptedBoosts option', async () => {
+        const uri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Test',
+        });
+
+        // Send but do not accept
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            uri,
+            false
+        );
+
+        const boostInstance = (await getBoostByUri(uri))!;
+
+        const includeCount = await countBoostRecipientsWithChildren(boostInstance, { includeUnacceptedBoosts: true });
+        expect(includeCount).toBe(1);
+
+        const excludeCount = await countBoostRecipientsWithChildren(boostInstance, { includeUnacceptedBoosts: false });
+        expect(excludeCount).toBe(0);
+    });
+
+    it('supports filtering by boostQuery', async () => {
+        const parentUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Achievement',
+        });
+        const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+            parentUri,
+            boost: { credential: testUnsignedBoost, category: 'Badge' },
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, parentUri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userc', user: userC }, childUri);
+
+        const boostInstance = (await getBoostByUri(parentUri))!;
+
+        const achCount = await countBoostRecipientsWithChildren(boostInstance, {
+            boostQuery: { category: 'Achievement' },
+        });
+        expect(achCount).toBe(1);
+
+        const badgeCount = await countBoostRecipientsWithChildren(boostInstance, {
+            boostQuery: { category: 'Badge' },
+        });
+        expect(badgeCount).toBe(1);
+    });
+
+    it('supports filtering by profileQuery', async () => {
+        const uri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Test',
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, uri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userc', user: userC }, uri);
+
+        const boostInstance = (await getBoostByUri(uri))!;
+
+        const onlyUserB = await countBoostRecipientsWithChildren(boostInstance, {
+            // Use $in single value to exercise typed map path reliably
+            profileQuery: { profileId: { $in: ['userb'] } },
+        } as any);
+        expect(onlyUserB).toBe(1);
+
+        const inQuery = await countBoostRecipientsWithChildren(boostInstance, {
+            profileQuery: { profileId: { $in: ['userb', 'userd'] } },
+        } as any);
+        expect(inQuery).toBe(1);
+    });
+
+    it('supports filtering by profileQuery with regex', async () => {
+        const uri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            category: 'Test',
+        });
+
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userb', user: userB }, uri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userc', user: userC }, uri);
+        await sendBoost({ profileId: 'usera', user: userA }, { profileId: 'userd', user: userD }, uri);
+
+        const boostInstance = (await getBoostByUri(uri))!;
+
+        const regexQuery = await countBoostRecipientsWithChildren(boostInstance, {
+            // Provide RegExpValue so convertObjectRegExpToNeo4j generates Neo4j-compatible pattern
+            profileQuery: { profileId: { $regex: { source: 'userb', flags: 'i' } } },
+        } as any);
+
+        expect(regexQuery).toBe(1);
+    });
+});

--- a/services/learn-card-network/brain-service/test/boosts.spec.ts
+++ b/services/learn-card-network/brain-service/test/boosts.spec.ts
@@ -6020,4 +6020,297 @@ describe('Boosts', () => {
             expect(profileIds2Gen).toEqual(['userb', 'userc', 'userd']);
         });
     });
+
+    describe('getBoostRecipientsWithChildrenCount', () => {
+        beforeEach(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+
+            await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+            await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+            await userC.clients.fullAuth.profile.createProfile({ profileId: 'userc' });
+            await userD.clients.fullAuth.profile.createProfile({ profileId: 'userd' });
+        });
+
+        afterAll(async () => {
+            await Profile.delete({ detach: true, where: {} });
+            await Credential.delete({ detach: true, where: {} });
+            await Boost.delete({ detach: true, where: {} });
+        });
+
+        it('should not allow access without full auth', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            await expect(
+                noAuthClient.boost.getBoostRecipientsWithChildrenCount({ uri })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+            await expect(
+                userA.clients.partialAuth.boost.getBoostRecipientsWithChildrenCount({ uri })
+            ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        });
+
+        it('should return 0 for boost with no recipients', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+            });
+
+            const count = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri,
+            });
+
+            expect(count).toBe(0);
+        });
+
+        it('should count recipients across child boosts', async () => {
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Parent',
+            });
+
+            const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testUnsignedBoost, category: 'Child' },
+            });
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                parentUri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userc', user: userC },
+                childUri
+            );
+
+            const count = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri: parentUri,
+            });
+
+            expect(count).toBe(2);
+        });
+
+        it('should count distinct recipients once when they receive multiple boosts', async () => {
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Parent',
+            });
+
+            const childUri1 = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testUnsignedBoost, category: 'Child1' },
+            });
+            const childUri2 = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testUnsignedBoost, category: 'Child2' },
+            });
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                parentUri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                childUri1
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                childUri2
+            );
+
+            const count = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri: parentUri,
+            });
+
+            expect(count).toBe(1);
+        });
+
+        it('should respect numberOfGenerations parameter', async () => {
+            // 3-level hierarchy: parent -> child -> grandchild
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Parent',
+            });
+
+            const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testUnsignedBoost, category: 'Child' },
+            });
+
+            const grandchildUri = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri: childUri,
+                boost: { credential: testUnsignedBoost, category: 'Grandchild' },
+            });
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                parentUri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userc', user: userC },
+                childUri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userd', user: userD },
+                grandchildUri
+            );
+
+            // Only parent + 1 level (default = 1)
+            const count1 = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri: parentUri,
+                numberOfGenerations: 1,
+            });
+            expect(count1).toBe(2);
+
+            // Include grandchild (2 levels)
+            const count2 = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri: parentUri,
+                numberOfGenerations: 2,
+            });
+            expect(count2).toBe(3);
+        });
+
+        it('should include or exclude unaccepted boosts based on includeUnacceptedBoosts option', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Test',
+            });
+
+            // Send but do not accept
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                uri,
+                false
+            );
+
+            const includeCount =
+                await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                    uri,
+                    includeUnacceptedBoosts: true,
+                });
+            expect(includeCount).toBe(1);
+
+            const excludeCount =
+                await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                    uri,
+                    includeUnacceptedBoosts: false,
+                });
+            expect(excludeCount).toBe(0);
+        });
+
+        it('should support filtering by boost query', async () => {
+            // Create parent and child with different categories
+            const parentUri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Achievement',
+            });
+
+            const childUri = await userA.clients.fullAuth.boost.createChildBoost({
+                parentUri,
+                boost: { credential: testUnsignedBoost, category: 'Badge' },
+            });
+
+            // Send both boosts
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                parentUri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userc', user: userC },
+                childUri
+            );
+
+            const achCount = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount(
+                {
+                    uri: parentUri,
+                    boostQuery: { category: 'Achievement' },
+                }
+            );
+            expect(achCount).toBe(1);
+
+            const badgeCount =
+                await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                    uri: parentUri,
+                    boostQuery: { category: 'Badge' },
+                });
+            expect(badgeCount).toBe(1);
+        });
+
+        it('should support filtering by profile query', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Test',
+            });
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                uri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userc', user: userC },
+                uri
+            );
+
+            const onlyUserB =
+                await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                    uri,
+                    // Use $in single value to exercise typed map path reliably
+                    profileQuery: { profileId: { $in: ['userb'] } },
+                } as any);
+            expect(onlyUserB).toBe(1);
+
+            const inQuery = await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                uri,
+                profileQuery: { profileId: { $in: ['userb', 'userd'] } },
+            } as any);
+            expect(inQuery).toBe(1);
+        });
+
+        it('should support filtering by profile query with regex', async () => {
+            const uri = await userA.clients.fullAuth.boost.createBoost({
+                credential: testUnsignedBoost,
+                category: 'Test',
+            });
+
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userb', user: userB },
+                uri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userc', user: userC },
+                uri
+            );
+            await sendBoost(
+                { profileId: 'usera', user: userA },
+                { profileId: 'userd', user: userD },
+                uri
+            );
+
+            const regexCount =
+                await userA.clients.fullAuth.boost.getBoostRecipientsWithChildrenCount({
+                    uri,
+                    // Provide regex pattern. The server supports
+                    // string-form '/pattern/flags' for convenience.
+                    profileQuery: { profileId: { $regex: '/userb/i' } },
+                } as any);
+
+            expect(regexCount).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
 # Overview

#### 🎟 Relevant Jira Issues
[LC-1228] Create countBoostRecipientsWithChildren resolver

#### 📚 What is the context and goal of this PR?
- Add counting of unique boost recipients across a boost’s descendants.
- Expose `boost.getBoostRecipientsWithChildrenCount(...)` and brain-service resolver/route.
- Maintain filtering and traversal parity with recipients-with-children listing.

#### 🥴 TL; RL:
Add count across child boosts with filters, generation depth, and unaccepted-boosts toggle; unit + e2e tests included.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
- Server: `countBoostRecipientsWithChildren` resolver
  - `services/learn-card-network/brain-service/src/routes/boosts.ts`
  - `services/learn-card-network/brain-service/src/accesslayer/boost/relationships/read.ts`
- Client: `boost.getBoostRecipientsWithChildrenCount`
  - `packages/plugins/learn-card-network/src/plugin.ts`
  - `packages/plugins/learn-card-network/src/types.ts`
- Tests
  - Unit: `services/learn-card-network/brain-service/test/boost.countRecipientsWithChildren.spec.ts`
  - Suite updates: `services/learn-card-network/brain-service/test/boosts.spec.ts`
  - E2E: `tests/e2e/tests/boosts.spec.ts`

#### 🛠 Important tradeoffs made:
- Traversal depth via `numberOfGenerations`; explicit and bounded to avoid deep graph cost.
- Distinct recipients counted once across parent + descendants.
- Filtering parity: `boostQuery`, `profileQuery` (supports `$in` and string-form regex), `includeUnacceptedBoosts`.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [ ] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
- Automated
  - Run unit tests: `services/learn-card-network/brain-service/test/boost.countRecipientsWithChildren.spec.ts`
  - Run e2e tests: `tests/e2e/tests/boosts.spec.ts`
- Manual sanity (programmatic)
  1. Create a parent boost and 1–2 child boosts.
  2. Send boosts to distinct profiles at different levels.
  3. Call `boost.getBoostRecipientsWithChildrenCount({ uri })` and verify:
     - Distinct recipients are counted once across levels.
     - `numberOfGenerations` limits traversal depth.
     - `includeUnacceptedBoosts` toggles inclusion.
     - Filters work: `boostQuery` and `profileQuery` (with `$in`, string-form regex like `/userb/i`).

#### 📱 🖥 Which devices would you like help testing on?
- N/A (server-side only)

#### 🧪 Code Coverage
- Unit and e2e tests cover auth, empty states, multi-level graphs, distinct counting, filters, and options.

# Documentation

#### 📜 Gitbook
- Not required; API aligns with existing recipients-with-children behavior. Release notes via changeset.

#### 📊 Storybook
- N/A


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1228]: https://welibrary.atlassian.net/browse/LC-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description

Purpose: Add countBoostRecipientsWithChildren method for efficiently counting distinct boost recipients across multiple boost generations.

Main changes:
- Implemented new countBoostRecipientsWithChildren Neo4j query function to count distinct recipients with filtering options
- Added corresponding API endpoint in boosts router with support for query filtering and generation depth control
- Added comprehensive test coverage including unit and E2E tests for the new functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
