### PR TITLE
[LC-1332] Stop Hitting Lambda Response Limit with LearnCloud tRPC client

### DIFF
--- a/.changeset/tender-bags-unite.md
+++ b/.changeset/tender-bags-unite.md
@@ -1,0 +1,6 @@
+---
+'@learncard/learn-cloud-client': patch
+'@learncard/learn-cloud-plugin': patch
+---
+
+Lower the `maxItems` in the tRPC client to 50 to prevent AWS payload response limits

--- a/packages/learn-card-network/cloud-client/src/index.ts
+++ b/packages/learn-card-network/cloud-client/src/index.ts
@@ -19,6 +19,7 @@ export const getClient = async (
                 methodOverride: 'POST',
                 url,
                 maxURLLength: 3072,
+                maxItems: 50,
                 headers: { Authorization: `Bearer ${await didAuthFunction()}` },
             }),
         ],
@@ -40,6 +41,7 @@ export const getClient = async (
             httpBatchLink({
                 methodOverride: 'POST',
                 url,
+                maxItems: 50,
                 maxURLLength: 3072,
                 headers: async () => {
                     if (challenges.length === 0) challenges.push(...(await getChallenges()));


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1332] Lower maxItems in LearnCloud tRPC client to 50 to avoid AWS Lambda max response payload

#### 📚 What is the context and goal of this PR?
If you send too many batch requests to the lambda, AWS actually errors its response!

#### 🥴 TL; RL:
Limit the amount of requests in a single batch to 50

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Add `maxItems: 50` to the LearnCloud tRPC client

#### 🛠 Important tradeoffs made:
This isn't a perfect fix. It could be 50 requests that happen to return a _ton_ of data and still hit that limit (its like 6 MB I think or something like that),
and this also could block say 500 tiny requests that wouldn't hit that limit, but I think it's a fair tradeoff at 50.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
You can just run the E2E tests to make sure things still work!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1332]: https://welibrary.atlassian.net/browse/LC-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add maxItems limit to LearnCloud tRPC client to prevent exceeding AWS Lambda response size limits.
Main changes:
- Set maxItems parameter to 50 in both httpBatchLink configurations
- Added changeset file documenting the patch versions for affected packages

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
