### PR TITLE
[Hotfix] KeyAgreement Backwards Compatibility

### DIFF
--- a/.changeset/bright-plants-wash.md
+++ b/.changeset/bright-plants-wash.md
@@ -1,11 +1,10 @@
 ---
-"@learncard/types": patch
-"@learncard/didkit-plugin": patch
-"@learncard/vc-plugin": patch
-"@learncard/network-brain-service": patch
-"@learncard/learn-cloud-service": patch
-"@learncard/simple-signing-service": patch
-"@workspace/e2e-tests": patch
+'@learncard/types': patch
+'@learncard/didkit-plugin': patch
+'@learncard/vc-plugin': patch
+'@learncard/network-brain-service': patch
+'@learncard/learn-cloud-service': patch
+'@learncard/simple-signing-service': patch
 ---
 
 chore: Add Interop Tests for DCC + Multikey to DID Doc

--- a/.changeset/eight-seals-cross.md
+++ b/.changeset/eight-seals-cross.md
@@ -1,0 +1,7 @@
+---
+"@learncard/network-brain-service": patch
+"@learncard/learn-cloud-service": patch
+"@learncard/simple-signing-service": patch
+---
+
+[Hotfix] KeyAgreement Backwards Compatibility

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -155,7 +155,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                 ...existingKA.filter(ka => ka?.id !== primaryKAId),
             ];
         } catch (e) {
-            request.log?.warn({ err: e }, 'Failed to set 2020 VM on did:web document');
+            request.log?.warn({ err: e }, 'Failed to set 2019 keyAgreement on did:web document');
         }
 
         if (saDocs) {

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -134,7 +134,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
 
         let finalDoc = { ...replacedDoc, controller: profile.did };
 
-        // Ensure the primary verification method is 2020 (publicKeyMultibase) only
+        // Ensure the primary keyAgreement uses 2019 suite format for backwards compatibility
         try {
             const vm0 = (finalDoc.verificationMethod?.[0] as any) || {};
             const { bytes: ed25519Bytes } = extractEd25519FromVerificationMethod(vm0);


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Existing didkit JWE creation is dependent on `keyAgreement` containing a `publicKeyBase58` field and
will crash if it's not there! Our latest update changed it to use `publicKeyMultibase` instead, causing
existing code to break. New clients will no longer crash though, and so eventually we can just use
use the new one =)

#### 🥴 TL; RL:
Reverts the `keyAgreement` field to use `publicKeyBase58`

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:
This reverts us using `X25519KeyAgreementKey2020` and puts us back on `X25519KeyAgreementKey2019`.
In the future we'll probably want to just move to 2020.

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Run the whole E2E suite, and then while it's running spin up the CLI with _old_ code:

```bash
pnpm dlx @learncard/cli
```

Then, in the CLI, try out some things! Specifically make sure encryption/decryption work:

```js
let test = await initLearnCard({ seed: 'a', network: 'http://localhost:4000/trpc', cloud: { url: 'http://localhost:4100/trpc' } })
await test.invoke.createProfile({ profileId: 'nicelol' });

await test.invoke.resolveDid(test.id.did()); // You should see an Ed25519VerificationKey2020 and an X25519KeyAgreementKey2019

let testVc = test.invoke.getTestVc(test.id.did());
let vc = await test.invoke.issueCredential(testVc); // should work

await test.invoke.verifyCredential(vc); // should verify

let jwe = await test.invoke.createDagJwe(vc); // should work
await test.invoke.decryptDagJwe(jwe); // should be the same as `vc`

let uri = await test.store.LearnCloud.uploadEncrypted(vc);
await test.read.get(uri); // should be the same as `vc`

await test.index.LearnCloud.get(); // should be []
await test.index.LearnCloud.add({ id: 'nice', uri }); // should work
await test.index.LearnCloud.get(); // should be [{ id: 'nice', uri: uri from above }]
```

Feel free to test other things like connections and sending boosts and whatnot but that should cover
any possible regressions!

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix KeyAgreement backwards compatibility in DID documents by ensuring 2019 suite format is maintained for interoperability between systems.
Main changes:
- Restored X25519KeyAgreementKey2019 format with publicKeyBase58 encoding for primary keyAgreement entries
- Preserved existing keyAgreement entries while ensuring primary entry uses compatible format
- Removed multikey verification method implementation that was breaking compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
