### PR TITLE
feat: LC-1310 - Add Evidence Support 

### DIFF
--- a/packages/learn-card-contexts/boosts/1.0.3.json
+++ b/packages/learn-card-contexts/boosts/1.0.3.json
@@ -1,0 +1,252 @@
+{
+    "@context": {
+        "id": "@id",
+        "type": "@type",
+        "lcn": "https://docs.learncard.com/definitions#",
+        "cred": "https://www.w3.org/2018/credentials#",
+        "xsd": "https://www.w3.org/2001/XMLSchema#",
+        "EvidenceFile": {
+            "@id": "https://docs.learncard.com/definitions#EvidenceFile",
+            "@context": {
+                "fileName": {
+                    "@id": "https://docs.learncard.com/definitions#evidenceFileName",
+                    "@type": "xsd:string"
+                },
+                "fileType": {
+                    "@id": "https://docs.learncard.com/definitions#evidenceFileType",
+                    "@type": "xsd:string"
+                },
+                "fileSize": {
+                    "@id": "https://docs.learncard.com/definitions#evidenceFileSize",
+                    "@type": "xsd:string"
+                }
+            }
+        },
+        "BoostCredential": {
+            "@context": {
+                "address": {
+                    "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Address"
+                },
+                "attachments": {
+                    "@container": "@set",
+                    "@context": {
+                        "title": {
+                            "@id": "lcn:boostAttachmentTitle",
+                            "@type": "xsd:string"
+                        },
+                        "type": {
+                            "@id": "lcn:boostAttachmentType",
+                            "@type": "xsd:string"
+                        },
+                        "url": {
+                            "@id": "lcn:boostAttachmentUrl",
+                            "@type": "xsd:string"
+                        },
+                        "fileName": {
+                            "@id": "lcn:boostAttachmentFileName",
+                            "@type": "xsd:string"
+                        },
+                        "fileSize": {
+                            "@id": "lcn:boostAttachmentFileSize",
+                            "@type": "xsd:string"
+                        },
+                        "fileType": {
+                            "@id": "lcn:boostAttachmentFileType",
+                            "@type": "xsd:string"
+                        }
+                    },
+                    "@id": "lcn:boostAttachments"
+                },
+                "boostId": {
+                    "@id": "lcn:boostId",
+                    "@type": "xsd:string"
+                },
+                "display": {
+                    "@context": {
+                        "backgroundColor": {
+                            "@id": "lcn:boostBackgroundColor",
+                            "@type": "xsd:string"
+                        },
+                        "backgroundImage": {
+                            "@id": "lcn:boostBackgroundImage",
+                            "@type": "xsd:string"
+                        },
+                        "displayType": {
+                            "@id": "lcn:boostDisplayType",
+                            "@type": "xsd:string"
+                        },
+                        "previewType": {
+                            "@id": "lcn:boostPreviewType",
+                            "@type": "xsd:string"
+                        },
+                        "emoji": {
+                            "@context": {
+                                "activeSkinTone": {
+                                    "@id": "lcn:boostEmojiActiveSkinTone",
+                                    "@type": "xsd:string"
+                                },
+                                "imageUrl": {
+                                    "@id": "lcn:boostEmojiImageUrl",
+                                    "@type": "xsd:string"
+                                },
+                                "names": {
+                                    "@container": "@set",
+                                    "@id": "lcn:boostEmojiNames",
+                                    "@type": "xsd:string"
+                                },
+                                "unified": {
+                                    "@id": "lcn:boostEmojiUnified",
+                                    "@type": "xsd:string"
+                                },
+                                "unifiedWithoutSkinTone": {
+                                    "@id": "lcn:boostEmojiUnifiedWithoutSkinTone",
+                                    "@type": "xsd:string"
+                                }
+                            },
+                            "@id": "lcn:boostEmoji"
+                        },
+                        "fadeBackgroundImage": {
+                            "@id": "lcn:boostFadeBackgroundImage",
+                            "@type": "xsd:boolean"
+                        },
+                        "repeatBackgroundImage": {
+                            "@id": "lcn:boostRepeatBackgroundImage",
+                            "@type": "xsd:boolean"
+                        }
+                    },
+                    "@id": "lcn:boostDisplay"
+                },
+                "familyTitles": {
+                    "@context": {
+                        "dependents": {
+                            "@container": "@set",
+                            "@context": {
+                                "plural": {
+                                    "@id": "lcn:plural",
+                                    "@type": "xsd:string"
+                                },
+                                "singular": {
+                                    "@id": "lcn:singular",
+                                    "@type": "xsd:string"
+                                }
+                            },
+                            "@id": "lcn:dependents"
+                        },
+                        "guardians": {
+                            "@container": "@set",
+                            "@context": {
+                                "plural": {
+                                    "@id": "lcn:plural",
+                                    "@type": "xsd:string"
+                                },
+                                "singular": {
+                                    "@id": "lcn:singular",
+                                    "@type": "xsd:string"
+                                }
+                            },
+                            "@id": "lcn:guardians"
+                        }
+                    },
+                    "@id": "lcn:familyTitles"
+                },
+                "groupID": {
+                    "@id": "lcn:groupID",
+                    "@type": "xsd:string"
+                },
+                "skills": {
+                    "@container": "@set",
+                    "@context": {
+                        "category": {
+                            "@id": "lcn:boostSkillCategory",
+                            "@type": "xsd:string"
+                        },
+                        "skill": {
+                            "@id": "lcn:boostSkill",
+                            "@type": "xsd:string"
+                        },
+                        "subskills": {
+                            "@container": "@set",
+                            "@id": "lcn:boostSubskills",
+                            "@type": "xsd:string"
+                        }
+                    },
+                    "@id": "lcn:boostSkills"
+                }
+            },
+            "@id": "lcn:boostCredential"
+        },
+        "BoostID": {
+            "@id": "lcn:boostID",
+            "@context": {
+                "boostID": {
+                    "@id": "lcn:boostIDField",
+                    "@context": {
+                        "fontColor": {
+                            "@id": "lcn:boostIDFontColor",
+                            "@type": "xsd:string"
+                        },
+                        "accentColor": {
+                            "@id": "lcn:boostIDAccentColor",
+                            "@type": "xsd:string"
+                        },
+                        "backgroundImage": {
+                            "@id": "lcn:boostIDBackgroundImage",
+                            "@type": "xsd:string"
+                        },
+                        "dimBackgroundImage": {
+                            "@id": "lcn:boostIDDimBackgroundImage",
+                            "@type": "xsd:boolean"
+                        },
+                        "issuerThumbnail": {
+                            "@id": "lcn:boostIDIssuerThumbnail",
+                            "@type": "xsd:string"
+                        },
+                        "showIssuerThumbnail": {
+                            "@id": "lcn:boostIDShowIssuerThumbnail",
+                            "@type": "xsd:boolean"
+                        },
+                        "IDIssuerName": {
+                            "@id": "lcn:boostIDIssuerName",
+                            "@type": "xsd:string"
+                        },
+                        "idThumbnail": {
+                            "@id": "lcn:boostIDThumbnail",
+                            "@type": "xsd:string"
+                        },
+                        "accentFontColor": {
+                            "@id": "lcn:boostIDFontColor",
+                            "@type": "xsd:string"
+                        },
+                        "idBackgroundColor": {
+                            "@id": "lcn:boostIDBackgroundColor",
+                            "@type": "xsd:string"
+                        },
+                        "repeatIdBackgroundImage": {
+                            "@id": "lcn:boostIDRepeatIdBackgroundImage",
+                            "@type": "xsd:boolean"
+                        },
+                        "idDescription": {
+                            "@id": "lcn:boostIDDescription",
+                            "@type": "xsd:string"
+                        }
+                    }
+                }
+            }
+        },
+        "CertifiedBoostCredential": {
+            "@id": "lcn:certifiedBoostCredential",
+            "@context": {
+                "@version": 1.1,
+                "boostId": {
+                    "@id": "lcn:boostId",
+                    "@type": "xsd:string"
+                },
+                "boostCredential": {
+                    "@id": "cred:VerifiableCredential",
+                    "@type": "@id",
+                    "@container": "@graph"
+                }
+            }
+        }
+    }
+}

--- a/packages/learn-card-types/src/obv3.ts
+++ b/packages/learn-card-types/src/obv3.ts
@@ -142,10 +142,24 @@ export const ResultDescriptionValidator = z
     .catchall(z.any());
 export type ResultDescription = z.infer<typeof ResultDescriptionValidator>;
 
+export const EvidenceValidator = z
+    .object({
+        id: z.string().optional(),
+        type: z.array(z.string()).nonempty(),
+        name: z.string().optional(),
+        narrative: z.string().optional(),
+        description: z.string().optional(),
+        genre: z.string().optional(),
+        audience: z.string().optional(),
+    })
+    .catchall(z.any());
+
+export type Evidence = z.infer<typeof EvidenceValidator>;
+
 export const AchievementValidator = z
     .object({
         id: z.string().optional(),
-        type: z.string().array().nonempty(),
+        type: z.array(z.string()).nonempty(),
         alignment: AlignmentValidator.array().optional(),
         achievementType: AchievementTypeValidator.optional(),
         creator: ProfileValidator.optional(),
@@ -162,7 +176,7 @@ export const AchievementValidator = z
         related: RelatedValidator.array().optional(),
         resultDescription: ResultDescriptionValidator.array().optional(),
         specialization: z.string().optional(),
-        tag: z.string().array().optional(),
+        tag: z.array(z.string()).optional(),
         version: z.string().optional(),
     })
     .catchall(z.any());
@@ -219,19 +233,6 @@ export const AchievementSubjectValidator = z
     .catchall(z.any());
 export type AchievementSubject = z.infer<typeof AchievementSubjectValidator>;
 
-export const EvidenceValidator = z
-    .object({
-        id: z.string().optional(),
-        type: z.string().or(z.string().array().nonempty()),
-        narrative: z.string().optional(),
-        name: z.string().optional(),
-        description: z.string().optional(),
-        genre: z.string().optional(),
-        audience: z.string().optional(),
-    })
-    .catchall(z.any());
-export type Evidence = z.infer<typeof EvidenceValidator>;
-
 export const UnsignedAchievementCredentialValidator = UnsignedVCValidator.extend({
     name: z.string().optional(),
     description: z.string().optional(),
@@ -242,7 +243,6 @@ export const UnsignedAchievementCredentialValidator = UnsignedVCValidator.extend
         [typeof AchievementSubjectValidator, z.ZodArray<typeof AchievementSubjectValidator>]
     >,
     endorsement: UnsignedVCValidator.array().optional(),
-    evidence: EvidenceValidator.array().optional(),
 });
 export type UnsignedAchievementCredential = z.infer<typeof UnsignedAchievementCredentialValidator>;
 

--- a/packages/learn-card-types/src/vc.ts
+++ b/packages/learn-card-types/src/vc.ts
@@ -122,7 +122,15 @@ export const TermsOfUseValidator = z
 export type TermsOfUse = z.infer<typeof TermsOfUseValidator>;
 
 export const VC2EvidenceValidator = z
-    .object({ type: z.string().or(z.string().array().nonempty()), id: z.string().optional() })
+    .object({
+        id: z.string().optional(),
+        type: z.array(z.string()).nonempty(),
+        name: z.string().optional(),
+        narrative: z.string().optional(),
+        description: z.string().optional(),
+        genre: z.string().optional(),
+        audience: z.string().optional(),
+    })
     .catchall(z.any());
 export type VC2Evidence = z.infer<typeof VC2EvidenceValidator>;
 
@@ -152,7 +160,7 @@ export const UnsignedVCValidator = z
         validUntil: z.string().optional(),
         status: CredentialStatusValidator.or(CredentialStatusValidator.array()).optional(),
         termsOfUse: TermsOfUseValidator.or(TermsOfUseValidator.array()).optional(),
-        evidence: VC2EvidenceValidator.or(VC2EvidenceValidator.array()).optional(),
+        evidence: z.union([VC2EvidenceValidator, z.array(VC2EvidenceValidator)]).optional(),
     })
     .catchall(z.any());
 export type UnsignedVC = z.infer<typeof UnsignedVCValidator>;

--- a/packages/plugins/vc-templates/src/templates.ts
+++ b/packages/plugins/vc-templates/src/templates.ts
@@ -126,7 +126,7 @@ export const VC_TEMPLATES: {
         '@context': [
             'https://www.w3.org/ns/credentials/v2',
             'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json',
-            'https://ctx.learncard.com/boosts/1.0.2.json',
+            'https://ctx.learncard.com/boosts/1.0.3.json',
         ],
         type: ['VerifiableCredential', 'OpenBadgeCredential', 'BoostCredential'],
         id: `urn:uuid:${crypto.randomUUID()}`,

--- a/packages/plugins/vc-templates/src/templates.ts
+++ b/packages/plugins/vc-templates/src/templates.ts
@@ -149,7 +149,19 @@ export const VC_TEMPLATES: {
                 },
             },
         },
-        ...(Array.isArray(evidence) && evidence.length > 0 && { evidence }),
+        ...(Array.isArray(evidence) &&
+            evidence.length > 0 && {
+                evidence: evidence.map(e => ({
+                    ...e,
+                    type: e.type?.includes('EvidenceFile')
+                        ? e.type
+                        : [
+                              'Evidence',
+                              'EvidenceFile',
+                              ...(e.type?.filter(t => t !== 'Evidence') || []),
+                          ],
+                })),
+            }),
         display,
         familyTitles,
         image: boostImage,
@@ -185,7 +197,7 @@ export const VC_TEMPLATES: {
         '@context': [
             'https://www.w3.org/ns/credentials/v2',
             'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json',
-            'https://ctx.learncard.com/boosts/1.0.1.json',
+            'https://ctx.learncard.com/boosts/1.0.3.json',
             'https://ctx.learncard.com/boostIDs/1.0.0.json',
         ],
         type: ['VerifiableCredential', 'OpenBadgeCredential', 'BoostCredential', 'BoostID'],
@@ -218,7 +230,19 @@ export const VC_TEMPLATES: {
                   },
               }
             : {}),
-        ...(Array.isArray(evidence) && evidence.length > 0 && { evidence }),
+        ...(Array.isArray(evidence) &&
+            evidence.length > 0 && {
+                evidence: evidence.map(e => ({
+                    ...e,
+                    type: e.type?.includes('EvidenceFile')
+                        ? e.type
+                        : [
+                              'Evidence',
+                              'EvidenceFile',
+                              ...(e.type?.filter(t => t !== 'Evidence') || []),
+                          ],
+                })),
+            }),
         display,
         familyTitles,
         image: boostImage,

--- a/packages/plugins/vc-templates/src/templates.ts
+++ b/packages/plugins/vc-templates/src/templates.ts
@@ -119,6 +119,7 @@ export const VC_TEMPLATES: {
             familyTitles,
             skills,
             groupID = '',
+            evidence = [],
         } = {},
         crypto
     ) => ({
@@ -148,6 +149,7 @@ export const VC_TEMPLATES: {
                 },
             },
         },
+        ...(Array.isArray(evidence) && evidence.length > 0 && { evidence }),
         display,
         familyTitles,
         image: boostImage,
@@ -176,6 +178,7 @@ export const VC_TEMPLATES: {
             familyTitles,
             boostID,
             groupID = '',
+            evidence = [],
         } = {},
         crypto
     ) => ({
@@ -215,6 +218,7 @@ export const VC_TEMPLATES: {
                   },
               }
             : {}),
+        ...(Array.isArray(evidence) && evidence.length > 0 && { evidence }),
         display,
         familyTitles,
         image: boostImage,

--- a/packages/plugins/vc-templates/src/types.ts
+++ b/packages/plugins/vc-templates/src/types.ts
@@ -87,9 +87,13 @@ export interface Evidence {
     name?: string;
     narrative?: string;
     description?: string;
-    // evidenceDocument?: string; // Added this back - it's in the validator
     genre?: string;
     audience?: string;
+
+    // Extended fields
+    fileName?: string;
+    fileType?: string;
+    fileSize?: string;
 }
 
 export type BoostTemplate = {

--- a/packages/plugins/vc-templates/src/types.ts
+++ b/packages/plugins/vc-templates/src/types.ts
@@ -80,6 +80,18 @@ export type AddressSpec = {
         longitude?: number | undefined;
     };
 };
+
+export interface Evidence {
+    id?: string;
+    type: [string, ...string[]]; // Changed from string[] to ensure at least one element
+    name?: string;
+    narrative?: string;
+    description?: string;
+    // evidenceDocument?: string; // Added this back - it's in the validator
+    genre?: string;
+    audience?: string;
+}
+
 export type BoostTemplate = {
     did?: string;
     subject?: string;
@@ -101,6 +113,7 @@ export type BoostTemplate = {
     boostID?: BoostID;
     address?: AddressSpec;
     groupID?: string;
+    evidence?: Evidence[];
 };
 
 /** @group VC Templates Plugin */


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

[LC-1309](https://welibrary.atlassian.net/browse/LC-1309)
[LC-1310](https://welibrary.atlassian.net/browse/LC-1310)

[CLIENT SIDE PR](https://github.com/WeLibraryOS/learncardapp/pull/1032)

#### 📚 What is the context and goal of this PR?

This PR introduces full Evidence support into our BoostCredential workflow and updates our VC context to version 1.03. The goal is to make LearnCard-issued credentials more interoperable with external verifiable credentials while still supporting our enhanced metadata needs.

1. Extended JSON-LD Context (v1.03)
   - Added a new EvidenceFile type extending the standard Evidence class.
   - Moves all file metadata (fileName, fileSize, fileType) into EvidenceFile to avoid redefining Evidence.

2. Evidence Integration
   - Added support for including evidence arrays in generated credentials.
   - Each evidence entry now supports dual typing: ["Evidence", "EvidenceFile"].
   - Ensures that existing audience, genre, and other OBv3-compliant fields remain compatible.

3. Implementation Improvements
   - Updated BoostCredential construction logic to dynamically map evidence data with extended types.
   - Standardized context references and added type safety for future Zod validation updates.
   - Verified compatibility with JSON-LD playground and ingestion pipeline.

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [X] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

1. Generate a new BoostCredential with  at least one evidence object with fileName, fileType, and fileSize.
2. Validate the generated VC on [JSON-LD Playground](https://json-ld.org/playground/) to confirm expanded context resolution.
4. Verify rendering and metadata extraction on the frontend 

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [X] My code follows **style guidelines** (eslint / prettier)
- [X] I have **manually tested** common end-2-end cases
- [X] I have **reviewed** my code
- [X] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [X] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [X] Code is backwards compatible
- [X] There is **not** a "Do Not Merge" label on this PR
- [X] I have thoughtfully considered the security implications of this change.
- [X] This change does not expose new public facing endpoints that do not have authentication
