### PR TITLE
fix: Add local dev fallback for notification queue 

### DIFF
--- a/.changeset/eleven-apes-explain.md
+++ b/.changeset/eleven-apes-explain.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+fix: Add local dev fallback for notification queue 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
If you run the LCA backend services via docker for the purpose of development, you will find that the inapp notifications don't work at all.



#### 🥴 TL; RL:

Fix notifications not working when running dockerized LCA backend services for local dev

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Notifications use the function addNotificationToQueue which is used like everywhere when we want to enqueue a notification. In the addNotificationQueue to function there is a block that looks like this and when running the service locally it early returns if these conditions are met

```
 if (
        process.env.NODE_ENV === 'test' ||
        process.env.IS_OFFLINE ||
        !process.env.NOTIFICATIONS_QUEUE_URL
    ) {
        console.log('///EARLY RETURN ADD NOTIFICATION');
        return; // Can not use SQS in test environment or locally
    }
```
when running locally process.env.IS_OFFLINE is set to true (look in compose-local.yaml) so it hits this early return and the notification then never gets added to the queue and thus never gets sent

Instead, we can fallback to sendNotification directly in local dev environments:

```
  // If running unit tests, do not attempt to deliver (keep legacy behavior for tests)
    if (process.env.NODE_ENV === 'test') {
        return;
    }

    // In local development (offline or missing SQS URL), deliver directly via webhook
    if (process.env.IS_OFFLINE || !process.env.NOTIFICATIONS_QUEUE_URL) {
        if (process.env.NODE_ENV !== 'test') {
            console.log(
                'Notifications Helpers - Local dev fallback: sending directly via sendNotification'
            );
        }
        return sendNotification(notification);
    }
```

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

Run the dockerized backend and do something that would trigger a notification eg send a boost to another account and check if you received a notification for that.

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix local development notification delivery by implementing direct webhook fallback when SQS queue is unavailable.
Main changes:
- Added direct webhook delivery via sendNotification() for local development environments
- Preserved existing behavior for unit tests by skipping notification delivery
- Added logging for local development fallback to improve developer experience

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
