### PR TITLE
fix: [LC-1400] Fix long title for merit badge from running off screen

### DIFF
--- a/.changeset/brown-walls-clap.md
+++ b/.changeset/brown-walls-clap.md
@@ -1,0 +1,5 @@
+---
+"@learncard/react": patch
+---
+
+fix: [LC-1400] Fix long title for merit badge from running off screen

--- a/packages/react-learn-card/src/components/MeritBadgeDisplayCard/MeritBadgeFrontFace.tsx
+++ b/packages/react-learn-card/src/components/MeritBadgeDisplayCard/MeritBadgeFrontFace.tsx
@@ -140,7 +140,7 @@ export const MeritBadgeFrontFace: React.FC<MeritBadgeFrontFaceProps> = ({
             <div
                 className={`flex flex-col gap-[15px] items-center px-[20px] pt-[92px] pb-[19px] border-solid border-[4px] ${borderColor} rounded-[30px]`}
             >
-                <div className="flex flex-col gap-[5px]">
+                <div className="flex flex-col gap-[5px] w-full">
                     <div className="flex flex-col items-center text-grayscale-900">
                         <span className="text-[16px] leading-[150%] font-jacques">
                             {issueeName || <Line width="60" />}
@@ -150,7 +150,7 @@ export const MeritBadgeFrontFace: React.FC<MeritBadgeFrontFaceProps> = ({
                         </span>
                     </div>
                     <div className="flex flex-col items-center">
-                        <h1 className="text-grayscale-900 text-center text-[25px] font-jacques">
+                        <h1 className="text-grayscale-900 text-center text-[25px] font-jacques w-full">
                             {title}
                         </h1>
                         <div


### PR DESCRIPTION
# Overview
Run this [PR](https://github.com/WeLibraryOS/learncardapp/pull/1040) with it.

This PR fixes the issue of a really long title running off the screen when you view the details for a merit badge.

#### 🎟 Relevant Jira Issues
https://welibrary.atlassian.net/browse/LC-1400

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

https://github.com/user-attachments/assets/2a09ca95-89db-40e5-bbca-4260f7e92ad2

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )
- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?
<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage
<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

#### 📜 Gitbook
<!-- Link to gitbook documentation that you created alongside this PR, or describe why documentation is not needed.-->

#### 📊 Storybook
<!-- If relevant, Chromatic link to Storybook that you created alongside this PR. -->


# ✅ PR Checklist
- [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
- [ ] My code follows **style guidelines** (eslint / prettier)
- [ ] I have **manually tested** common end-2-end cases
- [ ] I have **reviewed** my code
- [ ] I have **commented** my code, particularly where ambiguous
- [ ] New and existing **unit tests pass** locally with my changes
- [ ] I have made corresponding changes to **gitbook documentation**

### 🚀 Ready to squash-and-merge?:
- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [ ] I have thoughtfully considered the security implications of this change.
- [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix UI issue in MeritBadgeFrontFace component where long badge titles were overflowing container boundaries.
Main changes:
- Added width constraint (w-full) to the title container to ensure proper text wrapping
- Applied w-full to parent container to ensure consistent width management across nested elements
- Added changeset file to document patch version bump for @learncard/react package

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
