### PR TITLE
[Test] Fix LCA API Dockerfiles

### DIFF
--- a/.changeset/spicy-dingos-juggle.md
+++ b/.changeset/spicy-dingos-juggle.md
@@ -1,0 +1,5 @@
+---
+'@learncard/lca-api-service': patch
+---
+
+Fix Dockerfiles

--- a/services/learn-card-network/lca-api/Dockerfile
+++ b/services/learn-card-network/lca-api/Dockerfile
@@ -87,4 +87,4 @@ RUN pnpm exec nx build:docker lca-api-service
 # Expose common ports used by server
 EXPOSE 3000
 
-CMD ["sh", "-c", "cd services/lca-api && node --enable-source-maps dist/docker-entry.js"]
+CMD ["sh", "-c", "cd services/learn-card-network/lca-api && node --enable-source-maps dist/docker-entry.js"]

--- a/services/learn-card-network/lca-api/Dockerfile.local
+++ b/services/learn-card-network/lca-api/Dockerfile.local
@@ -88,4 +88,4 @@ RUN pnpm exec nx build:docker lca-api-service
 EXPOSE 3000
 EXPOSE 4200
 
-CMD ["sh", "-c", "cd services/lca-api && pnpm dev"]
+CMD ["sh", "-c", "cd services/learn-card-network/lca-api && pnpm dev"]


### PR DESCRIPTION
This is another test that also has a quickfix in it =) should deploy only the LCA API service, but will likely also deploy the frontend, which is fine! Should _not_ deploy brain/cloud services though!

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix directory path in LCA API Dockerfiles to correctly locate and execute application entry points.
Main changes:
- Updated CMD paths in Dockerfiles to use correct directory structure 'services/learn-card-network/lca-api' instead of 'services/lca-api'
- Added changeset file to document patch version update for '@learncard/lca-api-service' package

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
