### PR TITLE
feat: Issue & Verify API routes

### DIFF
--- a/.changeset/stale-roses-exist.md
+++ b/.changeset/stale-roses-exist.md
@@ -1,0 +1,7 @@
+---
+"@learncard/types": patch
+"@learncard/network-plugin": patch
+"@learncard/network-brain-service": patch
+---
+
+feat: Issue & Verify API routes

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -330,6 +330,39 @@ export const LCNSigningAuthorityForUserValidator = z.object({
 });
 export type LCNSigningAuthorityForUserType = z.infer<typeof LCNSigningAuthorityForUserValidator>;
 
+export const IssueCredentialInputValidator = z.object({
+    credential: UnsignedVCValidator,
+    signingAuthority: z
+        .object({
+            endpoint: z.string(),
+            name: z.string(),
+        })
+        .optional(),
+    options: z
+        .object({
+            encrypt: z.boolean().optional(),
+        })
+        .optional(),
+});
+export type IssueCredentialInput = z.infer<typeof IssueCredentialInputValidator>;
+
+export const VerifyCredentialInputValidator = z.object({
+    credential: VCValidator,
+    options: z
+        .object({
+            verifyExpiration: z.boolean().optional(),
+        })
+        .optional(),
+});
+export type VerifyCredentialInput = z.infer<typeof VerifyCredentialInputValidator>;
+
+export const VerificationResultValidator = z.object({
+    checks: z.array(z.string()),
+    warnings: z.array(z.string()),
+    errors: z.array(z.string()),
+});
+export type VerificationResult = z.infer<typeof VerificationResultValidator>;
+
 export const AutoBoostConfigValidator = z.object({
     boostUri: z.string(),
     signingAuthority: z.object({

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -549,7 +549,7 @@ export async function getLearnCardNetworkPlugin(
                 let hasLocalKeypair = false;
 
                 try {
-                    const kp = (learnCard as any).id?.keypair?.();
+                    const kp = _learnCard.id.keypair();
                     hasLocalKeypair = !!kp;
                 } catch {
                     hasLocalKeypair = false;

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -534,6 +534,23 @@ export async function getLearnCardNetworkPlugin(
                 return client.credential.deleteCredential.mutate({ uri });
             },
 
+            issueCredentialWithNetwork: async (_learnCard, credential, options) => {
+                await ensureUser();
+
+                return client.credential.issueCredential.mutate({
+                    credential,
+                    signingAuthority: options?.signingAuthority,
+                    options: options?.encrypt !== undefined ? { encrypt: options.encrypt } : undefined,
+                });
+            },
+
+            verifyCredentialWithNetwork: async (_learnCard, credential, options) => {
+                return client.credential.verifyCredential.mutate({
+                    credential,
+                    options,
+                });
+            },
+
             sendPresentation: async (_learnCard, profileId, vp, encrypt = true) => {
                 await ensureUser();
 

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -54,6 +54,7 @@ import {
     ContactMethodType,
     InboxCredentialQuery,
     IssueInboxCredentialResponseType,
+    VerificationResult,
     // Shared Skills/Frameworks/Tags (non-flat)
     TagType,
     SkillFrameworkType,
@@ -209,6 +210,19 @@ export type LearnCardNetworkPluginMethods = {
     getSentCredentials: (to?: string) => Promise<SentCredentialInfo[]>;
     getIncomingCredentials: (from?: string) => Promise<SentCredentialInfo[]>;
     deleteCredential: (uri: string) => Promise<boolean>;
+
+    issueCredentialWithNetwork: (
+        credential: UnsignedVC,
+        options?: {
+            signingAuthority?: { endpoint: string; name: string };
+            encrypt?: boolean;
+        }
+    ) => Promise<VC | JWE>;
+
+    verifyCredentialWithNetwork: (
+        credential: VC,
+        options?: { verifyExpiration?: boolean }
+    ) => Promise<VerificationResult>;
 
     sendPresentation: (profileId: string, vp: VP, encrypt?: boolean) => Promise<string>;
     acceptPresentation: (uri: string) => Promise<boolean>;

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -219,6 +219,11 @@ export type LearnCardNetworkPluginMethods = {
         }
     ) => Promise<VC | JWE>;
 
+    issueCredential: (
+        credential: UnsignedVC,
+        signingOptions?: Partial<ProofOptions>
+    ) => Promise<VC>;
+
     verifyCredentialWithNetwork: (
         credential: VC,
         options?: { verifyExpiration?: boolean }

--- a/tests/e2e/tests/credential-issuance.spec.ts
+++ b/tests/e2e/tests/credential-issuance.spec.ts
@@ -1,0 +1,229 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import crypto from 'crypto';
+
+import {
+    getLearnCard,
+    getLearnCardForUser,
+    createApiTokenForUser,
+    LearnCard,
+} from './helpers/learncard.helpers';
+
+describe('Credential Issuance and Verification via Signing Authority', () => {
+    let issuerLearnCard: LearnCard;
+    let signingAuthorityEndpoint: string;
+    let signingAuthorityName: string;
+    let signingAuthorityDid: string;
+
+    beforeAll(async () => {
+        issuerLearnCard = await getLearnCardForUser('a');
+
+        const sa = await issuerLearnCard.invoke.createSigningAuthority('e2e-issue-sa');
+        signingAuthorityEndpoint = sa.endpoint;
+        signingAuthorityName = 'issue-sa';
+        signingAuthorityDid = sa.did;
+
+        await issuerLearnCard.invoke.registerSigningAuthority(
+            signingAuthorityEndpoint,
+            signingAuthorityName,
+            signingAuthorityDid
+        );
+    });
+
+    describe('issueCredential endpoint', () => {
+        test('should issue a credential using the primary signing authority', async () => {
+            const unsignedCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: '', // Will be set by the endpoint
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:recipient',
+                    achievement: 'Test Achievement',
+                },
+            };
+
+            const signedCredential = await issuerLearnCard.invoke.issueCredentialWithNetwork(
+                unsignedCredential as any
+            );
+
+            expect(signedCredential).toBeDefined();
+            expect(signedCredential.proof).toBeDefined();
+            expect(signedCredential.issuer).toBe(signingAuthorityDid);
+        });
+
+        test('should issue a credential using a specific signing authority', async () => {
+            const sa2 = await issuerLearnCard.invoke.createSigningAuthority('e2e-issue-sa-2');
+            await issuerLearnCard.invoke.registerSigningAuthority(sa2.endpoint, 'issue-sa-2', sa2.did);
+
+            const unsignedCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: '',
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:recipient2',
+                    skill: 'TypeScript',
+                },
+            };
+
+            const signedCredential = await issuerLearnCard.invoke.issueCredentialWithNetwork(
+                unsignedCredential as any,
+                {
+                    signingAuthority: {
+                        endpoint: sa2.endpoint,
+                        name: 'issue-sa-2',
+                    },
+                }
+            );
+
+            expect(signedCredential).toBeDefined();
+            expect(signedCredential.proof).toBeDefined();
+            expect(signedCredential.issuer).toBe(sa2.did);
+        });
+
+        test('should fail if no signing authority is registered', async () => {
+            const newLearnCard = await getLearnCard(crypto.randomBytes(32).toString('hex'));
+            await newLearnCard.invoke.createServiceProfile({
+                profileId: 'no-sa-test',
+                displayName: 'No SA Test',
+                bio: '',
+                shortBio: '',
+            });
+
+            const unsignedCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: '',
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:recipient3',
+                },
+            };
+
+            await expect(
+                newLearnCard.invoke.issueCredentialWithNetwork(unsignedCredential as any)
+            ).rejects.toThrow();
+        });
+
+        test('should work with API key authentication', async () => {
+            const { token } = await createApiTokenForUser(
+                'a',
+                ['credentials:write', 'signingAuthorities:read']
+            );
+
+            const response = await fetch('http://localhost:4000/api/credential/issue', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    credential: {
+                        '@context': ['https://www.w3.org/2018/credentials/v1'],
+                        type: ['VerifiableCredential'],
+                        issuer: '',
+                        issuanceDate: new Date().toISOString(),
+                        credentialSubject: {
+                            id: 'did:example:api-key-recipient',
+                            badge: 'API Key Test Badge',
+                        },
+                    },
+                }),
+            });
+
+            expect(response.status).toBe(200);
+
+            const signedCredential = await response.json();
+
+            expect(signedCredential).toBeDefined();
+            expect(signedCredential.proof).toBeDefined();
+        });
+    });
+
+    describe('verifyCredential endpoint', () => {
+        test('should verify a valid credential', async () => {
+            const unsignedCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: '',
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:verify-test',
+                    status: 'verified',
+                },
+            };
+
+            const signedCredential = await issuerLearnCard.invoke.issueCredentialWithNetwork(
+                unsignedCredential as any
+            );
+
+            const verificationResult = await issuerLearnCard.invoke.verifyCredentialWithNetwork(
+                signedCredential as any
+            );
+
+            expect(verificationResult).toBeDefined();
+            expect(verificationResult.checks).toContain('proof');
+            expect(verificationResult.errors).toHaveLength(0);
+        });
+
+        test('should return errors for an invalid credential', async () => {
+            const invalidCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: 'did:example:fake-issuer',
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:invalid-test',
+                },
+                proof: {
+                    type: 'Ed25519Signature2018',
+                    created: new Date().toISOString(),
+                    verificationMethod: 'did:example:fake-issuer#key-1',
+                    proofPurpose: 'assertionMethod',
+                    jws: 'invalid-signature',
+                },
+            };
+
+            const verificationResult = await issuerLearnCard.invoke.verifyCredentialWithNetwork(
+                invalidCredential as any
+            );
+
+            expect(verificationResult).toBeDefined();
+            expect(verificationResult.errors.length).toBeGreaterThan(0);
+        });
+
+        test('should be accessible without authentication via HTTP', async () => {
+            const unsignedCredential = {
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                type: ['VerifiableCredential'],
+                issuer: '',
+                issuanceDate: new Date().toISOString(),
+                credentialSubject: {
+                    id: 'did:example:public-verify',
+                },
+            };
+
+            const signedCredential = await issuerLearnCard.invoke.issueCredentialWithNetwork(
+                unsignedCredential as any
+            );
+
+            const response = await fetch('http://localhost:4000/api/credential/verify', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    credential: signedCredential,
+                }),
+            });
+
+            expect(response.status).toBe(200);
+
+            const verificationResult = await response.json();
+
+            expect(verificationResult).toBeDefined();
+            expect(verificationResult.checks).toContain('proof');
+            expect(verificationResult.errors).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
# Issue & Verify API routes 

## Summary

This PR introduces two new endpoints in the brain-service that enable credential issuance and verification through the LearnCard Network API, along with corresponding SDK methods and comprehensive documentation.

## Features

### New Brain-Service Endpoints

- **[issueCredential](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/vc/src/issueCredential.ts:6:0-37:2)** - Authenticated endpoint that allows clients to issue credentials using registered signing authorities
  - Uses the user's primary signing authority if none specified
  - Supports optional encryption of the resulting credential
  - Requires `credentials:write` scope
  
- **[verifyCredential](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/learn-card-network/src/plugin.ts:1937:12-1983:13)** - Public endpoint for verifying credentials
  - Returns verification result with checks, warnings, and errors
  - No authentication required

### Network Plugin Enhancements

- Added [issueCredentialWithNetwork()](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/learn-card-network/src/plugin.ts:536:12-544:13) method for explicit network-based credential issuance
- Added [verifyCredentialWithNetwork()](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/learn-card-network/src/plugin.ts:582:12-587:13) method for network-based verification
- **Added [issueCredential](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/vc/src/issueCredential.ts:6:0-37:2) override** that automatically delegates to network signing when no local keypair is available (API key mode)

### API Key LearnCard Support

API key-initialized LearnCards can now seamlessly issue credentials via [learnCard.invoke.issueCredential()](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/vc/src/issueCredential.ts:6:0-37:2) - the network plugin automatically detects the absence of a local keypair and delegates to the user's registered signing authority.

## Files Changed

| Package/Service | Files |
|-----------------|-------|
| `@learncard/types` | [src/lcn.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/learn-card-types/src/lcn.ts:0:0-0:0) - Added `IssueCredentialInputValidator`, `VerifyCredentialInputValidator` |
| `brain-service` | `src/routes/credentials.ts` - New route implementations |
| `brain-service` | [test/credentials.spec.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/services/learn-card-network/brain-service/test/credentials.spec.ts:0:0-0:0) - Unit tests (12 new tests) |
| `@learncard/network-plugin` | [src/plugin.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/learn-card-network/src/plugin.ts:0:0-0:0), [src/types.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/vc/src/types.ts:0:0-0:0) - New methods + issueCredential override |
| E2E tests | [tests/e2e/tests/credential-issuance.spec.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/tests/e2e/tests/credential-issuance.spec.ts:0:0-0:0) - New E2E test file |
| Docs | [docs/sdks/learncard-core/construction.md](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/docs/sdks/learncard-core/construction.md:0:0-0:0) - API key initialization guide |

## Testing

### Unit Tests Added
- [issueCredential](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/vc/src/issueCredential.ts:6:0-37:2) tests: auth requirements, scope validation, signing authority handling (8 tests)
- [verifyCredential](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/packages/plugins/learn-card-network/src/plugin.ts:1937:12-1983:13) tests: public access, result structure, error handling (4 tests)

### E2E Tests Added
- Credential issuance with primary and specific signing authorities
- API key authentication flow
- Credential verification (valid/invalid credentials)

## Documentation

Added comprehensive documentation for API key initialization in [docs/sdks/learncard-core/construction.md](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/docs/sdks/learncard-core/construction.md:0:0-0:0):
- When to use API key initialization
- Step-by-step guide for generating and using API tokens
- Limitations and considerations

