### PR TITLE
[LC-1554] fix: Use GitHub App token for changeset PRs to enable E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -687,23 +687,24 @@ jobs:
     manage-releases:
         name: Manage Release PR
         needs: determine-affected
+        continue-on-error: true
         if: |
             needs.determine-affected.outputs.is_release != 'true' &&
             needs.determine-affected.outputs.is_manual != 'true'
         runs-on: ubuntu-latest
         steps:
-            # - name: Generate GitHub App Token
-            #   id: app-token
-            #   uses: actions/create-github-app-token@v2
-            #   with:
-            #       app-id: ${{ secrets.E2E_RUNNER_APP_ID }}
-            #       private-key: ${{ secrets.E2E_RUNNER_PRIVATE_KEY }}
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@v2
+              with:
+                  app-id: ${{ secrets.E2E_RUNNER_APP_ID }}
+                  private-key: ${{ secrets.E2E_RUNNER_PRIVATE_KEY }}
 
             - name: Checkout Repo
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  # token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Use Composite Setup Action
               uses: ./.github/actions/setup
@@ -714,5 +715,4 @@ jobs:
                   commit: 'chore(release): version packages'
                   title: 'chore(release): version packages'
               env:
-                  # GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Overview                   

#### 🎟 Relevant Jira Issues                                                                                                                                                                      
  
https://welibrary.atlassian.net/browse/LC-1554?search_id=9c125fbe-dac9-450e-98ee-22be5a918e2a                                                                                                                                                                             
                                                                                                                                                                                                
#### 📚 What is the context and goal of this PR?

E2E tests weren't running on changeset release PRs because the `changesets/action` uses `GITHUB_TOKEN`, and GitHub prevents workflows from triggering on events created by `GITHUB_TOKEN`
(security feature to prevent infinite loops).

#### 🥴 TL; RL:

Use GitHub App token instead of `GITHUB_TOKEN` for changesets so release PRs trigger E2E tests.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Installed E2E Runner GitHub App on the LearnCard repo (required for token generation)  
- Uncomment GitHub App token generation in `manage-releases` job
- Add `continue-on-error: true` so failures don't block deploys

**Testing performed:**

Added a test workflow in [PR #984](https://github.com/learningeconomy/LearnCard/pull/984/changes) to verify the GitHub App token generation step.

- **Attempt 1 - Failed:** https://github.com/learningeconomy/LearnCard/actions/runs/21648921554/attempts/1
  <img width="1203" height="966" alt="image" src="https://github.com/user-attachments/assets/ab6090a1-5a07-48d5-a86f-f700c8867409" />
  - Same "Not Found" error that blocked previous deploy: https://github.com/learningeconomy/LearnCard/actions/runs/21525088162
    <img width="1063" height="956" alt="image" src="https://github.com/user-attachments/assets/681dff5f-fd37-4a32-b7c5-8d80f76f6824" />
  - Root cause: E2E Runner app wasn't installed on the LearnCard repo
- **Fix:** Installed the E2E Runner app on the LearnCard repo
    <img width="1005" height="226" alt="image" src="https://github.com/user-attachments/assets/1d7442a6-d033-445d-b09b-1d26d4ee986f" />
- **Attempt 2 - Passed:** https://github.com/learningeconomy/LearnCard/actions/runs/21648921554?pr=984
    <img width="1788" height="623" alt="image" src="https://github.com/user-attachments/assets/a398b4d5-5aac-49bb-828a-0d5680301fa5" />

#### 🛠 Important tradeoffs made:

Added `continue-on-error: true` so if the token generation ever fails, it won't block actual deployments.

#### 🔍 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### 💳 Does This Create Any New Technical Debt?

- [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. Merge this PR
2. Merge another PR with a changeset to main
3. Verify the resulting changeset PR triggers E2E tests in the checks

#### 📱 🖥 Which devices would you like help testing on?

N/A - CI/CD change only

#### 🧪 Code Coverage

N/A - workflow configuration change

# Documentation

#### 📝 Documentation Checklist

None needed - internal CI/CD fix

#### 💭 Documentation Notes

Internal workflow fix, no user-facing or API changes.

# ✅ PR Checklist

- [x] Related to a Jira issue
- [x] My code follows **style guidelines**
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have completed the **Documentation Checklist** above (or explained why N/A)

### 🚀 Ready to squash-and-merge?:

- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication