### PR TITLE
Docker fix, switch from mongo:latest to mongo:7.0

### DIFF
--- a/apps/learn-card-app/compose-local.yaml
+++ b/apps/learn-card-app/compose-local.yaml
@@ -299,7 +299,7 @@ services:
                 '/var/log/mongodb/mongod.log',
             ]
         container_name: 'lcn-mongodb'
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:

--- a/apps/learn-card-app/compose.yaml
+++ b/apps/learn-card-app/compose.yaml
@@ -217,7 +217,7 @@ services:
                 '/var/log/mongodb/mongod.log',
             ]
         container_name: 'lcn-mongodb'
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:

--- a/apps/scouts/compose-local.yaml
+++ b/apps/scouts/compose-local.yaml
@@ -319,7 +319,7 @@ services:
                 '/var/log/mongodb/mongod.log',
             ]
         container_name: 'lcn-mongodb'
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:

--- a/apps/scouts/compose.yaml
+++ b/apps/scouts/compose.yaml
@@ -213,7 +213,7 @@ services:
                 '/var/log/mongodb/mongod.log',
             ]
         container_name: 'lcn-mongodb'
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:

--- a/examples/learn-card-network-docker-compose/compose.yaml
+++ b/examples/learn-card-network-docker-compose/compose.yaml
@@ -151,7 +151,7 @@ services:
 
     mongodb:
         command: --quiet
-        image: mongo:latest
+        image: mongo:7.0
         environment:
             MONGO_INITDB_DATABASE: start
         expose:

--- a/preview/README.md
+++ b/preview/README.md
@@ -90,7 +90,7 @@ Each PR stack is a fully isolated Docker Compose project:
 | **Signing Service** | `Dockerfile.monorepo` | 4200 |
 | **LCA API** | `lca-api/Dockerfile` | 5100 |
 | **Neo4j** | `neo4j:latest` | 7687 |
-| **MongoDB** (replica set) | `mongo:latest` | 27017 |
+| **MongoDB** (replica set) | `mongo:7.0` | 27017 |
 | **Redis** ×3 | `redis:alpine` | 6379 |
 | **ElasticMQ** | `softwaremill/elasticmq-native` | 9324 |
 | **Postgres** | `postgres` | 5432 |

--- a/preview/docker-compose.preview.yaml
+++ b/preview/docker-compose.preview.yaml
@@ -208,7 +208,7 @@ services:
 
     mongodb:
         command: ['--replSet', 'rs0', '--bind_ip_all', '--port', '27017', '--quiet', '--logpath', '/var/log/mongodb/mongod.log']
-        image: mongo:latest
+        image: mongo:7.0
         extra_hosts:
             - 'localhost:host-gateway'
         healthcheck:

--- a/services/learn-card-network/compose.yaml
+++ b/services/learn-card-network/compose.yaml
@@ -174,7 +174,7 @@ services:
                 '--logpath',
                 '/var/log/mongodb/mongod.log',
             ]
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:

--- a/tests/e2e/compose.yaml
+++ b/tests/e2e/compose.yaml
@@ -247,7 +247,7 @@ services:
                 '--logpath',
                 '/var/log/mongodb/mongod.log',
             ]
-        image: mongo:latest
+        image: mongo:7.0
         expose:
             - 27017
         ports:


### PR DESCRIPTION
I was having these annoying docker issues. This just switches all of our docker compose files to use `mongo:7.0` instead of `mongo:latest`

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Pin MongoDB Docker image to version 7.0 across all compose files to ensure consistent environment behavior and prevent breaking changes from latest tag updates.

Main changes:
- Replaced mongo:latest with mongo:7.0 in 8 Docker Compose files across apps, services, and test environments
- Updated preview documentation to reflect pinned MongoDB version for replica set configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
