### PR TITLE
Add LAiSER to registry

### DIFF
--- a/packages/learn-card-registries/trusted/registry.json
+++ b/packages/learn-card-registries/trusted/registry.json
@@ -213,6 +213,11 @@
             "name": "Whitehall Demo",
             "location": "Washington, DC, USA",
             "url": "https://www.learncard.com/"
+        },
+        "did:web:laiser.gwu.edu": {
+            "name": "LAiSER",
+            "location": "Washington, DC, USA",
+            "url": "https://laiser.gwu.edu"
         }
     }
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add LAiSER (GWU) organization to the trusted registry to enable their participation in the LearnCard network ecosystem.

Main changes:
- Added new DID entry "did:web:laiser.gwu.edu" with organization metadata to trusted registry configuration
- Configured LAiSER organization details including name, Washington DC location, and website URL
- Fixed missing comma in JSON structure after whitehall-demo registry entry

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
