### PR TITLE
Replace did:web entry with did:key entry in registry

### DIFF
--- a/packages/learn-card-registries/trusted/registry.json
+++ b/packages/learn-card-registries/trusted/registry.json
@@ -214,7 +214,7 @@
             "location": "Washington, DC, USA",
             "url": "https://www.learncard.com/"
         },
-        "did:web:laiser.gwu.edu": {
+        "did:key:z6MkjQCNHNfmdQ59AkcxH721E86YvkhPd1YmPojTdLoaTjLW": {
             "name": "LAiSER",
             "location": "Washington, DC, USA",
             "url": "https://laiser.gwu.edu"


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update LAiSER registry entry from did:web to did:key identifier to align with decentralized identity best practices and improve key management security.

Main changes:
- Replaced did:web:laiser.gwu.edu with did:key:z6MkjQCNHNfmdQ59AkcxH721E86YvkhPd1YmPojTdLoaTjLW for LAiSER organization entry
- Maintained existing metadata (name, location, URL) while transitioning to cryptographic key-based identifier
- Updated trusted registry configuration to use self-certifying DID method instead of web-based resolution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
