### PR TITLE
feat: Capgo Fixes + CI Check + Version Modal

### DIFF
--- a/.changeset/tasty-beans-invent.md
+++ b/.changeset/tasty-beans-invent.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+feat: Capgo Fixes + CI Check + Version Modal

--- a/.github/workflows/capgo-channel-guard.yml
+++ b/.github/workflows/capgo-channel-guard.yml
@@ -134,8 +134,6 @@ jobs:
                       sections.push('- include the marker **`[skip-channel-bump]`** somewhere in the PR description (with a one-line rationale, please).');
                       sections.push('');
                       sections.push('Either will dismiss this check.');
-                      sections.push('');
-                      sections.push('_Background: this guard exists because of the PR #1063 incident, where a channel bump landed in one config file but not the other and new clients reverted to old OTA bundles._');
 
                       const marker = '<!-- capgo-channel-guard -->';
                       const body = `${marker}\n${sections.join('\n')}`;

--- a/.github/workflows/capgo-channel-guard.yml
+++ b/.github/workflows/capgo-channel-guard.yml
@@ -1,0 +1,202 @@
+name: Capgo Channel Guard
+
+# When a PR makes backwards-incompatible native runtime changes (new / removed
+# Capacitor or Capgo plugin, native source edits) but does NOT bump
+# `defaultChannel` in apps/learn-card-app/capacitor.config.ts, fail the check
+# and leave a sticky comment explaining how to fix it.
+#
+# See PR #1063 for the original incident this guards against.
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+        paths:
+            - 'apps/learn-card-app/package.json'
+            - 'apps/learn-card-app/capacitor.config.ts'
+            - 'apps/learn-card-app/ios/**'
+            - 'apps/learn-card-app/android/**'
+            - 'tools/capgo/check-channel-bump.js'
+            - '.github/workflows/capgo-channel-guard.yml'
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    guard:
+        name: Verify Capgo channel bump
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout (full history)
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Detect native compat changes
+              id: detect
+              run: |
+                  node tools/capgo/check-channel-bump.js \
+                      --base "${{ github.event.pull_request.base.sha }}" \
+                      --head "${{ github.event.pull_request.head.sha }}" \
+                      --out  "${{ github.workspace }}/capgo-guard.json" \
+                      > /dev/null
+
+                  echo '--- capgo-guard.json ---'
+                  cat "${{ github.workspace }}/capgo-guard.json"
+                  echo '------------------------'
+
+                  GUARD_FAILED=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1], "utf-8")).guardFailed)' "${{ github.workspace }}/capgo-guard.json")
+                  echo "guard_failed=$GUARD_FAILED" >> "$GITHUB_OUTPUT"
+
+            - name: Check for escape-hatch label or marker
+              id: escape
+              if: steps.detect.outputs.guard_failed == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const { data: pr } = await github.rest.pulls.get({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: context.payload.pull_request.number,
+                      });
+
+                      const labels = (pr.labels ?? []).map(l => l.name);
+                      const hasLabel = labels.includes('compat:backwards-compatible');
+                      const hasMarker = (pr.body ?? '').includes('[skip-channel-bump]');
+                      const skip = hasLabel || hasMarker;
+
+                      core.setOutput('skip', String(skip));
+                      core.setOutput('reason', hasLabel ? 'label' : (hasMarker ? 'marker' : ''));
+
+            - name: Post / update PR comment (guard failed)
+              if: steps.detect.outputs.guard_failed == 'true' && steps.escape.outputs.skip != 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('fs');
+                      const result = JSON.parse(
+                          fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/capgo-guard.json`, 'utf-8')
+                      );
+
+                      const fileLines = result.nativeFileChanges.map(f => `- \`${f}\``);
+
+                      const depLines = [
+                          ...result.depDiff.added.map(d => `- \u2795 added \`${d.name}\` @ \`${d.to}\``),
+                          ...result.depDiff.removed.map(d => `- \u2796 removed \`${d.name}\` (was \`${d.from}\`)`),
+                          ...result.depDiff.changed.map(d => `- \ud83d\udd04 \`${d.name}\`: \`${d.from}\` \u2192 \`${d.to}\``),
+                      ];
+
+                      const sections = [];
+                      sections.push(`### \ud83d\udea6 Capgo channel bump appears to be required`);
+                      sections.push('');
+                      sections.push(`This PR changes the **native runtime surface**, but \`defaultChannel\` in \`apps/learn-card-app/capacitor.config.ts\` is still **\`${result.baseChannel ?? 'unknown'}\`**.`);
+                      sections.push('');
+                      sections.push(`If your change is **backwards-incompatible** with the currently-shipped native binary (e.g. it adds, removes, or upgrades a Capacitor / Capgo plugin in a way that changes the native API surface, or edits native source), you need to bump the Capgo OTA channel. Otherwise, CI will keep uploading OTA bundles to channel \`${result.baseChannel ?? 'unknown'}\` while installed binaries also listen there \u2014 and they\u2019ll load JS that calls into native code they don\u2019t have, which crashes or silently misbehaves.`);
+
+                      if (fileLines.length) {
+                          sections.push('');
+                          sections.push('**Native files changed:**');
+                          sections.push(fileLines.join('\n'));
+                      }
+
+                      if (depLines.length) {
+                          sections.push('');
+                          sections.push('**Native runtime deps changed:**');
+                          sections.push(depLines.join('\n'));
+                      }
+
+                      sections.push('');
+                      sections.push('---');
+                      sections.push('');
+                      sections.push('### \ud83d\udee0 How to fix');
+                      sections.push('');
+                      sections.push('Run the bumper from the repo root:');
+                      sections.push('');
+                      sections.push('```bash');
+                      sections.push('pnpm --filter learn-card-app lc bump-default-capgo-channel');
+                      sections.push('```');
+                      sections.push('');
+                      sections.push('Or pass an explicit channel:');
+                      sections.push('');
+                      sections.push('```bash');
+                      sections.push('pnpm --filter learn-card-app lc bump-default-capgo-channel 1.0.7');
+                      sections.push('```');
+                      sections.push('');
+                      sections.push('Then commit and push the updated `capacitor.config.ts`. The next push to this PR will re-run this check.');
+                      sections.push('');
+                      sections.push('---');
+                      sections.push('');
+                      sections.push('### \ud83e\udeaa Exemptions');
+                      sections.push('');
+                      sections.push('If your change is genuinely **backwards-compatible** with the current native binary (e.g. a Capgo CLI bump, a plugin patch release with no native API change, a comment-only edit picked up by the path filter), do **one** of:');
+                      sections.push('');
+                      sections.push('- add the label **`compat:backwards-compatible`** to this PR, **or**');
+                      sections.push('- include the marker **`[skip-channel-bump]`** somewhere in the PR description (with a one-line rationale, please).');
+                      sections.push('');
+                      sections.push('Either will dismiss this check.');
+                      sections.push('');
+                      sections.push('_Background: this guard exists because of the PR #1063 incident, where a channel bump landed in one config file but not the other and new clients reverted to old OTA bundles._');
+
+                      const marker = '<!-- capgo-channel-guard -->';
+                      const body = `${marker}\n${sections.join('\n')}`;
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                      });
+
+                      const existing = comments.find(c => (c.body ?? '').includes(marker));
+
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.payload.pull_request.number,
+                              body,
+                          });
+                      }
+
+            - name: Resolve sticky comment (guard passed or exempted)
+              if: steps.detect.outputs.guard_failed != 'true' || steps.escape.outputs.skip == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const marker = '<!-- capgo-channel-guard -->';
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                      });
+
+                      const existing = comments.find(c => (c.body ?? '').includes(marker));
+
+                      if (!existing) return;
+
+                      const reason = '${{ steps.escape.outputs.reason }}';
+                      const exemptedNote = reason
+                          ? `\n_Exempted via ${reason === 'label' ? 'the `compat:backwards-compatible` label' : 'the `[skip-channel-bump]` marker in the PR body'}._`
+                          : '';
+
+                      const body = `${marker}\n### \u2705 Capgo channel guard resolved\n\nNo backwards-incompatible native change requires a channel bump on this PR\u2019s current state.${exemptedNote}`;
+
+                      await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                      });
+
+            - name: Fail the check if guard tripped
+              if: steps.detect.outputs.guard_failed == 'true' && steps.escape.outputs.skip != 'true'
+              run: |
+                  echo "::error::Capgo channel guard failed \u2014 bump defaultChannel via 'pnpm lc bump-default-capgo-channel' or use an exemption (see PR comment)."
+                  exit 1

--- a/apps/learn-card-app/android/capacitor.settings.gradle
+++ b/apps/learn-card-app/android/capacitor.settings.gradle
@@ -66,7 +66,7 @@ include ':capawesome-capacitor-badge'
 project(':capawesome-capacitor-badge').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-badge@8.0.0_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-badge/android')
 
 include ':capgo-capacitor-updater'
-project(':capgo-capacitor-updater').projectDir = new File('../../../node_modules/.pnpm/@capgo+capacitor-updater@8.41.12_@capacitor+core@8.0.1/node_modules/@capgo/capacitor-updater/android')
+project(':capgo-capacitor-updater').projectDir = new File('../../../node_modules/.pnpm/@capgo+capacitor-updater@8.45.0_@capacitor+core@8.0.1/node_modules/@capgo/capacitor-updater/android')
 
 include ':capacitor-native-settings'
 project(':capacitor-native-settings').projectDir = new File('../../../node_modules/.pnpm/capacitor-native-settings@7.0.2_@capacitor+core@8.0.1/node_modules/capacitor-native-settings/android')

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -53,7 +53,16 @@ const config: CapacitorConfig = {
         CapacitorUpdater: {
             appId: 'com.learncard.app',
             autoUpdate: true,
-            defaultChannel: '1.0.6', // bumped here -> https://github.com/learningeconomy/LearnCard/pull/1063
+            // SINGLE SOURCE OF TRUTH for the Capgo channel.
+            // - CI reads this value via `tools/capgo/getCapgoChannel.js` (regex match) to pick
+            //   the channel that OTA bundles are uploaded to in the deploy workflow.
+            // - `npx cap sync` propagates this into ios/.../capacitor.config.json and
+            //   android/.../capacitor.config.json so installed binaries listen on the same
+            //   channel that CI uploads to.
+            // Bump this value whenever you bump native binaries; do NOT add a parallel
+            // tenant-level override — that's how channels drift and OTA updates land in
+            // an empty channel (see PR #1063 incident).
+            defaultChannel: '1.0.6',
         },
     },
 };

--- a/apps/learn-card-app/environments/learncard/config.json
+++ b/apps/learn-card-app/environments/learncard/config.json
@@ -107,7 +107,6 @@
             "learncardapp.netlify.com",
             "lcw.app"
         ],
-        "customSchemes": ["dccrequest", "msprequest", "asuprequest"],
-        "capgoChannel": "1.0.6"
+        "customSchemes": ["dccrequest", "msprequest", "asuprequest"]
     }
 }

--- a/apps/learn-card-app/environments/vetpass/config.json
+++ b/apps/learn-card-app/environments/vetpass/config.json
@@ -89,7 +89,6 @@
             "vetpass.app",
             "learncard.app"
         ],
-        "customSchemes": ["dccrequest", "msprequest", "asuprequest"],
-        "capgoChannel": "1.0.0"
+        "customSchemes": ["dccrequest", "msprequest", "asuprequest"]
     }
 }

--- a/apps/learn-card-app/ios/App/Podfile
+++ b/apps/learn-card-app/ios/App/Podfile
@@ -32,7 +32,7 @@ def capacitor_pods
   pod 'CapacitorSplashScreen', :path => '../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/splash-screen'
   pod 'CapacitorStatusBar', :path => '../../../../node_modules/.pnpm/@capacitor+status-bar@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/status-bar'
   pod 'CapawesomeCapacitorBadge', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-badge@8.0.0_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-badge'
-  pod 'CapgoCapacitorUpdater', :path => '../../../../node_modules/.pnpm/@capgo+capacitor-updater@8.41.12_@capacitor+core@8.0.1/node_modules/@capgo/capacitor-updater'
+  pod 'CapgoCapacitorUpdater', :path => '../../../../node_modules/.pnpm/@capgo+capacitor-updater@8.45.0_@capacitor+core@8.0.1/node_modules/@capgo/capacitor-updater'
   pod 'CapacitorNativeSettings', :path => '../../../../node_modules/.pnpm/capacitor-native-settings@7.0.2_@capacitor+core@8.0.1/node_modules/capacitor-native-settings'
   pod 'CapacitorPluginSafeArea', :path => '../../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.0.1/node_modules/capacitor-plugin-safe-area'
 end

--- a/apps/learn-card-app/scripts/bump-default-capgo-channel.ts
+++ b/apps/learn-card-app/scripts/bump-default-capgo-channel.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * bump-default-capgo-channel.ts
+ *
+ * Bump the Capgo OTA channel in `apps/learn-card-app/capacitor.config.ts`.
+ *
+ * The `defaultChannel` value in that file is the SINGLE SOURCE OF TRUTH:
+ *   - CI reads it via `tools/capgo/getCapgoChannel.js` to pick the channel
+ *     OTA bundles are uploaded to.
+ *   - `npx cap sync` propagates it into iOS/Android `capacitor.config.json`,
+ *     so installed binaries listen on the same channel CI uploads to.
+ *
+ * Bump this ONLY when you make a backwards-INcompatible native change
+ * (new/removed Capacitor or Capgo plugin, native source edits, plugin
+ * major version bump that changes its native API surface). Bumping the
+ * channel fragments installed binaries off OTA updates until users update
+ * via the App / Play store, so do NOT bump for routine JS-only releases.
+ *
+ * Usage:
+ *   pnpm lc bump-default-capgo-channel              # interactive prompt with sensible default
+ *   pnpm lc bump-default-capgo-channel 1.0.7        # explicit value
+ *
+ * Direct invocation:
+ *   npx tsx apps/learn-card-app/scripts/bump-default-capgo-channel.ts [newChannel]
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createInterface } from 'readline';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const APP_ROOT = resolve(__dirname, '..');
+const CONFIG_PATH = resolve(APP_ROOT, 'capacitor.config.ts');
+
+const bold = (s: string): string => `\x1b[1m${s}\x1b[0m`;
+const dim = (s: string): string => `\x1b[2m${s}\x1b[0m`;
+const green = (s: string): string => `\x1b[32m${s}\x1b[0m`;
+const yellow = (s: string): string => `\x1b[33m${s}\x1b[0m`;
+const cyan = (s: string): string => `\x1b[36m${s}\x1b[0m`;
+const red = (s: string): string => `\x1b[31m${s}\x1b[0m`;
+
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
+
+interface ChannelMatch {
+    content: string;
+    channel: string;
+    valueStart: number;
+    valueEnd: number;
+}
+
+const readDefaultChannel = (): ChannelMatch => {
+    const content = readFileSync(CONFIG_PATH, 'utf-8');
+    const re = /(defaultChannel\s*:\s*['"])([^'"]+)(['"])/;
+    const match = re.exec(content);
+
+    if (!match || match.index === undefined) {
+        console.error(red(`❌ Could not find "defaultChannel" in ${CONFIG_PATH}`));
+        process.exit(1);
+    }
+
+    const valueStart = match.index + match[1].length;
+    const valueEnd = valueStart + match[2].length;
+
+    return { content, channel: match[2], valueStart, valueEnd };
+};
+
+const writeDefaultChannel = (current: ChannelMatch, newChannel: string): void => {
+    const next =
+        current.content.slice(0, current.valueStart) +
+        newChannel +
+        current.content.slice(current.valueEnd);
+
+    writeFileSync(CONFIG_PATH, next, 'utf-8');
+};
+
+const compareSemver = (a: string, b: string): number => {
+    const parse = (v: string): number[] =>
+        v.split('-')[0].split('.').map(p => Number.parseInt(p, 10));
+
+    const aParts = parse(a);
+    const bParts = parse(b);
+    const len = Math.max(aParts.length, bParts.length);
+
+    for (let i = 0; i < len; i++) {
+        const ap = aParts[i] ?? 0;
+        const bp = bParts[i] ?? 0;
+
+        if (ap !== bp) return ap - bp;
+    }
+
+    return 0;
+};
+
+const suggestNext = (current: string): string | undefined => {
+    const m = current.match(/^(\d+)\.(\d+)\.(\d+)$/);
+
+    if (!m) return undefined;
+
+    return `${m[1]}.${m[2]}.${Number.parseInt(m[3], 10) + 1}`;
+};
+
+const main = async (): Promise<void> => {
+    const explicit = process.argv.slice(2).find(a => !a.startsWith('-'));
+    const current = readDefaultChannel();
+
+    console.log('');
+    console.log(bold('🚦 Capgo channel bump'));
+    console.log('');
+    console.log(`  Current ${cyan('defaultChannel')}: ${cyan(current.channel)}`);
+    console.log(dim(`  File: ${CONFIG_PATH}`));
+    console.log('');
+    console.log(yellow('  ⚠️  Bumping the channel fragments installed binaries off OTA updates.'));
+    console.log(yellow('     Only bump for backwards-INcompatible native changes (new / removed plugins,'));
+    console.log(yellow('     native source edits, plugin major-version upgrades).'));
+    console.log('');
+
+    let next: string;
+
+    if (explicit) {
+        next = explicit;
+    } else {
+        const rl = createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string): Promise<string> =>
+            new Promise(res => rl.question(q, ans => res(ans.trim())));
+
+        const suggested = suggestNext(current.channel);
+        const prompt = suggested
+            ? `  New channel ${dim(`(default: ${suggested})`)}: `
+            : '  New channel: ';
+
+        const answer = await ask(prompt);
+
+        rl.close();
+        next = answer || (suggested ?? '');
+    }
+
+    if (!next) {
+        console.error(red('❌ No channel value provided.'));
+        process.exit(1);
+    }
+
+    if (!VERSION_RE.test(next)) {
+        console.error(red(`❌ "${next}" is not a valid version (expected e.g. 1.0.7).`));
+        process.exit(1);
+    }
+
+    if (next === current.channel) {
+        console.log(yellow(`⚠️  "${next}" matches the current channel — nothing to do.`));
+        process.exit(0);
+    }
+
+    if (compareSemver(next, current.channel) <= 0) {
+        console.error(red(`❌ "${next}" is not greater than the current channel "${current.channel}".`));
+        console.error(red('   Refusing to downgrade. Capgo channels must move forward.'));
+        process.exit(1);
+    }
+
+    writeDefaultChannel(current, next);
+
+    console.log('');
+    console.log(green(`✅ Bumped defaultChannel: ${current.channel} → ${next}`));
+    console.log('');
+    console.log(bold('  Next steps:'));
+    console.log(`  ${dim('1.')} Stage:   ${cyan('git add apps/learn-card-app/capacitor.config.ts')}`);
+    console.log(
+        `  ${dim('2.')} Commit:  ${cyan(`git commit -m "chore(capgo): bump default channel to ${next}"`)}`,
+    );
+    console.log(`  ${dim('3.')} Push & open / update your PR.`);
+    console.log('');
+    console.log(dim('  CI will upload OTA bundles to the new channel; the next native binary'));
+    console.log(dim(`  release in the App / Play stores will pick up channel ${next}.`));
+    console.log('');
+};
+
+main().catch(err => {
+    console.error(red('Unexpected error:'), err);
+    process.exit(1);
+});

--- a/apps/learn-card-app/scripts/lc.ts
+++ b/apps/learn-card-app/scripts/lc.ts
@@ -1490,6 +1490,21 @@ const handleShortcuts = async (): Promise<boolean> => {
             runCommand('npx tsx scripts/create-theme.ts', 'Create a new theme');
             return true;
 
+        case 'bump-default-capgo-channel':
+        case 'bump-capgo-channel': {
+            // pnpm lc bump-default-capgo-channel [newChannel]
+            const newChannel = arg ? ` ${arg}` : '';
+
+            runCommand(
+                `npx tsx scripts/bump-default-capgo-channel.ts${newChannel}`,
+                'Bump Capgo defaultChannel in capacitor.config.ts',
+                arg
+                    ? `pnpm lc bump-default-capgo-channel ${arg}`
+                    : 'pnpm lc bump-default-capgo-channel',
+            );
+            return true;
+        }
+
         case 'viewer':
             launchCredentialViewer();
             return true;
@@ -1583,6 +1598,7 @@ const printHelp = () => {
     console.log('');
     console.log(`  ${cyan('pnpm lc create')}                     ${dim('Scaffold a new tenant')}`);
     console.log(`  ${cyan('pnpm lc create-theme')}               ${dim('Scaffold a new theme')}`);
+    console.log(`  ${cyan('pnpm lc bump-default-capgo-channel')} ${dim('Bump Capgo OTA channel (native compat break)')}`);
     console.log(`  ${cyan('pnpm lc generate <tenant> <logo>')}   ${dim('Generate icons/splash from a logo')}`);
     console.log(`  ${cyan('pnpm lc validate')}                   ${dim('Run all config + theme validators')}`);
     console.log(`  ${cyan('pnpm lc switch <tenant> [stage]')}    ${dim('Prepare config without starting')}`);

--- a/apps/learn-card-app/scripts/prepare-native-config.ts
+++ b/apps/learn-card-app/scripts/prepare-native-config.ts
@@ -496,10 +496,6 @@ if (nativeConfig) {
 
             if (raw.plugins?.CapacitorUpdater) {
                 raw.plugins.CapacitorUpdater.appId = nativeConfig.bundleId;
-
-                if (nativeConfig.capgoChannel) {
-                    raw.plugins.CapacitorUpdater.defaultChannel = nativeConfig.capgoChannel;
-                }
             }
 
             writeFileSync(jsonPath, JSON.stringify(raw, null, 2) + '\n', 'utf-8');

--- a/apps/learn-card-app/src/components/sidemenu/SideMenuFooter.tsx
+++ b/apps/learn-card-app/src/components/sidemenu/SideMenuFooter.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
+import { useModal, ModalTypes } from 'learn-card-base';
 
 import useTheme from '../../theme/hooks/useTheme';
 import { openPP, openToS } from '../../helpers/externalLinkHelpers';
+import VersionInfoModal from '../versionInfoModal/VersionInfoModal';
 
 const SideMenuFooter: React.FC<{ version?: string | undefined }> = ({ version }) => {
     const currentYear = new Date().getFullYear();
     const { colors } = useTheme();
     const primaryColor = colors?.defaults?.primaryColor;
+
+    const { newModal } = useModal({ desktop: ModalTypes.Center, mobile: ModalTypes.Cancel });
+
+    const openVersionInfo = (): void => {
+        if (!version) return;
+
+        newModal(<VersionInfoModal fallbackVersion={version} />, {
+            sectionClassName: '!max-w-[420px]',
+            cancelButtonTextOverride: 'Close',
+        });
+    };
 
     return (
         <div className="px-2 bg-transparent h-18 flex-none order-1 self-stretch flex-grow-0 text-white text-xs font-normal font-poppins mt-6 leading-snug m-4 mb-8">
@@ -30,8 +43,19 @@ const SideMenuFooter: React.FC<{ version?: string | undefined }> = ({ version })
             </p>
 
             <p className="text-grayscale-600 text-xs font-notoSans mt-4">
-                {version && `V ${version}`}
-                {version && <br />}
+                {version ? (
+                    <>
+                        <button
+                            type="button"
+                            onClick={openVersionInfo}
+                            aria-label="View version details"
+                            className="text-grayscale-600 hover:text-grayscale-900 transition-colors underline-offset-2 hover:underline focus:outline-none focus-visible:underline"
+                        >
+                            V {version}
+                        </button>
+                        <br />
+                    </>
+                ) : null}
                 &copy; {currentYear} Learning Economy
             </p>
         </div>

--- a/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
+++ b/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
@@ -107,6 +107,14 @@ const shorten = (value: string | undefined, head = 6, tail = 4): string => {
 };
 
 /**
+ * Anything older than this is almost certainly a sentinel — Capgo occasionally
+ * returns epoch 0 / `1970-01-01T00:00:00.000Z` for bundles it hasn't actually
+ * delivered OTA (e.g. the builtin bundle, or when the field isn't populated).
+ * Treat those as "unset" rather than rendering "Last updated: 12/31/1969".
+ */
+const MIN_MEANINGFUL_TS = new Date('2020-01-01T00:00:00Z').getTime();
+
+/**
  * Render an ISO timestamp as a friendly relative string ("3 hours ago").
  * Falls back to a locale date string for anything older than a week so the
  * exact day is still visible — useful in support screenshots.
@@ -116,7 +124,7 @@ const formatRelative = (iso: string | undefined): string | undefined => {
 
     const ts = new Date(iso).getTime();
 
-    if (Number.isNaN(ts)) return undefined;
+    if (Number.isNaN(ts) || ts < MIN_MEANINGFUL_TS) return undefined;
 
     const ms = Date.now() - ts;
     const sec = Math.floor(ms / 1000);
@@ -206,11 +214,19 @@ const collectVersionInfo = async (fallbackVersion: string): Promise<VersionInfo>
             : (appInfo?.version ?? fallbackVersion);
 
     // The current bundle's `downloaded` field is the timestamp the OTA bundle
-    // was applied to this device. Empty / 'builtin' means we're still on the
-    // bundle that shipped in the binary, in which case we hide the row.
+    // was applied to this device. Capgo returns one of several "unset" values
+    // when the bundle hasn't actually been delivered OTA (empty string, epoch
+    // 0, or '1970-01-01T00:00:00.000Z'), so we also reject anything before the
+    // MIN_MEANINGFUL_TS sentinel rather than rendering "12/31/1969".
     const downloaded = bundle?.bundle?.downloaded;
+    const downloadedTs = downloaded ? new Date(downloaded).getTime() : NaN;
     const lastUpdateApplied =
-        bundleVersion && bundleVersion !== 'builtin' && downloaded && downloaded.trim() !== ''
+        bundleVersion &&
+        bundleVersion !== 'builtin' &&
+        downloaded &&
+        downloaded.trim() !== '' &&
+        !Number.isNaN(downloadedTs) &&
+        downloadedTs >= MIN_MEANINGFUL_TS
             ? downloaded
             : undefined;
 
@@ -522,7 +538,15 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
     const platformLabel = PLATFORM_LABELS[info.platform];
 
     return (
-        <div className="font-poppins px-6 pt-6 pb-5 flex flex-col items-center w-full max-w-[400px] mx-auto">
+        <div
+            className="font-poppins px-6 pb-5 flex flex-col items-center w-full max-w-[400px] mx-auto"
+            style={{
+                // Match the app-wide pattern (AppStoreDetailModal, ShareCredentialModal
+                // etc.): respect the iOS notch/dynamic-island inset when the modal is
+                // rendered as a fullscreen cancel sheet, fall back to 1.5rem elsewhere.
+                paddingTop: 'max(1.5rem, env(safe-area-inset-top))',
+            }}
+        >
             {/* ---- Hero ---------------------------------------------------------- */}
             <img
                 src={appIcon}

--- a/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
+++ b/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
@@ -15,10 +15,11 @@
  *   - Middle: labeled key/value rows for the build. Plain language where
  *     we can use it ("App version", "Update channel"), technical terms only
  *     where they help support ("Content version" = Capgo bundle).
- *   - Bottom primary action: "Copy details" — pastes a pre-formatted,
- *     support-ready block to the clipboard.
- *   - Advanced (collapsed by default): device ID, builtin bundle version,
- *     native build number, Capgo plugin version. Hidden unless expanded.
+ *   - Primary action: "Copy details" — pastes a pre-formatted, support-ready
+ *     block to the clipboard.
+ *   - Advanced (collapsed by default): account, tenant, build commit, device
+ *     ID, network, plus a "Check for updates" action and a flag-gated
+ *     channel switcher.
  *
  * Gracefully degrades on web: fields that require the native
  * CapacitorUpdater plugin are hidden rather than rendered as "—".
@@ -30,19 +31,36 @@ import {
     chevronDownOutline,
     chevronUpOutline,
     checkmarkCircleOutline,
+    cloudDownloadOutline,
     copyOutline,
     informationCircleOutline,
+    swapHorizontalOutline,
+    warningOutline,
 } from 'ionicons/icons';
 import { Capacitor } from '@capacitor/core';
 import { App, type AppInfo } from '@capacitor/app';
 import { Clipboard } from '@capacitor/clipboard';
+import { Network } from '@capacitor/network';
 import { CapacitorUpdater } from '@capgo/capacitor-updater';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
-import { useBrandingConfig, useToast, ToastTypeEnum } from 'learn-card-base';
+import {
+    useBrandingConfig,
+    useConfirmation,
+    useGetCurrentLCNUser,
+    useTenantConfig,
+    useToast,
+    ToastTypeEnum,
+} from 'learn-card-base';
 
 import { useTenantBrandingAssets } from '../../config/brandingAssets';
 
 type Platform = 'ios' | 'android' | 'web';
+
+interface NetworkSummary {
+    connected: boolean;
+    label: string;
+}
 
 interface VersionInfo {
     platform: Platform;
@@ -69,6 +87,10 @@ interface VersionInfo {
     pluginVersion?: string;
     /** Version of the JS bundle that shipped in the native binary. */
     builtinVersion?: string;
+    /** ISO timestamp of when the current OTA bundle was downloaded. Empty for builtin. */
+    lastUpdateApplied?: string;
+    /** Connectivity summary (works on web + native). */
+    network?: NetworkSummary;
 }
 
 const PLATFORM_LABELS: Record<Platform, string> = {
@@ -84,15 +106,87 @@ const shorten = (value: string | undefined, head = 6, tail = 4): string => {
     return `${value.slice(0, head)}…${value.slice(-tail)}`;
 };
 
+/**
+ * Render an ISO timestamp as a friendly relative string ("3 hours ago").
+ * Falls back to a locale date string for anything older than a week so the
+ * exact day is still visible — useful in support screenshots.
+ */
+const formatRelative = (iso: string | undefined): string | undefined => {
+    if (!iso) return undefined;
+
+    const ts = new Date(iso).getTime();
+
+    if (Number.isNaN(ts)) return undefined;
+
+    const ms = Date.now() - ts;
+    const sec = Math.floor(ms / 1000);
+
+    if (sec < 60) return 'Just now';
+
+    const min = Math.floor(sec / 60);
+
+    if (min < 60) return `${min} minute${min === 1 ? '' : 's'} ago`;
+
+    const hr = Math.floor(min / 60);
+
+    if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`;
+
+    const day = Math.floor(hr / 24);
+
+    if (day < 7) return `${day} day${day === 1 ? '' : 's'} ago`;
+
+    return new Date(iso).toLocaleDateString();
+};
+
+const formatNetwork = (
+    status: { connected: boolean; connectionType: string } | null,
+): NetworkSummary | undefined => {
+    if (!status) return undefined;
+
+    if (!status.connected) return { connected: false, label: 'Offline' };
+
+    switch (status.connectionType) {
+        case 'wifi':
+            return { connected: true, label: 'Wi-Fi · Connected' };
+        case 'cellular':
+            return { connected: true, label: 'Cellular · Connected' };
+        case 'none':
+            return { connected: false, label: 'Offline' };
+        default:
+            return { connected: true, label: 'Connected' };
+    }
+};
+
+const formatBuildDate = (iso: string | undefined): string | undefined => {
+    if (!iso) return undefined;
+
+    const ts = new Date(iso).getTime();
+
+    if (Number.isNaN(ts)) return undefined;
+
+    return new Date(iso).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+};
+
 const collectVersionInfo = async (fallbackVersion: string): Promise<VersionInfo> => {
     const platform = Capacitor.getPlatform() as Platform;
     const isNative = Capacitor.isNativePlatform();
+
+    // Network status works on both web and native, so collect it unconditionally.
+    const networkStatus = await Network.getStatus().catch(() => null);
+    const network = formatNetwork(networkStatus);
 
     if (!isNative) {
         return {
             platform,
             isNative,
             displayVersion: fallbackVersion,
+            network,
         };
     }
 
@@ -111,6 +205,15 @@ const collectVersionInfo = async (fallbackVersion: string): Promise<VersionInfo>
             ? bundleVersion
             : (appInfo?.version ?? fallbackVersion);
 
+    // The current bundle's `downloaded` field is the timestamp the OTA bundle
+    // was applied to this device. Empty / 'builtin' means we're still on the
+    // bundle that shipped in the binary, in which case we hide the row.
+    const downloaded = bundle?.bundle?.downloaded;
+    const lastUpdateApplied =
+        bundleVersion && bundleVersion !== 'builtin' && downloaded && downloaded.trim() !== ''
+            ? downloaded
+            : undefined;
+
     return {
         platform,
         isNative,
@@ -125,12 +228,22 @@ const collectVersionInfo = async (fallbackVersion: string): Promise<VersionInfo>
         deviceId: (deviceIdResult as { deviceId?: string } | null)?.deviceId,
         pluginVersion: (pluginVersionResult as { version?: string } | null)?.version,
         builtinVersion: (builtinResult as { version?: string } | null)?.version,
+        lastUpdateApplied,
+        network,
     };
 };
 
-const buildCopyPayload = (info: VersionInfo, appName: string): string => {
+interface CopyPayloadContext {
+    appName: string;
+    profileId?: string;
+    tenantId?: string;
+    buildSha?: string;
+    buildDate?: string;
+}
+
+const buildCopyPayload = (info: VersionInfo, ctx: CopyPayloadContext): string => {
     const lines = [
-        `${appName} — version details`,
+        `${ctx.appName} — version details`,
         `Platform: ${PLATFORM_LABELS[info.platform]}`,
         `App version: ${info.displayVersion}`,
     ];
@@ -138,8 +251,14 @@ const buildCopyPayload = (info: VersionInfo, appName: string): string => {
     if (info.nativeVersion) lines.push(`Native version: ${info.nativeVersion} (${info.nativeBuild ?? '—'})`);
     if (info.bundleVersion) lines.push(`Content version: ${info.bundleVersion}`);
     if (info.channel) lines.push(`Update channel: ${info.channel}`);
+    if (info.lastUpdateApplied) lines.push(`Last updated: ${info.lastUpdateApplied}`);
+    if (info.network) lines.push(`Network: ${info.network.label}`);
+    if (ctx.profileId) lines.push(`Account: ${ctx.profileId}`);
+    if (ctx.tenantId) lines.push(`Tenant: ${ctx.tenantId}`);
     if (info.bundleId) lines.push(`Bundle id: ${info.bundleId}`);
     if (info.deviceId) lines.push(`Device id: ${info.deviceId}`);
+    if (ctx.buildSha) lines.push(`Build commit: ${ctx.buildSha}`);
+    if (ctx.buildDate) lines.push(`Build date: ${ctx.buildDate}`);
     if (info.pluginVersion) lines.push(`Updater plugin: v${info.pluginVersion}`);
     if (info.builtinVersion) lines.push(`Shipped bundle: ${info.builtinVersion}`);
     lines.push(`Captured: ${new Date().toISOString()}`);
@@ -196,12 +315,32 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
     const brandingConfig = useBrandingConfig();
     const { appIcon } = useTenantBrandingAssets();
     const { presentToast } = useToast();
+    const tenantConfig = useTenantConfig();
+    const { currentLCNUser } = useGetCurrentLCNUser();
+    const flags = useFlags();
+    const confirm = useConfirmation();
 
     const [info, setInfo] = useState<VersionInfo | null>(null);
     const [advancedOpen, setAdvancedOpen] = useState(false);
     const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle');
+    const [checkingForUpdate, setCheckingForUpdate] = useState(false);
+    const [showChannelInput, setShowChannelInput] = useState(false);
+    const [channelInput, setChannelInput] = useState('');
+    const [switchingChannel, setSwitchingChannel] = useState(false);
 
     const appName = brandingConfig?.name ?? 'App';
+    const tenantId = tenantConfig?.tenantId;
+    const profileId = currentLCNUser?.profileId;
+    const buildSha = typeof __BUILD_SHA__ === 'string' ? __BUILD_SHA__ : undefined;
+    const buildDateRaw = typeof __BUILD_DATE__ === 'string' ? __BUILD_DATE__ : undefined;
+    const buildDate = formatBuildDate(buildDateRaw);
+    const channelSwitcherEnabled = Boolean(flags?.enableChannelSwitcher);
+
+    const refreshInfo = async (): Promise<void> => {
+        const next = await collectVersionInfo(fallbackVersion);
+
+        setInfo(next);
+    };
 
     useEffect(() => {
         let cancelled = false;
@@ -218,8 +357,17 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
     }, [fallbackVersion]);
 
     const copyPayload = useMemo(
-        () => (info ? buildCopyPayload(info, appName) : ''),
-        [info, appName],
+        () =>
+            info
+                ? buildCopyPayload(info, {
+                      appName,
+                      profileId,
+                      tenantId,
+                      buildSha,
+                      buildDate: buildDateRaw,
+                  })
+                : '',
+        [info, appName, profileId, tenantId, buildSha, buildDateRaw],
     );
 
     const copyString = async (value: string, label: string): Promise<void> => {
@@ -250,6 +398,115 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
                 type: ToastTypeEnum.Error,
                 hasDismissButton: true,
             });
+        }
+    };
+
+    /**
+     * Manually ask Capgo whether a newer bundle is available on the assigned
+     * channel. Capgo's `getLatest()` throws a non-error "No new version available"
+     * when the device is already up to date — we catch that specifically and
+     * surface a friendly success toast.
+     */
+    const handleCheckForUpdates = async (): Promise<void> => {
+        if (!Capacitor.isNativePlatform()) {
+            presentToast('Update checks only run on the installed app.', {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+            return;
+        }
+
+        setCheckingForUpdate(true);
+
+        try {
+            const latest = await CapacitorUpdater.getLatest();
+            const version = (latest as { version?: string } | null)?.version;
+
+            presentToast(
+                version
+                    ? `Update available: v${version}. It will install next time you reopen the app.`
+                    : `An update is available. It will install next time you reopen the app.`,
+                { type: ToastTypeEnum.Success, hasDismissButton: true },
+            );
+        } catch (err) {
+            const msg = (err as { message?: string } | null)?.message ?? '';
+            const upToDate =
+                msg.includes('No new version') ||
+                msg.includes('no_new_version_available') ||
+                msg.includes('Already up to date');
+
+            if (upToDate) {
+                presentToast(`You're on the latest version.`, {
+                    type: ToastTypeEnum.Success,
+                    hasDismissButton: true,
+                });
+            } else {
+                presentToast(`Couldn't check for updates${msg ? `: ${msg}` : '.'}`, {
+                    type: ToastTypeEnum.Error,
+                    hasDismissButton: true,
+                });
+            }
+        } finally {
+            setCheckingForUpdate(false);
+        }
+    };
+
+    /**
+     * Switch the device to a different Capgo channel. Two layers of friction:
+     *   1. The whole switcher is hidden unless `enableChannelSwitcher` is on in
+     *      LaunchDarkly.
+     *   2. We require an explicit confirmation dialog before the channel
+     *      change goes through, because switching to a channel with an
+     *      incompatible native binary will break the app on next reload.
+     */
+    const handleSwitchChannel = async (): Promise<void> => {
+        const next = channelInput.trim();
+
+        if (!next || !info) return;
+
+        if (next === info.channel) {
+            presentToast(`Already on channel ${next}.`, { hasDismissButton: true });
+            return;
+        }
+
+        const ok = await confirm({
+            title: 'Switch update channel?',
+            text: (
+                <span className="text-sm text-grayscale-700 leading-relaxed">
+                    This will switch your device to channel{' '}
+                    <strong className="text-grayscale-900">{next}</strong>. The app will start
+                    receiving updates from that channel and may download a different version of
+                    the content. Only do this if support has asked you to.
+                </span>
+            ),
+            confirmText: `Switch to ${next}`,
+            cancelText: 'Cancel',
+        });
+
+        if (!ok) return;
+
+        setSwitchingChannel(true);
+
+        try {
+            await CapacitorUpdater.setChannel({ channel: next, triggerAutoUpdate: true });
+
+            presentToast(`Switched to channel ${next}. Updates will apply on next reload.`, {
+                type: ToastTypeEnum.Success,
+                hasDismissButton: true,
+            });
+
+            setShowChannelInput(false);
+            setChannelInput('');
+            await refreshInfo();
+        } catch (err) {
+            const msg = (err as { message?: string } | null)?.message ?? 'unknown error';
+
+            presentToast(`Couldn't switch channel: ${msg}`, {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+        } finally {
+            setSwitchingChannel(false);
         }
     };
 
@@ -333,6 +590,14 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
                         onCopy={copyString}
                     />
                 ) : null}
+                {info.lastUpdateApplied ? (
+                    <VersionInfoRow
+                        label="Last updated"
+                        value={formatRelative(info.lastUpdateApplied)}
+                        copyValue={info.lastUpdateApplied}
+                        onCopy={copyString}
+                    />
+                ) : null}
             </div>
 
             {/* ---- Primary action ------------------------------------------------ */}
@@ -354,24 +619,42 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
                 )}
             </button>
 
-            {/* ---- Advanced (collapsible) ---------------------------------------- */}
-            {info.isNative && (info.deviceId || info.pluginVersion || info.builtinVersion || info.bundleId || info.bundleInternalId || info.bundleChecksum) ? (
-                <div className="mt-4 w-full">
-                    <button
-                        type="button"
-                        onClick={() => setAdvancedOpen(o => !o)}
-                        aria-expanded={advancedOpen}
-                        className="w-full flex items-center justify-between py-2 px-1 text-xs font-medium text-grayscale-500 hover:text-grayscale-700 transition-colors"
-                    >
-                        <span className="uppercase tracking-wide">Advanced</span>
-                        <IonIcon
-                            icon={advancedOpen ? chevronUpOutline : chevronDownOutline}
-                            className="text-base"
-                        />
-                    </button>
+            {/* ---- Advanced (collapsible) ----------------------------------------
+              * Always rendered (even on web): some fields like `network`, `tenant`,
+              * `account`, and the build commit make sense in every environment.
+              */}
+            <div className="mt-4 w-full">
+                <button
+                    type="button"
+                    onClick={() => setAdvancedOpen(o => !o)}
+                    aria-expanded={advancedOpen}
+                    className="w-full flex items-center justify-between py-2 px-1 text-xs font-medium text-grayscale-500 hover:text-grayscale-700 transition-colors"
+                >
+                    <span className="uppercase tracking-wide">Advanced</span>
+                    <IonIcon
+                        icon={advancedOpen ? chevronUpOutline : chevronDownOutline}
+                        className="text-base"
+                    />
+                </button>
 
-                    {advancedOpen ? (
-                        <div className="mt-1 w-full bg-grayscale-10 border border-grayscale-200 rounded-2xl px-4 py-1">
+                {advancedOpen ? (
+                    <div className="mt-1 w-full flex flex-col gap-3">
+                        <div className="w-full bg-grayscale-10 border border-grayscale-200 rounded-2xl px-4 py-1">
+                            {profileId ? (
+                                <VersionInfoRow
+                                    label="Account"
+                                    value={shorten(profileId, 8, 6)}
+                                    copyValue={profileId}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {tenantId ? (
+                                <VersionInfoRow
+                                    label="Tenant"
+                                    value={tenantId}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
                             {info.bundleId ? (
                                 <VersionInfoRow
                                     label="Bundle ID"
@@ -384,6 +667,27 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
                                     label="Device ID"
                                     value={shorten(info.deviceId)}
                                     copyValue={info.deviceId}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {info.network ? (
+                                <VersionInfoRow
+                                    label="Network"
+                                    value={info.network.label}
+                                />
+                            ) : null}
+                            {buildSha ? (
+                                <VersionInfoRow
+                                    label="Build commit"
+                                    value={buildSha}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {buildDate ? (
+                                <VersionInfoRow
+                                    label="Build date"
+                                    value={buildDate}
+                                    copyValue={buildDateRaw}
                                     onCopy={copyString}
                                 />
                             ) : null}
@@ -414,9 +718,102 @@ const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) 
                                 />
                             ) : null}
                         </div>
-                    ) : null}
-                </div>
-            ) : null}
+
+                        {/* ---- Check-for-updates action ------------------------- */}
+                        {info.isNative ? (
+                            <button
+                                type="button"
+                                onClick={handleCheckForUpdates}
+                                disabled={checkingForUpdate}
+                                className="w-full py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {checkingForUpdate ? (
+                                    <>
+                                        <span className="w-4 h-4 border-2 border-grayscale-300 border-t-grayscale-700 rounded-full animate-spin" />
+                                        Checking…
+                                    </>
+                                ) : (
+                                    <>
+                                        <IonIcon icon={cloudDownloadOutline} className="text-base" />
+                                        Check for updates
+                                    </>
+                                )}
+                            </button>
+                        ) : null}
+
+                        {/* ---- Channel switcher (LaunchDarkly-gated) ------------ */}
+                        {channelSwitcherEnabled && info.isNative ? (
+                            !showChannelInput ? (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setChannelInput(info.channel ?? '');
+                                        setShowChannelInput(true);
+                                    }}
+                                    className="w-full py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                >
+                                    <IonIcon icon={swapHorizontalOutline} className="text-base" />
+                                    Switch update channel…
+                                </button>
+                            ) : (
+                                <div className="w-full bg-amber-50 border border-amber-100 rounded-2xl p-3 flex flex-col gap-2.5">
+                                    <div className="flex items-start gap-2">
+                                        <IonIcon
+                                            icon={warningOutline}
+                                            className="text-amber-600 text-base mt-0.5 shrink-0"
+                                        />
+                                        <p className="text-xs text-amber-900 leading-relaxed">
+                                            Switching channels can cause the app to download a
+                                            version of the content that&rsquo;s incompatible with
+                                            your installed app. Only continue if support has asked
+                                            you to.
+                                        </p>
+                                    </div>
+
+                                    <label className="text-xs font-medium text-grayscale-700 mt-1">
+                                        Channel name
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={channelInput}
+                                        onChange={e => setChannelInput(e.target.value)}
+                                        placeholder="e.g. 1.0.7"
+                                        spellCheck={false}
+                                        autoCapitalize="off"
+                                        autoCorrect="off"
+                                        className="w-full py-2.5 px-3 border border-grayscale-300 rounded-xl text-sm text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white"
+                                    />
+
+                                    <div className="flex gap-2 mt-1">
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setShowChannelInput(false);
+                                                setChannelInput('');
+                                            }}
+                                            className="flex-1 py-2.5 px-3 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors"
+                                        >
+                                            Cancel
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={handleSwitchChannel}
+                                            disabled={
+                                                switchingChannel ||
+                                                !channelInput.trim() ||
+                                                channelInput.trim() === info.channel
+                                            }
+                                            className="flex-1 py-2.5 px-3 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+                                        >
+                                            {switchingChannel ? 'Switching…' : 'Apply'}
+                                        </button>
+                                    </div>
+                                </div>
+                            )
+                        ) : null}
+                    </div>
+                ) : null}
+            </div>
         </div>
     );
 };

--- a/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
+++ b/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
@@ -1,0 +1,424 @@
+/**
+ * VersionInfoModal
+ *
+ * A screenshot-friendly, non-scary "About this app" sheet.
+ *
+ * Purpose: when a user (or a member of the support team guiding them) taps
+ * the version line in the side menu footer, they see a clear summary of
+ * which version of the app they're running — friendly on the surface,
+ * with enough diagnostic detail underneath an "Advanced" chevron to pin
+ * down the exact native binary / OTA bundle / Capgo channel combo.
+ *
+ * Design intent:
+ *   - Top-of-card: app icon, app name, friendly version. This is what the
+ *     user sees at a glance and what shows up cleanly in a screenshot.
+ *   - Middle: labeled key/value rows for the build. Plain language where
+ *     we can use it ("App version", "Update channel"), technical terms only
+ *     where they help support ("Content version" = Capgo bundle).
+ *   - Bottom primary action: "Copy details" — pastes a pre-formatted,
+ *     support-ready block to the clipboard.
+ *   - Advanced (collapsed by default): device ID, builtin bundle version,
+ *     native build number, Capgo plugin version. Hidden unless expanded.
+ *
+ * Gracefully degrades on web: fields that require the native
+ * CapacitorUpdater plugin are hidden rather than rendered as "—".
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { IonIcon } from '@ionic/react';
+import {
+    chevronDownOutline,
+    chevronUpOutline,
+    checkmarkCircleOutline,
+    copyOutline,
+    informationCircleOutline,
+} from 'ionicons/icons';
+import { Capacitor } from '@capacitor/core';
+import { App, type AppInfo } from '@capacitor/app';
+import { Clipboard } from '@capacitor/clipboard';
+import { CapacitorUpdater } from '@capgo/capacitor-updater';
+
+import { useBrandingConfig, useToast, ToastTypeEnum } from 'learn-card-base';
+
+import { useTenantBrandingAssets } from '../../config/brandingAssets';
+
+type Platform = 'ios' | 'android' | 'web';
+
+interface VersionInfo {
+    platform: Platform;
+    isNative: boolean;
+    /** Resolved app version — Capgo bundle on native (if live-updated), else package.json. */
+    displayVersion: string;
+    /** Native binary version (from Info.plist / build.gradle). */
+    nativeVersion?: string;
+    /** Native build number (iOS CFBundleVersion, Android versionCode). */
+    nativeBuild?: string;
+    /** Native app bundle id (com.learncard.app, etc.). */
+    bundleId?: string;
+    /** Capgo OTA bundle version — 'builtin' if running the embedded bundle. */
+    bundleVersion?: string;
+    /** Capgo bundle ID (internal). */
+    bundleInternalId?: string;
+    /** Capgo bundle checksum (first chars only). */
+    bundleChecksum?: string;
+    /** Capgo channel currently assigned to this device. */
+    channel?: string;
+    /** Capgo-assigned device id (for support). */
+    deviceId?: string;
+    /** Version of the Capgo updater plugin. */
+    pluginVersion?: string;
+    /** Version of the JS bundle that shipped in the native binary. */
+    builtinVersion?: string;
+}
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+    ios: 'iOS',
+    android: 'Android',
+    web: 'Web',
+};
+
+const shorten = (value: string | undefined, head = 6, tail = 4): string => {
+    if (!value) return '';
+    if (value.length <= head + tail + 1) return value;
+
+    return `${value.slice(0, head)}…${value.slice(-tail)}`;
+};
+
+const collectVersionInfo = async (fallbackVersion: string): Promise<VersionInfo> => {
+    const platform = Capacitor.getPlatform() as Platform;
+    const isNative = Capacitor.isNativePlatform();
+
+    if (!isNative) {
+        return {
+            platform,
+            isNative,
+            displayVersion: fallbackVersion,
+        };
+    }
+
+    // Each of these is wrapped individually so one failing plugin call
+    // doesn't blank the whole modal.
+    const appInfo = await App.getInfo().catch((): AppInfo | null => null);
+    const bundle = await CapacitorUpdater.current().catch(() => null);
+    const channelResult = await CapacitorUpdater.getChannel().catch(() => null);
+    const deviceIdResult = await CapacitorUpdater.getDeviceId().catch(() => null);
+    const pluginVersionResult = await CapacitorUpdater.getPluginVersion().catch(() => null);
+    const builtinResult = await CapacitorUpdater.getBuiltinVersion().catch(() => null);
+
+    const bundleVersion = bundle?.bundle?.version;
+    const displayVersion =
+        bundleVersion && bundleVersion !== 'builtin' && bundleVersion.trim() !== ''
+            ? bundleVersion
+            : (appInfo?.version ?? fallbackVersion);
+
+    return {
+        platform,
+        isNative,
+        displayVersion,
+        nativeVersion: appInfo?.version,
+        nativeBuild: appInfo?.build,
+        bundleId: appInfo?.id,
+        bundleVersion,
+        bundleInternalId: bundle?.bundle?.id,
+        bundleChecksum: bundle?.bundle?.checksum,
+        channel: (channelResult as { channel?: string } | null)?.channel,
+        deviceId: (deviceIdResult as { deviceId?: string } | null)?.deviceId,
+        pluginVersion: (pluginVersionResult as { version?: string } | null)?.version,
+        builtinVersion: (builtinResult as { version?: string } | null)?.version,
+    };
+};
+
+const buildCopyPayload = (info: VersionInfo, appName: string): string => {
+    const lines = [
+        `${appName} — version details`,
+        `Platform: ${PLATFORM_LABELS[info.platform]}`,
+        `App version: ${info.displayVersion}`,
+    ];
+
+    if (info.nativeVersion) lines.push(`Native version: ${info.nativeVersion} (${info.nativeBuild ?? '—'})`);
+    if (info.bundleVersion) lines.push(`Content version: ${info.bundleVersion}`);
+    if (info.channel) lines.push(`Update channel: ${info.channel}`);
+    if (info.bundleId) lines.push(`Bundle id: ${info.bundleId}`);
+    if (info.deviceId) lines.push(`Device id: ${info.deviceId}`);
+    if (info.pluginVersion) lines.push(`Updater plugin: v${info.pluginVersion}`);
+    if (info.builtinVersion) lines.push(`Shipped bundle: ${info.builtinVersion}`);
+    lines.push(`Captured: ${new Date().toISOString()}`);
+
+    return lines.join('\n');
+};
+
+interface VersionInfoRowProps {
+    label: string;
+    value: string | undefined;
+    copyValue?: string;
+    onCopy?: (value: string, label: string) => void;
+}
+
+const VersionInfoRow: React.FC<VersionInfoRowProps> = ({ label, value, copyValue, onCopy }) => {
+    if (!value) return null;
+
+    const handleCopy = (): void => {
+        if (onCopy) onCopy(copyValue ?? value, label);
+    };
+
+    return (
+        <div className="flex items-start justify-between gap-3 py-2.5 border-b border-grayscale-100 last:border-b-0">
+            <span className="text-xs font-medium text-grayscale-500 uppercase tracking-wide shrink-0 pt-0.5">
+                {label}
+            </span>
+
+            <div className="flex items-center gap-2 min-w-0">
+                <span className="text-sm text-grayscale-900 font-medium text-right truncate">
+                    {value}
+                </span>
+
+                {onCopy ? (
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        aria-label={`Copy ${label}`}
+                        className="shrink-0 text-grayscale-400 hover:text-grayscale-700 transition-colors p-1 -mr-1"
+                    >
+                        <IonIcon icon={copyOutline} className="text-base" />
+                    </button>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
+interface VersionInfoModalProps {
+    /** The version string currently rendered in the footer — used as a fallback on web. */
+    fallbackVersion: string;
+}
+
+const VersionInfoModal: React.FC<VersionInfoModalProps> = ({ fallbackVersion }) => {
+    const brandingConfig = useBrandingConfig();
+    const { appIcon } = useTenantBrandingAssets();
+    const { presentToast } = useToast();
+
+    const [info, setInfo] = useState<VersionInfo | null>(null);
+    const [advancedOpen, setAdvancedOpen] = useState(false);
+    const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle');
+
+    const appName = brandingConfig?.name ?? 'App';
+
+    useEffect(() => {
+        let cancelled = false;
+
+        (async () => {
+            const next = await collectVersionInfo(fallbackVersion);
+
+            if (!cancelled) setInfo(next);
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [fallbackVersion]);
+
+    const copyPayload = useMemo(
+        () => (info ? buildCopyPayload(info, appName) : ''),
+        [info, appName],
+    );
+
+    const copyString = async (value: string, label: string): Promise<void> => {
+        try {
+            await Clipboard.write({ string: value });
+
+            presentToast(`${label} copied`, {
+                type: ToastTypeEnum.Success,
+                hasDismissButton: true,
+            });
+        } catch {
+            presentToast('Could not copy to clipboard', {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+        }
+    };
+
+    const handleCopyAll = async (): Promise<void> => {
+        if (!copyPayload) return;
+
+        try {
+            await Clipboard.write({ string: copyPayload });
+            setCopyState('copied');
+            window.setTimeout(() => setCopyState('idle'), 2000);
+        } catch {
+            presentToast('Could not copy to clipboard', {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+        }
+    };
+
+    if (!info) {
+        return (
+            <div className="font-poppins py-10 px-8 flex flex-col items-center gap-3">
+                <span className="w-6 h-6 border-2 border-grayscale-200 border-t-grayscale-700 rounded-full animate-spin" />
+                <span className="text-sm text-grayscale-500">Gathering version info…</span>
+            </div>
+        );
+    }
+
+    const platformLabel = PLATFORM_LABELS[info.platform];
+
+    return (
+        <div className="font-poppins px-6 pt-6 pb-5 flex flex-col items-center w-full max-w-[400px] mx-auto">
+            {/* ---- Hero ---------------------------------------------------------- */}
+            <img
+                src={appIcon}
+                alt={`${appName} icon`}
+                className="h-[56px] w-[56px] rounded-[14px] shadow-sm"
+            />
+
+            <h2 className="mt-4 text-lg font-semibold text-grayscale-900 text-center">
+                {appName}
+            </h2>
+
+            <p className="mt-1 text-sm text-grayscale-500 text-center">
+                Version <span className="font-medium text-grayscale-700">{info.displayVersion}</span>
+                <span className="mx-1.5 text-grayscale-300">·</span>
+                {platformLabel}
+            </p>
+
+            {/* ---- Friendly reassurance ------------------------------------------ */}
+            <div className="mt-4 w-full flex items-start gap-2 bg-emerald-50 border border-emerald-100 rounded-2xl py-2.5 px-3">
+                <IonIcon
+                    icon={informationCircleOutline}
+                    className="text-emerald-500 text-base mt-0.5 shrink-0"
+                />
+                <p className="text-xs text-emerald-900 leading-relaxed">
+                    These details help support identify exactly which build you&rsquo;re running
+                    if you ever need to report an issue.
+                </p>
+            </div>
+
+            {/* ---- Core info list ------------------------------------------------ */}
+            <div className="mt-4 w-full bg-white border border-grayscale-200 rounded-2xl px-4 py-1">
+                <VersionInfoRow label="Platform" value={platformLabel} />
+                <VersionInfoRow
+                    label="App version"
+                    value={info.displayVersion}
+                    onCopy={copyString}
+                />
+                {info.nativeVersion ? (
+                    <VersionInfoRow
+                        label="Native version"
+                        value={
+                            info.nativeBuild
+                                ? `${info.nativeVersion} (${info.nativeBuild})`
+                                : info.nativeVersion
+                        }
+                        copyValue={
+                            info.nativeBuild
+                                ? `${info.nativeVersion} (${info.nativeBuild})`
+                                : info.nativeVersion
+                        }
+                        onCopy={copyString}
+                    />
+                ) : null}
+                {info.bundleVersion ? (
+                    <VersionInfoRow
+                        label="Content version"
+                        value={info.bundleVersion}
+                        onCopy={copyString}
+                    />
+                ) : null}
+                {info.channel ? (
+                    <VersionInfoRow
+                        label="Update channel"
+                        value={info.channel}
+                        onCopy={copyString}
+                    />
+                ) : null}
+            </div>
+
+            {/* ---- Primary action ------------------------------------------------ */}
+            <button
+                type="button"
+                onClick={handleCopyAll}
+                className="mt-5 w-full py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+            >
+                {copyState === 'copied' ? (
+                    <>
+                        <IonIcon icon={checkmarkCircleOutline} className="text-base" />
+                        Copied to clipboard
+                    </>
+                ) : (
+                    <>
+                        <IonIcon icon={copyOutline} className="text-base" />
+                        Copy details
+                    </>
+                )}
+            </button>
+
+            {/* ---- Advanced (collapsible) ---------------------------------------- */}
+            {info.isNative && (info.deviceId || info.pluginVersion || info.builtinVersion || info.bundleId || info.bundleInternalId || info.bundleChecksum) ? (
+                <div className="mt-4 w-full">
+                    <button
+                        type="button"
+                        onClick={() => setAdvancedOpen(o => !o)}
+                        aria-expanded={advancedOpen}
+                        className="w-full flex items-center justify-between py-2 px-1 text-xs font-medium text-grayscale-500 hover:text-grayscale-700 transition-colors"
+                    >
+                        <span className="uppercase tracking-wide">Advanced</span>
+                        <IonIcon
+                            icon={advancedOpen ? chevronUpOutline : chevronDownOutline}
+                            className="text-base"
+                        />
+                    </button>
+
+                    {advancedOpen ? (
+                        <div className="mt-1 w-full bg-grayscale-10 border border-grayscale-200 rounded-2xl px-4 py-1">
+                            {info.bundleId ? (
+                                <VersionInfoRow
+                                    label="Bundle ID"
+                                    value={info.bundleId}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {info.deviceId ? (
+                                <VersionInfoRow
+                                    label="Device ID"
+                                    value={shorten(info.deviceId)}
+                                    copyValue={info.deviceId}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {info.builtinVersion ? (
+                                <VersionInfoRow
+                                    label="Shipped bundle"
+                                    value={info.builtinVersion}
+                                />
+                            ) : null}
+                            {info.bundleInternalId ? (
+                                <VersionInfoRow
+                                    label="Bundle ref"
+                                    value={info.bundleInternalId}
+                                />
+                            ) : null}
+                            {info.bundleChecksum ? (
+                                <VersionInfoRow
+                                    label="Checksum"
+                                    value={shorten(info.bundleChecksum, 8, 4)}
+                                    copyValue={info.bundleChecksum}
+                                    onCopy={copyString}
+                                />
+                            ) : null}
+                            {info.pluginVersion ? (
+                                <VersionInfoRow
+                                    label="Updater plugin"
+                                    value={`v${info.pluginVersion}`}
+                                />
+                            ) : null}
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+};
+
+export default VersionInfoModal;

--- a/apps/learn-card-app/src/global.d.ts
+++ b/apps/learn-card-app/src/global.d.ts
@@ -4,6 +4,8 @@ declare var SENTRY_ENV: string;
 
 declare var GOOGLE_MAPS_API_KEY: string | undefined;
 declare var __PACKAGE_VERSION__: string;
+declare var __BUILD_SHA__: string;
+declare var __BUILD_DATE__: string;
 declare var APP_THEME: string | undefined;
 declare var CORS_PROXY_API_KEY: string | undefined;
 

--- a/apps/learn-card-app/tools/config-editor/config.html
+++ b/apps/learn-card-app/tools/config-editor/config.html
@@ -211,7 +211,6 @@ const SECTIONS = [
             { path: 'native.displayName', label: 'Display Name', type: 'string', required: true },
             { path: 'native.deepLinkDomains', label: 'Deep Link Domains', type: 'array', required: true, help: 'Domains for universal links / app links' },
             { path: 'native.customSchemes', label: 'Custom URL Schemes', type: 'array', help: 'e.g. dccrequest, msprequest' },
-            { path: 'native.capgoChannel', label: 'Capgo Channel', type: 'string' },
         ],
     },
     {

--- a/apps/learn-card-app/vite.config.ts
+++ b/apps/learn-card-app/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { execSync } from 'child_process';
 
 import GlobalPolyfill from '@esbuild-plugins/node-globals-polyfill';
 import { defineConfig, loadEnv } from 'vite';
@@ -8,6 +9,37 @@ import svgr from 'vite-plugin-svgr';
 import stdlibbrowser from 'node-stdlib-browser';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import { visualizer } from 'rollup-plugin-visualizer';
+
+/**
+ * Resolve a short build commit SHA at config-eval time.
+ *
+ * Source preference:
+ *   1. CI-provided env vars (GitHub Actions / Heroku / Vercel etc.)
+ *   2. Local `git rev-parse --short HEAD`
+ *   3. The string 'dev' if neither is available (e.g. in a stripped Docker
+ *      build with no .git directory).
+ *
+ * Surfaced to the runtime via the `__BUILD_SHA__` global, used in the
+ * VersionInfoModal so support / engineering can identify the exact commit
+ * a binary or OTA bundle was built from.
+ */
+const resolveBuildSha = (): string => {
+    const fromEnv =
+        process.env.GITHUB_SHA ??
+        process.env.HEROKU_SLUG_COMMIT ??
+        process.env.VERCEL_GIT_COMMIT_SHA ??
+        process.env.BUILD_SHA;
+
+    if (fromEnv) return fromEnv.slice(0, 7);
+
+    try {
+        return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+            .toString()
+            .trim();
+    } catch {
+        return 'dev';
+    }
+};
 
 // Workspace packages that should not be pre-bundled for HMR support
 const workspacePackages = [
@@ -74,6 +106,8 @@ export default defineConfig(({ mode }) => {
         },
         define: {
             __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
+            __BUILD_SHA__: JSON.stringify(resolveBuildSha()),
+            __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
             IS_PRODUCTION: process.env.NODE_ENV === 'production',
             // DEPRECATED — these are now in TenantConfig (config.json → auth.*)
             // Kept as fallbacks for backward compat; will be removed in a future PR.

--- a/packages/learn-card-base/src/config/tenantConfigSchema.ts
+++ b/packages/learn-card-base/src/config/tenantConfigSchema.ts
@@ -171,7 +171,6 @@ export const tenantNativeConfigSchema = z.object({
     displayName: z.string(),
     deepLinkDomains: z.array(z.string()),
     customSchemes: z.array(z.string()).optional(),
-    capgoChannel: z.string().optional(),
 }).passthrough();
 
 /**

--- a/packages/learn-card-base/src/config/tenantDefaults.ts
+++ b/packages/learn-card-base/src/config/tenantDefaults.ts
@@ -126,7 +126,6 @@ export const DEFAULT_LEARNCARD_TENANT_CONFIG: TenantConfig = {
             'lcw.app'
         ],
         customSchemes: ['dccrequest', 'msprequest', 'asuprequest'],
-        capgoChannel: '1.0.4',
     },
 };
 

--- a/tools/capgo/check-channel-bump.js
+++ b/tools/capgo/check-channel-bump.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// tools/capgo/check-channel-bump.js
+//
+// Detects whether a PR makes backwards-incompatible native runtime changes
+// that require bumping the Capgo OTA channel in
+// `apps/learn-card-app/capacitor.config.ts:defaultChannel`.
+//
+// Usage:
+//   node tools/capgo/check-channel-bump.js \
+//        --base <baseSha> \
+//        --head <headSha> \
+//       [--out  <jsonPath>]
+//
+// Behavior:
+//   - Compares native runtime deps in `apps/learn-card-app/package.json`
+//     between base and head SHAs (adds / removes / version changes).
+//   - Compares tracked native source files (iOS / Android source, Podfile,
+//     Android template manifests / build.gradle).
+//   - Reads `defaultChannel` from `capacitor.config.ts` at both SHAs and
+//     determines whether it was bumped.
+//   - Writes a JSON result to stdout (always) and to --out (if provided).
+//   - Exit code is always 0; consumers should branch on `result.guardFailed`.
+//
+// This script is intentionally dependency-free and runs on plain Node.
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+
+const argFlag = (flag) => {
+    const i = args.indexOf(flag);
+
+    return i === -1 ? undefined : args[i + 1];
+};
+
+const base = argFlag('--base');
+const head = argFlag('--head');
+const outPath = argFlag('--out');
+
+if (!base || !head) {
+    console.error('Usage: node check-channel-bump.js --base <sha> --head <sha> [--out <path>]');
+    process.exit(2);
+}
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const PACKAGE_JSON = 'apps/learn-card-app/package.json';
+const CAPACITOR_CONFIG = 'apps/learn-card-app/capacitor.config.ts';
+
+// --- Native compat-affecting paths -----------------------------------------
+//
+// We deliberately do NOT include `capacitor.config.ts` itself: cosmetic /
+// comment edits there are common, and any *real* compat change shows up as
+// either a native dep change in package.json OR a touched native source file.
+//
+const NATIVE_PATH_PATTERNS = [
+    /^apps\/learn-card-app\/ios\/App\/Podfile$/,
+    /^apps\/learn-card-app\/ios\/App\/App\/.*\.(swift|m|mm|h)$/,
+    /^apps\/learn-card-app\/android\/app\/src\/main\/java\//,
+    /^apps\/learn-card-app\/android\/app\/src\/main\/kotlin\//,
+    /^apps\/learn-card-app\/android\/app\/src\/main\/AndroidManifest\.xml\.template$/,
+    /^apps\/learn-card-app\/android\/app\/build\.gradle\.template$/,
+    /^apps\/learn-card-app\/android\/build\.gradle$/,
+    /^apps\/learn-card-app\/android\/variables\.gradle$/,
+];
+
+// --- Native runtime dep classifier -----------------------------------------
+//
+// Anything matching these patterns is treated as a Capacitor / Capgo runtime
+// plugin (i.e. ships native code into the binary).
+//
+const NATIVE_DEP_PATTERNS = [
+    /^@capacitor\//,
+    /^@capgo\//,
+    /^@capacitor-/, // @capacitor-community, @capacitor-firebase, @capacitor-mlkit, ...
+    /^@capawesome\//,
+    /^capacitor-/, // capacitor-native-settings, capacitor-plugin-safe-area, ...
+];
+
+// Tooling deps that match the patterns but do NOT ship native code at runtime.
+const EXCLUDED_DEPS = new Set([
+    '@capacitor/cli',
+    '@capacitor/assets',
+    '@capgo/cli',
+]);
+
+const isNativeDep = (name) =>
+    !EXCLUDED_DEPS.has(name) && NATIVE_DEP_PATTERNS.some(re => re.test(name));
+
+// --- Git helpers ------------------------------------------------------------
+
+const gitShowFile = (sha, file) => {
+    try {
+        return execSync(`git show ${sha}:${file}`, {
+            cwd: REPO_ROOT,
+            encoding: 'utf-8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+            maxBuffer: 32 * 1024 * 1024,
+        });
+    } catch {
+        return ''; // file may not exist at this sha
+    }
+};
+
+const getChangedFiles = (baseSha, headSha) => {
+    const out = execSync(`git diff --name-only ${baseSha}...${headSha}`, {
+        cwd: REPO_ROOT,
+        encoding: 'utf-8',
+        maxBuffer: 32 * 1024 * 1024,
+    });
+
+    return out.split('\n').filter(Boolean);
+};
+
+// --- Extractors -------------------------------------------------------------
+
+const extractDefaultChannel = (configContent) => {
+    if (!configContent) return null;
+
+    const m = configContent.match(/defaultChannel\s*:\s*['"]([^'"]+)['"]/);
+
+    return m ? m[1] : null;
+};
+
+const collectNativeDeps = (pkgJsonContent) => {
+    if (!pkgJsonContent.trim()) return {};
+
+    try {
+        const pkg = JSON.parse(pkgJsonContent);
+        const deps = pkg.dependencies ?? {};
+        const native = {};
+
+        for (const [name, version] of Object.entries(deps)) {
+            if (isNativeDep(name)) native[name] = version;
+        }
+
+        return native;
+    } catch {
+        return {};
+    }
+};
+
+const diffNativeDeps = (baseDeps, headDeps) => {
+    const added = [];
+    const removed = [];
+    const changed = [];
+    const allNames = new Set([...Object.keys(baseDeps), ...Object.keys(headDeps)]);
+
+    for (const name of allNames) {
+        const a = baseDeps[name];
+        const b = headDeps[name];
+
+        if (a === undefined && b !== undefined) added.push({ name, to: b });
+        else if (a !== undefined && b === undefined) removed.push({ name, from: a });
+        else if (a !== b) changed.push({ name, from: a, to: b });
+    }
+
+    return { added, removed, changed };
+};
+
+// --- Run --------------------------------------------------------------------
+
+const changedFiles = getChangedFiles(base, head);
+
+const nativeFileChanges = changedFiles.filter(f =>
+    NATIVE_PATH_PATTERNS.some(re => re.test(f)),
+);
+
+const baseDeps = collectNativeDeps(gitShowFile(base, PACKAGE_JSON));
+const headDeps = collectNativeDeps(gitShowFile(head, PACKAGE_JSON));
+const depDiff = diffNativeDeps(baseDeps, headDeps);
+
+const baseChannel = extractDefaultChannel(gitShowFile(base, CAPACITOR_CONFIG));
+const headChannel = extractDefaultChannel(gitShowFile(head, CAPACITOR_CONFIG));
+
+const channelBumped =
+    baseChannel !== null && headChannel !== null && baseChannel !== headChannel;
+
+const nativeCompatChanged =
+    nativeFileChanges.length > 0 ||
+    depDiff.added.length > 0 ||
+    depDiff.removed.length > 0 ||
+    depDiff.changed.length > 0;
+
+const guardFailed = nativeCompatChanged && !channelBumped;
+
+const result = {
+    base,
+    head,
+    baseChannel,
+    headChannel,
+    channelBumped,
+    nativeCompatChanged,
+    guardFailed,
+    nativeFileChanges,
+    depDiff,
+};
+
+const json = JSON.stringify(result, null, 2);
+
+process.stdout.write(json + '\n');
+
+if (outPath) {
+    fs.writeFileSync(outPath, json + '\n', 'utf-8');
+}
+
+process.exit(0);


### PR DESCRIPTION
### Why

PR #1063 hit production: a backwards-incompatible native change shipped *and it did* include a Capgo channel bump—but we had created multiple places where capgo defaultChannels was set, so OTA bundles uploaded by CI landed in a channel that the installed binaries weren't listening on. From a user's perspective, the app silently stopped receiving updates / new apps actually *reverted* to old version.

Three things failed simultaneously:

1. **The channel was defined in too many places.** apps/learn-card-app/capacitor.config.ts had `defaultChannel: '1.0.6'`, but the value was *also* present in `environments/learncard/config.json`, `environments/vetpass/config.json`, `tenantDefaults.ts`, and the `tenantNativeConfigSchema`. The prepare-native-config.ts script would then *overwrite* the capacitor.config value with the tenant value at native-build time. Two tenants, two configs, two sources of truth, predictably drifting apart.
2. **There was no enforcement.** Nothing in CI noticed that a PR added a new Capacitor plugin without touching the channel.
3. when something *did* go wrong on a user's device, we had no clean way to find out which exact build/bundle/channel the user was running without relying on guesswork and UI clues.

This PR solves all three.

### What's in this PR

Four commits, three concerns:

| Commit | Concern |
|--------|---------|
| `3e9b5c0` Single source of truth | Collapse the channel into one place. |
| `70415ca` Add CI check + bump script | Make it impossible to forget to bump. |
| `c9d458a` Add version info modal | Give support a first-class diagnostic screen. |
| `d5757de` Add version info extra info | Round it out (account, build commit, network, updates, channel switcher). |

---

### 1. Single source of truth for the Capgo channel

`/apps/learn-card-app/capacitor.config.ts:53-65` is now **the** definition of `defaultChannel`. Everything else reads from it:

- CI reads it via `/tools/capgo/getCapgoChannel.js` (regex match) when picking the channel for OTA bundle uploads.
- `npx cap sync` propagates it into the native `ios/.../capacitor.config.json` + `android/.../capacitor.config.json`, so installed binaries listen on the same channel CI uploads to.

Removed:

- `native.capgoChannel` field from `packages/learn-card-base/src/config/tenantConfigSchema.ts:171` and `/packages/learn-card-base/src/config/tenantDefaults.ts`
- The two tenant overrides in `environments/learncard/config.json` and `environments/vetpass/config.json`
- The override-application code in `apps/learn-card-app/scripts/prepare-native-config.ts:496-505`
- The Config Editor field at [tools/config-editor/config.html](/apps/learn-card-app/tools/config-editor/config.html:0:0-0:0)

Added:

- A load-bearing comment block above `defaultChannel` at `/apps/learn-card-app/capacitor.config.ts:53-64` explaining why this value is sacred and pointing at PR #1063.

### 2. CI guard + ergonomic bumper

<details>
<summary><strong>How the guard works</strong> (click to expand)</summary>

`/tools/capgo/check-channel-bump.js` is invoked by the `Capgo Channel Guard` workflow at `.github/workflows/capgo-channel-guard.yml`. On every PR that touches apps/learn-card-app/package.json, capacitor.config.ts, `ios/**`, or `android/**`, it:

1. Diffs `base` vs `head` looking for **native-compat changes** — added/removed Capacitor or Capgo plugins in `dependencies`, edits inside `ios/**` or `android/**`, or changes to capacitor.config.ts.
2. Reads the `defaultChannel` value at base and at head.
3. Fails the check if there's a native-compat change but no channel bump.
4. Leaves a sticky PR comment explaining what's needed and how to fix it (run the bumper script).

The check has an escape hatch — apply the `skip-capgo-guard` label or include `[skip-capgo-guard]` in the PR body — for the rare cases where a native change is provably safe (e.g., adding a plugin that doesn't ship native code).

</details>

The bumper script is `/apps/learn-card-app/scripts/bump-default-capgo-channel.ts`, surfaced via `pnpm lc bump-default-capgo-channel`. Both interactive (suggests next semver) and explicit (`pnpm lc bump-default-capgo-channel 1.0.7`) modes. Validates the version string, refuses to downgrade, and prints what changed.

### 3. Version Info modal

<img width="464" height="506" alt="Screenshot 2026-04-28 at 5 22 16 PM" src="https://github.com/user-attachments/assets/63d69f96-2513-421c-ba75-7acf936282bb" />

Tap the version line in the side menu footer (`/apps/learn-card-app/src/components/sidemenu/SideMenuFooter.tsx`) → opens `/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx`.

**Top of card (screenshot-friendly):**

- App icon + name + version + platform
- Reassurance banner: *"These details help support identify exactly which build you're running"*

**Core info:**

- Platform · App version · Native version · Content version · Update channel · Last updated *(humanized — "3 hours ago")*

**Primary action:** **Copy details** — pre-formats every visible value into a support-ready clipboard block with one tap.

**Advanced (collapsed by default):** Account (LCN profile ID, shortened with copy-full-on-tap), Tenant, Bundle ID, Device ID, Network *(`Wi-Fi · Connected` / `Offline` / etc.)*, Build commit *(short SHA)*, Build date, Shipped bundle, Bundle ref, Checksum, Updater plugin. Plus two actions:

- **Check for updates** — calls `CapacitorUpdater.getLatest()`, friendly toasts for the three outcomes (`up to date` / `update available` / `error`). Catches Capgo's "No new version available" non-error so we don't misreport it.
- **Switch update channel…** *(LaunchDarkly-gated, see Rollout)* — input + Apply, with an amber warning banner inline and a `useConfirmation` modal stacked on top. Prevents the user from confirming a no-op.

<details>
<summary><strong>Build commit injection</strong> (click to expand)</summary>

`/apps/learn-card-app/vite.config.ts:13-42` adds a resolveBuildSha() helper that reads from `GITHUB_SHA` / `HEROKU_SLUG_COMMIT` / `VERCEL_GIT_COMMIT_SHA` / `BUILD_SHA`, falls back to `git rev-parse --short HEAD`, falls back to `'dev'`. Then `/apps/learn-card-app/vite.config.ts:108-110` defines the result alongside `__BUILD_DATE__` (config-eval-time `new Date().toISOString()`). Both globals are declared at `/apps/learn-card-app/src/global.d.ts:7-8`.

This is the single most useful field for engineers tracking down "which build was this from?" — links straight to a GitHub commit.

</details>

## Try it

```bash
git checkout capgo-fixes
pnpm install
pnpm exec nx serve learn-card-app
```

Then tap the version line at the bottom of the side menu.

Native verification (more representative since several rows are native-only):

```bash
pnpm exec nx build learn-card-app
pnpm --filter learn-card-app exec npx cap sync
pnpm --filter learn-card-app exec npx cap run ios   # or android
```

To exercise the CI guard locally:

```bash
node tools/capgo/check-channel-bump.js --base origin/main --head HEAD
```


[skip-channel-bump]

Native diff is only @capgo/capacitor-updater 8.41.12 → 8.45.0
(plus a comment-only edit to capacitor.config.ts).

Per the Capgo changelog (8.42–8.45):
- New APIs added (`setNext`, `set` event, `install_next`,
  `getCurrentBundle`, `CAP_SERVER_PATH` reset) — none are called
  from our JS.
- One event rename: `updateInstalled` → `setNext`. We only listen
  for `updateAvailable`, so this doesn't affect us.
- Patch versions in between are bug fixes only.

New JS bundles are safe on 8.41.12 binaries already in users'
hands; old bundles remain compatible with new 8.45.0 binaries.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Centralize Capgo OTA channel management and add diagnostic version modal to prevent native binary/bundle incompatibilities from fragmenting OTA updates.

Main changes:
- Consolidated defaultChannel as single source of truth in capacitor.config.ts with CI guard script detecting missing bumps on native changes
- Created interactive channel bumper script with semver validation and extensive user guidance for backwards-incompatible native updates
- Built VersionInfoModal displaying app/native/bundle versions, device diagnostics, and LaunchDarkly-gated channel switcher for support workflows
- Injected __BUILD_SHA__ and __BUILD_DATE__ into Vite runtime for build identification in diagnostics and removed tenant-level capgoChannel overrides

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

