### PR TITLE
Fix: Example app builds failing due to zod/astro version

### DIFF
--- a/.changeset/dry-cases-show.md
+++ b/.changeset/dry-cases-show.md
@@ -1,0 +1,6 @@
+---
+'@learncard/app-store-demo-mozilla-social-badges': patch
+'@learncard/app-store-demo-lore-card': patch
+---
+
+Fix build failures

--- a/examples/app-store-apps/2-lore-card-app/package.json
+++ b/examples/app-store-apps/2-lore-card-app/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@learncard/app-store-demo-lore-card",
-  "type": "module",
-  "version": "0.0.20",
-  "private": true,
-  "description": "LoreCard - Social-Emotional Learning Badges for Tabletop RPG Players",
-  "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro build",
-    "preview": "astro preview",
-    "astro": "astro"
-  },
-  "dependencies": {
-    "@astrojs/netlify": "7.0.3",
-    "@learncard/init": "workspace:*",
-    "@learncard/partner-connect": "workspace:*",
-    "astro": "6.0.6"
-  },
-  "devDependencies": {
-    "prettier-plugin-astro": "^0.5.4"
-  }
+    "name": "@learncard/app-store-demo-lore-card",
+    "type": "module",
+    "version": "0.0.20",
+    "private": true,
+    "description": "LoreCard - Social-Emotional Learning Badges for Tabletop RPG Players",
+    "scripts": {
+        "dev": "astro dev",
+        "start": "astro dev",
+        "build": "astro build",
+        "preview": "astro preview",
+        "astro": "astro"
+    },
+    "dependencies": {
+        "@astrojs/netlify": "^6.6.5",
+        "@learncard/init": "workspace:*",
+        "@learncard/partner-connect": "workspace:*",
+        "astro": "^5.0.0"
+    },
+    "devDependencies": {
+        "prettier-plugin-astro": "^0.5.4"
+    }
 }

--- a/examples/app-store-apps/3-mozilla-social-badges-app/package.json
+++ b/examples/app-store-apps/3-mozilla-social-badges-app/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@learncard/app-store-demo-mozilla-social-badges",
-  "type": "module",
-  "version": "0.0.20",
-  "private": true,
-  "description": "Mozilla Social Badges - Recognize and celebrate open web contributions through verifiable badges",
-  "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro build",
-    "preview": "astro preview",
-    "astro": "astro"
-  },
-  "dependencies": {
-    "@astrojs/netlify": "7.0.3",
-    "@learncard/init": "workspace:*",
-    "@learncard/partner-connect": "workspace:*",
-    "astro": "6.0.6"
-  },
-  "devDependencies": {
-    "prettier-plugin-astro": "^0.5.4"
-  }
+    "name": "@learncard/app-store-demo-mozilla-social-badges",
+    "type": "module",
+    "version": "0.0.20",
+    "private": true,
+    "description": "Mozilla Social Badges - Recognize and celebrate open web contributions through verifiable badges",
+    "scripts": {
+        "dev": "astro dev",
+        "start": "astro dev",
+        "build": "astro build",
+        "preview": "astro preview",
+        "astro": "astro"
+    },
+    "dependencies": {
+        "@astrojs/netlify": "^6.6.5",
+        "@learncard/init": "workspace:*",
+        "@learncard/partner-connect": "workspace:*",
+        "astro": "^5.0.0"
+    },
+    "devDependencies": {
+        "prettier-plugin-astro": "^0.5.4"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,8 +995,8 @@ importers:
   examples/app-store-apps/2-lore-card-app:
     dependencies:
       '@astrojs/netlify':
-        specifier: 7.0.3
-        version: 7.0.3(@types/node@22.19.1)(astro@6.0.6(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1))(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        specifier: ^6.6.5
+        version: 6.6.5(@types/node@22.19.1)(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1))(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       '@learncard/init':
         specifier: workspace:*
         version: link:../../../packages/learn-card-init
@@ -1004,8 +1004,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/learn-card-partner-connect-sdk
       astro:
-        specifier: 6.0.6
-        version: 6.0.6(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1)
+        specifier: ^5.0.0
+        version: 5.18.1(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1)
     devDependencies:
       prettier-plugin-astro:
         specifier: ^0.5.4
@@ -1014,8 +1014,8 @@ importers:
   examples/app-store-apps/3-mozilla-social-badges-app:
     dependencies:
       '@astrojs/netlify':
-        specifier: 7.0.3
-        version: 7.0.3(@types/node@22.19.1)(astro@6.0.6(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1))(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        specifier: ^6.6.5
+        version: 6.6.5(@types/node@22.19.1)(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1))(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       '@learncard/init':
         specifier: workspace:*
         version: link:../../../packages/learn-card-init
@@ -1023,8 +1023,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/learn-card-partner-connect-sdk
       astro:
-        specifier: 6.0.6
-        version: 6.0.6(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1)
+        specifier: ^5.0.0
+        version: 5.18.1(@netlify/blobs@10.7.4)(@types/node@22.19.1)(idb-keyval@6.2.2)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(rollup@4.53.3)(sass@1.94.2)(terser@5.44.1)(tsx@4.20.6)(typescript@5.6.2)(yaml@2.8.1)
     devDependencies:
       prettier-plugin-astro:
         specifier: ^0.5.4


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Zod issue in example apps blocking deploy
<img width="1529" height="315" alt="image" src="https://github.com/user-attachments/assets/de2bb27c-981b-491c-be9d-5397470a9d5e" />


#### 🥴 TL; RL:
Example app builds succeed

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [ ] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [ ] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [ ] I have **reviewed** my code
-   [ ] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [ ] Code is backwards compatible
-   [ ] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Downgrade Astro and @astrojs/netlify to compatible versions and fix JSON formatting in example app package files.

Main changes:
- Downgraded astro from 6.0.6 to ^5.0.0 and @astrojs/netlify from 7.0.3 to ^6.6.5 for compatibility
- Reformatted package.json indentation from 2 spaces to 4 spaces in both example apps

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
