### PR TITLE
fix: gate per-recipient evidence to boosts on context >= 1.0.3

### DIFF
--- a/.changeset/tidy-doors-raise.md
+++ b/.changeset/tidy-doors-raise.md
@@ -1,0 +1,7 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+"@learncard/network-brain-service": patch
+---
+
+add context check >=1.0.3+

--- a/apps/learn-card-app/src/analytics/events.ts
+++ b/apps/learn-card-app/src/analytics/events.ts
@@ -20,6 +20,7 @@ export const AnalyticsEvents = {
     // Boost Sending
     SELF_BOOST: 'self_boost',
     SEND_BOOST: 'send_boost',
+    SEND_BOOST_WITH_ATTACHMENTS: 'send_boost_with_attachments',
     
     // Navigation/Screens
     SCREEN_VIEW: 'screen_view',
@@ -108,6 +109,17 @@ export interface AnalyticsEventPayloads {
         category?: string;
         boostType?: string;
         method: 'Managed Boost' | string;
+    };
+
+    [AnalyticsEvents.SEND_BOOST_WITH_ATTACHMENTS]: {
+        category?: string;
+        boostType?: string;
+        method: 'Managed Boost' | string;
+        recipientCount: number;
+        recipientsWithAttachments: number;
+        totalAttachments: number;
+        attachmentTypeCounts: Record<string, number>;
+        perRecipient: Array<{ attachmentCount: number; types: string[] }>;
     };
 
     [AnalyticsEvents.SCREEN_VIEW]: {

--- a/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostSomeoneScreen.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostSomeoneScreen.tsx
@@ -24,6 +24,12 @@ type ShortBoostSomeoneScreenProps = {
     category: BoostCategoryOptionsEnum;
     showBoostContext?: boolean;
     boostName?: string;
+    /**
+     * Whether the underlying boost's @context supports per-recipient dynamic
+     * evidence (boost context >= 1.0.3). Older boosts must be republished
+     * before recipient-specific media attachments can be signed onto them.
+     */
+    supportsRecipientAttachments?: boolean;
 };
 
 const ShortBoostSomeoneScreen: React.FC<ShortBoostSomeoneScreenProps> = ({
@@ -38,6 +44,7 @@ const ShortBoostSomeoneScreen: React.FC<ShortBoostSomeoneScreenProps> = ({
     category,
     showBoostContext = false,
     boostName,
+    supportsRecipientAttachments = false,
 }) => {
     const setIssuedTo: React.Dispatch<React.SetStateAction<BoostCMSIssueTo[]>> = action => {
         setState(prevState => ({
@@ -58,7 +65,7 @@ const ShortBoostSomeoneScreen: React.FC<ShortBoostSomeoneScreenProps> = ({
                 mode={BoostAddressBookEditMode.delete}
                 _issueTo={issuedTo}
                 _setIssueTo={setIssuedTo}
-                showRecipientAttachments
+                showRecipientAttachments={supportsRecipientAttachments}
                 version="sleek"
             />
         );

--- a/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostUserOptions.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostUserOptions.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../boost';
 import { closeAll } from 'apps/learn-card-app/src/helpers/uiHelpers';
 import { BoostIssuanceLoading } from '../../boostLoader/BoostLoader';
-import { getDefaultDisplayType } from '../../boostHelpers';
+import { getDefaultDisplayType, summarizeRecipientAttachments } from '../../boostHelpers';
 
 export enum ShortBoostStepsEnum {
     boostUserTypeOptions = 'boostUserTypeOptions',
@@ -128,6 +128,16 @@ const ShortBoostUserOptions: React.FC<{
             boostType: boost?.type,
             method: 'Managed Boost',
         });
+
+        const attachmentsAnalytics = summarizeRecipientAttachments(state.issueTo);
+        if (attachmentsAnalytics.recipientsWithAttachments > 0) {
+            track(AnalyticsEvents.SEND_BOOST_WITH_ATTACHMENTS, {
+                category: boost?.category,
+                boostType: boost?.type,
+                method: 'Managed Boost',
+                ...attachmentsAnalytics,
+            });
+        }
         setIssueLoading(false);
         onSuccess?.();
         if (!overrideClosingAllModals) {

--- a/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostUserOptions.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostUserOptions/ShortBoostUserOptions.tsx
@@ -18,6 +18,7 @@ import {
     ProfilePicture,
     boostCategoryMetadata,
     BoostCategoryOptionsEnum,
+    boostSupportsDynamicEvidence,
 } from 'learn-card-base';
 
 import { UnsignedVC, VC } from '@learncard/types';
@@ -317,6 +318,7 @@ const ShortBoostUserOptions: React.FC<{
                 category={category}
                 showBoostContext={showBoostContext}
                 boostName={boostName}
+                supportsRecipientAttachments={boostSupportsDynamicEvidence(boostCredential)}
             />
         );
     }

--- a/apps/learn-card-app/src/components/boost/boostHelpers.ts
+++ b/apps/learn-card-app/src/components/boost/boostHelpers.ts
@@ -1,6 +1,10 @@
 import moment from 'moment';
 import { VerificationItem, BoostRecipientInfo, LCNBoostStatusEnum, VC } from '@learncard/types';
-import { BoostCMSAppearanceDisplayTypeEnum, BoostCMSMediaAttachment } from './boost';
+import {
+    BoostCMSAppearanceDisplayTypeEnum,
+    BoostCMSIssueTo,
+    BoostCMSMediaAttachment,
+} from './boost';
 import { BespokeLearnCard } from 'learn-card-base/types/learn-card';
 import { RouteComponentProps } from 'react-router-dom';
 import {
@@ -74,6 +78,57 @@ const getRecipientMediaAttachmentTemplateData = (
                 last: index === evidence.length - 1,
             })),
         },
+    };
+};
+
+/**
+ * Builds an anonymized analytics payload describing per-recipient media
+ * attachments for a send-boost event. No DIDs, profileIds, or contact info
+ * are included — just counts and attachment types — so the event is safe to
+ * send to product analytics.
+ *
+ * Returned shape:
+ *   - recipientCount: total recipients in the send
+ *   - recipientsWithAttachments: how many of those had at least one attachment
+ *   - totalAttachments: sum of attachments across all recipients
+ *   - attachmentTypeCounts: aggregate count by media type (photo/document/video/link/...)
+ *   - perRecipient: ordered breakdown { attachmentCount, types[] } per recipient
+ */
+export const summarizeRecipientAttachments = (
+    issueTo: BoostCMSIssueTo[] = []
+): {
+    recipientCount: number;
+    recipientsWithAttachments: number;
+    totalAttachments: number;
+    attachmentTypeCounts: Record<string, number>;
+    perRecipient: Array<{ attachmentCount: number; types: string[] }>;
+} => {
+    const attachmentTypeCounts: Record<string, number> = {};
+    let totalAttachments = 0;
+    let recipientsWithAttachments = 0;
+
+    const perRecipient = issueTo.map(recipient => {
+        const attachments = recipient.mediaAttachments ?? [];
+        const types: string[] = [];
+
+        attachments.forEach(att => {
+            const type = (att.type as string) || 'unknown';
+            attachmentTypeCounts[type] = (attachmentTypeCounts[type] ?? 0) + 1;
+            types.push(type);
+        });
+
+        if (attachments.length > 0) recipientsWithAttachments += 1;
+        totalAttachments += attachments.length;
+
+        return { attachmentCount: attachments.length, types };
+    });
+
+    return {
+        recipientCount: issueTo.length,
+        recipientsWithAttachments,
+        totalAttachments,
+        attachmentTypeCounts,
+        perRecipient,
     };
 };
 

--- a/packages/learn-card-base/src/components/boost/boost.ts
+++ b/packages/learn-card-base/src/components/boost/boost.ts
@@ -361,6 +361,40 @@ export const getMediaAttachments = (mediaAttachments: BoostCMSMediaAttachment[])
     return mediaAttachments.filter(attachment => attachment.type === BoostMediaOptionsEnum.photo);
 };
 
+/**
+ * Per-recipient dynamic evidence (the `EvidenceFile` shape produced by
+ * `convertAttachmentsToEvidence`) only signs cleanly when the boost's
+ * credential `@context` resolves the LearnCard-specific evidence subterms
+ * (`fileName`, `fileType`, `fileSize`). Those terms first appeared in
+ * `https://ctx.learncard.com/boosts/1.0.3.json` — earlier versions
+ * (1.0.0–1.0.2) omit them, so attaching media to those boosts produces a
+ * JSON-LD safe-mode key-expansion failure at sign time.
+ *
+ * Use this helper to gate the recipient-attachments UI for a given boost. If
+ * it returns `false`, hide the attachments button — the boost would need to
+ * be republished against the newer context before it can carry per-recipient
+ * evidence.
+ */
+export const boostSupportsDynamicEvidence = (
+    credential: { '@context'?: unknown } | null | undefined
+): boolean => {
+    const ctx = credential?.['@context'];
+    const entries = Array.isArray(ctx) ? ctx : ctx ? [ctx] : [];
+
+    return entries.some(entry => {
+        if (typeof entry === 'string') {
+            // Match 1.0.3 and any future 1.0.x (x >= 3) or 1.y.z with y >= 1.
+            return /\/ctx\.learncard\.com\/boosts\/1\.(?:(?:0\.(?:[3-9]|\d{2,}))|(?:[1-9]\d*\.\d+))/.test(
+                entry
+            );
+        }
+        if (entry && typeof entry === 'object') {
+            return 'EvidenceFile' in (entry as Record<string, unknown>);
+        }
+        return false;
+    });
+};
+
 export const convertAttachmentsToEvidence = (
     attachments: BoostCMSMediaAttachment[] = []
 ): BoostEvidenceSpec[] => {

--- a/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/boost.helpers.ts
@@ -1,6 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import { v4 as uuidv4 } from 'uuid';
+import { TRPCError } from '@trpc/server';
 import {
     VC,
     JWE,
@@ -798,6 +799,18 @@ export const appendTemplateEvidenceToCredential = (
     // shouldn't clobber existing evidence.
     if (normalizedTemplateEvidence.length === 0) return credential;
 
+    // Refuse to append onto a boost whose @context can't expand the
+    // EvidenceFile subterms — otherwise the signer fails later with an opaque
+    // JSON-LD key-expansion error. Surface a clear message instead so the
+    // caller can prompt the user to republish the boost.
+    if (!credentialContextSupportsDynamicEvidence(credential)) {
+        throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message:
+                'This boost was created before per-recipient evidence was supported. Republish the boost against the latest boost context (>= 1.0.3) to enable recipient attachments.',
+        });
+    }
+
     // Preserve any evidence that was already baked into the credential by
     // the template, coercing a single-object shape to an array so we can spread.
     const existingEvidence = credential.evidence
@@ -809,6 +822,30 @@ export const appendTemplateEvidenceToCredential = (
     credential.evidence = [...existingEvidence, ...normalizedTemplateEvidence];
 
     return credential;
+};
+
+/**
+ * Returns true when the credential's `@context` array references a boost
+ * context that defines `EvidenceFile`/`fileName`/`fileType`/`fileSize`
+ * (LearnCard boost context 1.0.3 or newer), or already has those terms
+ * defined inline. Used as a precondition for auto-appending the dynamic
+ * `EvidenceFile` shape produced by `convertAttachmentsToEvidence`.
+ */
+const credentialContextSupportsDynamicEvidence = (credential: UnsignedVC): boolean => {
+    const ctx = (credential as Record<string, unknown>)['@context'];
+    const entries = Array.isArray(ctx) ? ctx : ctx ? [ctx] : [];
+
+    return entries.some(entry => {
+        if (typeof entry === 'string') {
+            return /\/ctx\.learncard\.com\/boosts\/1\.(?:(?:0\.(?:[3-9]|\d{2,}))|(?:[1-9]\d*\.\d+))/.test(
+                entry
+            );
+        }
+        if (entry && typeof entry === 'object') {
+            return 'EvidenceFile' in (entry as Record<string, unknown>);
+        }
+        return false;
+    });
 };
 
 /**


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

https://www.loom.com/share/8cfa2d37e04648899758864aa84e0d97

## Summary

Per-recipient dynamic evidence (LC-1746) was failing on boosts created before the feature shipped. The auto-appended evidence uses a LearnCard-specific `EvidenceFile` shape (`fileName`, `fileType`, `fileSize`) that's only defined in boost context **`1.0.3.json`**. Older boosts pinned to `1.0.1`/`1.0.2` couldn't expand those terms during JSON-LD signing → cryptic "key expansion error" in prod.

This PR gates the feature to boosts whose `@context` actually supports it.

## Changes

- **`packages/learn-card-base`** — new `boostSupportsDynamicEvidence(credential)` helper that checks `@context` for `https://ctx.learncard.com/boosts/1.0.3+` (or an inline `EvidenceFile` term).
- **`apps/learn-card-app`** — `ShortBoostUserOptions` now passes `supportsRecipientAttachments` into `ShortBoostSomeoneScreen`, which gates the per-recipient attachments button on `BoostAddressBookContactItem`. Older boosts no longer show the button.
- **`services/learn-card-network/brain-service`** — `appendTemplateEvidenceToCredential` now throws a `PRECONDITION_FAILED` TRPCError with a republish-prompting message when an older context is detected, instead of letting the signer fail with a key-expansion error. Covers SDK/API consumers that bypass the UI.

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [X] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [X] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [X] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [X] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Gate per-recipient media attachments to boosts with context >= 1.0.3 to prevent JSON-LD signing failures on older boost versions.

Main changes:
- Added `boostSupportsDynamicEvidence()` helper to verify boost context supports EvidenceFile subterms required for per-recipient evidence
- Gate recipient attachments UI visibility and server-side evidence appending based on context version check
- Added analytics event `SEND_BOOST_WITH_ATTACHMENTS` tracking anonymized per-recipient attachment counts and types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
