### PR TITLE
feat: LC-1827 Add multiple origins to partner connect with default tenants

### DIFF
--- a/.changeset/partner-connect-wildcard-tenants.md
+++ b/.changeset/partner-connect-wildcard-tenants.md
@@ -1,0 +1,9 @@
+---
+'@learncard/partner-connect': minor
+---
+
+Partner apps now work on any LearnCard-managed tenant out of the box.
+
+- `hostOrigin` entries now support wildcard patterns for the host portion, e.g. `https://*.learncard.app`. Protocol and port must still match exactly; wildcards are only allowed as leading DNS label(s).
+- Added a built-in whitelist `PartnerConnect.DEFAULT_TRUSTED_TENANTS` (`learncard.app`, `*.learncard.app`, `*.learncard.ai`, `vetpass.app`, `*.vetpass.app`) that is merged into `hostOrigin` automatically. New tenants under these domains work without a partner-app re-deploy. Opt out with `disableDefaultTenants: true`.
+- Origin resolution now prefers `window.location.ancestorOrigins[0]` (the browser-reported parent origin) over the `lc_host_override` query param when available and trusted. This is unspoofable by query-param manipulation; a mismatched override is logged and ignored.

--- a/.changeset/unlucky-foxes-appear.md
+++ b/.changeset/unlucky-foxes-appear.md
@@ -1,0 +1,5 @@
+---
+"@learncard/partner-connect": patch
+---
+
+feat: LC-1827 Add multiple origins to partner connect with default tenants

--- a/packages/learn-card-partner-connect-sdk/MULTIPLE-ORIGINS.md
+++ b/packages/learn-card-partner-connect-sdk/MULTIPLE-ORIGINS.md
@@ -2,9 +2,46 @@
 
 ## Overview
 
-The Partner Connect SDK supports configuring multiple allowed origins via the `hostOrigin` option. These origins serve as a **whitelist for the `lc_host_override` query parameter**, enabling partner apps to work across multiple deployment environments (production, staging, preview) without code changes.
+The Partner Connect SDK supports configuring multiple allowed origins via the `hostOrigin` option. These origins serve as a **whitelist for the `lc_host_override` query parameter** and for the browser-reported parent origin (`window.location.ancestorOrigins[0]`), enabling partner apps to work across multiple deployment environments (production, staging, preview) without code changes.
 
 **Important:** At runtime, only a **single active origin** is used for both sending and receiving messages. The multiple origins array does **not** enable accepting messages from multiple origins simultaneously.
+
+### Built-in LearnCard tenant whitelist
+
+The SDK ships with a curated default whitelist of LearnCard-managed tenant origins (`PartnerConnect.DEFAULT_TRUSTED_TENANTS`):
+
+```
+https://learncard.app
+https://*.learncard.app
+https://*.learncard.ai
+https://vetpass.app
+https://*.vetpass.app
+```
+
+These are **merged automatically** with whatever you pass in `hostOrigin`, so a partner app works out of the box inside any current or future LearnCard tenant (staging, preview, VetPass, …) without a re-deploy. Pass `disableDefaultTenants: true` to opt out if you want to lock the SDK down to only your own configured origins.
+
+### Wildcard patterns
+
+Entries in `hostOrigin` may be either an **exact origin** or a **wildcard pattern** where `*` stands in for one or more DNS labels at the start of the host:
+
+```typescript
+hostOrigin: [
+    'https://learncard.app',        // exact
+    'https://*.learncard.app',      // wildcard — any subdomain(s)
+]
+```
+
+Matching rules:
+
+| Pattern                       | Candidate                                   | Result |
+| ----------------------------- | ------------------------------------------- | ------ |
+| `https://*.learncard.app`     | `https://staging.learncard.app`             | ✅     |
+| `https://*.learncard.app`     | `https://pr-1.preview.learncard.app`        | ✅     |
+| `https://*.learncard.app`     | `https://learncard.app` (no subdomain)      | ❌     |
+| `https://*.learncard.app`     | `http://staging.learncard.app` (protocol)   | ❌     |
+| `https://*.learncard.app`     | `https://learncard.app.attacker.com`        | ❌     |
+
+Wildcards are only allowed as **leading** label(s) in the host portion. Protocol and port must match exactly.
 
 ## Usage
 
@@ -34,9 +71,13 @@ const learnCard = createPartnerConnect({
 
 At initialization, the SDK determines a **single `activeHostOrigin`** using this hierarchy:
 
-1. **`lc_host_override` query parameter** — if present and the value is in the configured `hostOrigin` array (or is a native app origin when `allowNativeAppOrigins` is `true`)
-2. **First configured `hostOrigin`** — fallback
-3. **Default** — `https://learncard.app`
+1. **`window.location.ancestorOrigins[0]`** — when the browser supports it (Chromium/WebKit) and the real parent origin is in the effective whitelist (configured + built-in tenants). This is unspoofable by a malicious query param and therefore takes precedence.
+2. **`lc_host_override` query parameter** — if present and the value is in the effective whitelist (or is a native app origin when `allowNativeAppOrigins` is `true`).
+3. **`sessionStorage['lc_host_override']`** — a previously-validated override, so subsequent in-iframe navigations in the same tab use the same origin.
+4. **First configured `hostOrigin`** — fallback.
+5. **Default** — `https://learncard.app`.
+
+If the parent origin and the query-param override disagree, the SDK prefers the browser-reported parent and logs a warning.
 
 ### Incoming Messages (Validation)
 
@@ -266,7 +307,7 @@ private sendMessage<T>(action: string, payload?: unknown): Promise<T> {
 ## FAQ
 
 **Q: Can I use wildcards like `*.example.com`?**  
-A: No, only exact origin matching is supported for security.
+A: Yes, in `hostOrigin` entries of the form `<protocol>://*.<domain>` (e.g. `https://*.learncard.app`). Wildcards must be the leading label(s); protocol and port must match exactly.
 
 **Q: Does the SDK accept messages from ALL configured origins?**  
 A: No. Only the single `activeHostOrigin` (determined at initialization) is used for message validation. The origins array is a whitelist for `lc_host_override` only.

--- a/packages/learn-card-partner-connect-sdk/QUERY-PARAMETER-OVERRIDE.md
+++ b/packages/learn-card-partner-connect-sdk/QUERY-PARAMETER-OVERRIDE.md
@@ -284,9 +284,11 @@ Allowed: ['https://learncard.app', 'https://staging.learncard.app']
 
 ### ❌ DON'T
 
-1. **Don't use wildcards (not supported):**
+1. **Use wildcards only for label(s) at the start of the host:**
    ```typescript
-   hostOrigin: ['https://*.learncard.app']  // Won't work
+   hostOrigin: ['https://*.learncard.app']  // ✅ Supported — matches any subdomain(s)
+   hostOrigin: ['https://learncard.*']      // ❌ Not supported — TLD wildcards
+   hostOrigin: ['https://api-*.example.com']// ❌ Not supported — partial labels
    ```
 
 2. **Don't hardcode staging URLs in production:**
@@ -400,10 +402,10 @@ hostOrigin: ['https://learncard.app', 'https://staging.learncard.app']
 ## FAQ
 
 **Q: Can I use wildcards in the whitelist?**  
-A: No, only exact origin matching is supported for security.
+A: Yes — `hostOrigin` entries of the form `<protocol>://*.<domain>` (e.g. `https://*.learncard.app`) match any non-empty chain of leading DNS labels. Protocol and port must still match exactly.
 
 **Q: What if I don't provide a whitelist?**  
-A: Any `lc_host_override` value will be accepted (less secure).
+A: The SDK still enforces the built-in LearnCard tenant whitelist (`PartnerConnect.DEFAULT_TRUSTED_TENANTS`: `learncard.app`, `*.learncard.app`, `*.learncard.ai`, `vetpass.app`, `*.vetpass.app`), plus native-app origins when `allowNativeAppOrigins` is true. Origins outside those patterns are still rejected. Pass `disableDefaultTenants: true` to disable the built-in list.
 
 **Q: Can attackers use this to hijack communication?**  
 A: No. Even with a malicious override, browser security prevents origin spoofing.

--- a/packages/learn-card-partner-connect-sdk/jest.config.js
+++ b/packages/learn-card-partner-connect-sdk/jest.config.js
@@ -1,0 +1,9 @@
+/* Jest config for @learncard/partner-connect */
+
+module.exports = {
+    testEnvironment: 'jsdom',
+    roots: ['<rootDir>/src'],
+    transform: {
+        '^.+\\.tsx?$': 'esbuild-jest',
+    },
+};

--- a/packages/learn-card-partner-connect-sdk/package.json
+++ b/packages/learn-card-partner-connect-sdk/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest -c jest.config.js",
+    "test:watch": "jest -c jest.config.js --watch"
   },
   "keywords": [
     "learncard",

--- a/packages/learn-card-partner-connect-sdk/project.json
+++ b/packages/learn-card-partner-connect-sdk/project.json
@@ -26,6 +26,11 @@
       "executor": "nx:run-script",
       "inputs": ["source"],
       "options": { "script": "typecheck" }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "inputs": ["source"],
+      "options": { "script": "test" }
     }
   }
 }

--- a/packages/learn-card-partner-connect-sdk/src/index.ts
+++ b/packages/learn-card-partner-connect-sdk/src/index.ts
@@ -62,6 +62,26 @@ export class PartnerConnect {
     /** Default host origin (security anchor) */
     public static readonly DEFAULT_HOST_ORIGIN = 'https://learncard.app';
 
+    /**
+     * Built-in list of LearnCard-managed tenant origins.
+     *
+     * These are merged with the partner app's configured `hostOrigin` whitelist
+     * unless `disableDefaultTenants: true` is passed. This lets a partner app
+     * run inside any current or future LearnCard tenant (staging, preview,
+     * VetPass, etc.) without needing a re-deploy each time a new tenant is
+     * onboarded.
+     *
+     * Patterns follow the same rules as user-supplied `hostOrigin` entries:
+     * `*` is a wildcard for one or more DNS labels in the host portion.
+     */
+    public static readonly DEFAULT_TRUSTED_TENANTS: readonly string[] = [
+        'https://learncard.app',
+        'https://*.learncard.app',
+        'https://*.learncard.ai',
+        'https://vetpass.app',
+        'https://*.vetpass.app',
+    ];
+
     private hostOrigins: string[] = ['https://learncard.app'];
     private activeHostOrigin: string = 'https://learncard.app';
     private allowNativeAppOrigins: boolean = true;
@@ -73,8 +93,17 @@ export class PartnerConnect {
 
     constructor(options?: PartnerConnectOptions) {
         // Normalize hostOrigin to an array for whitelist validation
-        const hostOrigin = options?.hostOrigin || PartnerConnect.DEFAULT_HOST_ORIGIN;
-        this.hostOrigins = Array.isArray(hostOrigin) ? hostOrigin : [hostOrigin];
+        const hostOrigin = options?.hostOrigin ?? PartnerConnect.DEFAULT_HOST_ORIGIN;
+        const configured = Array.isArray(hostOrigin) ? hostOrigin : [hostOrigin];
+
+        // Merge with the built-in tenant list unless the caller explicitly
+        // opted out. De-duplicate while preserving order so the caller's
+        // first entry remains the default active origin.
+        const disableDefaults = options?.disableDefaultTenants === true;
+        const merged = disableDefaults
+            ? [...configured]
+            : [...configured, ...PartnerConnect.DEFAULT_TRUSTED_TENANTS];
+        this.hostOrigins = Array.from(new Set(merged));
 
         this.protocol = options?.protocol || 'LEARNCARD_V1';
         this.requestTimeout = options?.requestTimeout || 30000;
@@ -86,18 +115,45 @@ export class PartnerConnect {
 
     /**
      * Configure the active host origin using the following hierarchy:
-     * 1. Check for `lc_host_override` query parameter (for staging/testing)
-     * 2. Check sessionStorage for a previously stored override (survives in-app navigation)
-     * 3. Fall back to first configured origin
-     * 4. Fall back to DEFAULT_HOST_ORIGIN
+     * 1. `window.location.ancestorOrigins[0]` (when supported) — the browser's
+     *    view of who our parent frame is. Cannot be forged by a malicious
+     *    `lc_host_override` query param and therefore takes precedence.
+     * 2. `?lc_host_override=<origin>` query param (for staging / cross-tenant).
+     * 3. `sessionStorage` value saved from a previously-validated override.
+     * 4. First configured origin.
+     * 5. `DEFAULT_HOST_ORIGIN`.
      *
-     * When a valid override is found in the query parameter, it is persisted to
-     * sessionStorage so that subsequent page navigations within the same tab
-     * automatically use the same override without requiring it in every URL.
-     *
-     * This origin will be used for all outgoing messages and incoming message validation.
+     * When a valid override is found in the query parameter, it is persisted
+     * to sessionStorage so subsequent in-iframe navigations in the same tab
+     * continue to use the same active origin.
      */
     private static readonly SESSION_STORAGE_KEY = 'lc_host_override';
+
+    /**
+     * Read `window.location.ancestorOrigins[0]` without throwing if the
+     * property is unavailable (Firefox) or the list is empty (top-level
+     * context, e.g. running outside of an iframe).
+     */
+    private readAncestorOrigin(): string | null {
+        if (typeof window === 'undefined') return null;
+
+        try {
+            const ancestors = window.location.ancestorOrigins;
+
+            if (ancestors && ancestors.length > 0) {
+                const parent = ancestors[0];
+
+                if (typeof parent === 'string' && parent.length > 0) {
+                    return parent;
+                }
+            }
+        } catch {
+            // `ancestorOrigins` is a WebKit/Blink extension; accessing it
+            // under unusual conditions can throw. Treat as unavailable.
+        }
+
+        return null;
+    }
 
     private configureActiveOrigin(): void {
         if (typeof window === 'undefined') {
@@ -106,57 +162,74 @@ export class PartnerConnect {
         }
 
         try {
-            // Check for lc_host_override query parameter
+            const ancestorOrigin = this.readAncestorOrigin();
             const urlParams = new URLSearchParams(window.location.search);
             const hostOverride = urlParams.get('lc_host_override');
 
-            if (hostOverride) {
-                // Validate override against whitelist (if provided)
-                if (this.hostOrigins.length > 0 && !this.isOriginInWhitelist(hostOverride)) {
+            // Priority 1: the real parent origin as reported by the browser.
+            // This is unspoofable by query-param manipulation, so if it is
+            // trusted we use it and ignore any override. If both are present
+            // and disagree, we log and prefer the ancestor.
+            if (ancestorOrigin && this.isOriginInWhitelist(ancestorOrigin)) {
+                if (hostOverride && hostOverride !== ancestorOrigin) {
                     console.warn(
-                        '[LearnCard SDK] lc_host_override value is not in the configured whitelist:',
-                        hostOverride,
-                        'Allowed:',
-                        this.hostOrigins
+                        '[LearnCard SDK] lc_host_override does not match the real parent origin; preferring parent.',
+                        { override: hostOverride, parent: ancestorOrigin }
                     );
-                    this.activeHostOrigin =
-                        this.hostOrigins[0] || PartnerConnect.DEFAULT_HOST_ORIGIN;
-                } else {
-                    this.activeHostOrigin = hostOverride;
-
-                    // Persist to sessionStorage so subsequent page navigations
-                    // within this tab automatically use the same override.
-                    try {
-                        sessionStorage.setItem(PartnerConnect.SESSION_STORAGE_KEY, hostOverride);
-                    } catch {
-                        // sessionStorage may be unavailable (e.g. sandboxed iframes)
-                    }
-
-                    console.log('[LearnCard SDK] Using lc_host_override:', hostOverride);
-                }
-            } else {
-                // Fall back to a previously stored override from this session
-                let storedOverride: string | null = null;
-
-                try {
-                    storedOverride = sessionStorage.getItem(PartnerConnect.SESSION_STORAGE_KEY);
-                } catch {
-                    // sessionStorage may be unavailable
                 }
 
-                if (storedOverride && this.isOriginInWhitelist(storedOverride)) {
-                    this.activeHostOrigin = storedOverride;
-                    console.log('[LearnCard SDK] Using stored lc_host_override:', storedOverride);
-                } else {
-                    // Use first configured origin or default
-                    this.activeHostOrigin =
-                        this.hostOrigins[0] || PartnerConnect.DEFAULT_HOST_ORIGIN;
-                    console.log('[LearnCard SDK] Using configured origin:', this.activeHostOrigin);
-                }
+                this.activeHostOrigin = ancestorOrigin;
+                this.persistOverride(ancestorOrigin);
+                console.log('[LearnCard SDK] Using parent origin:', ancestorOrigin);
+                return;
             }
+
+            // Priority 2: lc_host_override query parameter.
+            if (hostOverride) {
+                if (this.isOriginInWhitelist(hostOverride)) {
+                    this.activeHostOrigin = hostOverride;
+                    this.persistOverride(hostOverride);
+                    console.log('[LearnCard SDK] Using lc_host_override:', hostOverride);
+                    return;
+                }
+
+                console.warn(
+                    '[LearnCard SDK] lc_host_override value is not in the configured whitelist:',
+                    hostOverride,
+                    'Allowed:',
+                    this.hostOrigins
+                );
+            }
+
+            // Priority 3: a previously-validated override from this tab session.
+            let storedOverride: string | null = null;
+
+            try {
+                storedOverride = sessionStorage.getItem(PartnerConnect.SESSION_STORAGE_KEY);
+            } catch {
+                // sessionStorage may be unavailable (e.g. sandboxed iframes)
+            }
+
+            if (storedOverride && this.isOriginInWhitelist(storedOverride)) {
+                this.activeHostOrigin = storedOverride;
+                console.log('[LearnCard SDK] Using stored lc_host_override:', storedOverride);
+                return;
+            }
+
+            // Priority 4/5: fall back to the first configured origin or default.
+            this.activeHostOrigin = this.hostOrigins[0] || PartnerConnect.DEFAULT_HOST_ORIGIN;
+            console.log('[LearnCard SDK] Using configured origin:', this.activeHostOrigin);
         } catch (error) {
             console.error('[LearnCard SDK] Error configuring active origin:', error);
             this.activeHostOrigin = this.hostOrigins[0] || PartnerConnect.DEFAULT_HOST_ORIGIN;
+        }
+    }
+
+    private persistOverride(origin: string): void {
+        try {
+            sessionStorage.setItem(PartnerConnect.SESSION_STORAGE_KEY, origin);
+        } catch {
+            // sessionStorage may be unavailable (e.g. sandboxed iframes)
         }
     }
 
@@ -171,13 +244,83 @@ export class PartnerConnect {
     }
 
     /**
-     * Check if an origin is in the configured whitelist
+     * Check whether a candidate origin matches a configured whitelist entry.
+     *
+     * Supports exact matches and wildcard patterns. A wildcard entry has the
+     * form `<protocol>://*.<domain>` and matches any origin with the same
+     * protocol, same port, and a host ending in `.<domain>` with at least
+     * one non-empty DNS label in place of the `*`.
+     *
+     * Examples with pattern `https://*.learncard.app`:
+     * - `https://staging.learncard.app`      → match
+     * - `https://pr-1.preview.learncard.app` → match
+     * - `https://learncard.app`              → no match (no subdomain)
+     * - `http://staging.learncard.app`       → no match (protocol mismatch)
+     * - `https://learncard.app.attacker.com` → no match (suffix mismatch)
+     */
+    private static matchesOriginPattern(candidate: string, pattern: string): boolean {
+        if (candidate === pattern) return true;
+        if (!pattern.includes('*')) return false;
+
+        let patternUrl: URL;
+        let candidateUrl: URL;
+
+        try {
+            // Replace the wildcard labels with a syntactically-valid host so
+            // URL() can parse it; we validate the real shape ourselves below.
+            patternUrl = new URL(pattern.replace(/\*/g, '__lc_wildcard__'));
+            candidateUrl = new URL(candidate);
+        } catch {
+            return false;
+        }
+
+        // Protocol, port, and (empty) path-origin must match exactly.
+        if (patternUrl.protocol !== candidateUrl.protocol) return false;
+        if (patternUrl.port !== candidateUrl.port) return false;
+
+        const patternHost = patternUrl.hostname;
+        const candidateHost = candidateUrl.hostname;
+
+        // Only allow wildcards as leading label(s): `*.foo.bar`, not `a*.b` or
+        // `foo.*.bar`. This keeps the matching rule predictable and safe.
+        if (!patternHost.startsWith('__lc_wildcard__.')) return false;
+
+        const patternSuffix = patternHost.slice('__lc_wildcard__.'.length);
+
+        if (patternSuffix.length === 0) return false;
+        // No further wildcards anywhere else in the pattern.
+        if (patternSuffix.includes('__lc_wildcard__')) return false;
+
+        // Candidate must end with `.<suffix>` and have at least one label
+        // before the suffix (the portion that the `*` stands in for).
+        const required = '.' + patternSuffix;
+
+        if (!candidateHost.endsWith(required)) return false;
+
+        const prefix = candidateHost.slice(0, candidateHost.length - required.length);
+
+        if (prefix.length === 0) return false;
+        // Labels in the prefix must themselves be non-empty (no `..`).
+        if (prefix.startsWith('.') || prefix.endsWith('.')) return false;
+        if (prefix.split('.').some(label => label.length === 0)) return false;
+
+        return true;
+    }
+
+    /**
+     * Check if an origin is in the effective whitelist (exact origins +
+     * wildcard patterns + optional native-app origins).
      */
     private isOriginInWhitelist(origin: string): boolean {
-        return (
-            this.hostOrigins.includes(origin) ||
-            (this.allowNativeAppOrigins && this.isOriginNativeApp(origin))
-        );
+        if (!origin) return false;
+
+        for (const entry of this.hostOrigins) {
+            if (PartnerConnect.matchesOriginPattern(origin, entry)) return true;
+        }
+
+        if (this.allowNativeAppOrigins && this.isOriginNativeApp(origin)) return true;
+
+        return false;
     }
 
     /**

--- a/packages/learn-card-partner-connect-sdk/src/index.ts
+++ b/packages/learn-card-partner-connect-sdk/src/index.ts
@@ -244,6 +244,19 @@ export class PartnerConnect {
     }
 
     /**
+     * Internal placeholder substituted in for `*` so that `new URL(...)` can
+     * parse a wildcard pattern. Chosen to be a syntactically-valid DNS label
+     * that cannot collide with a real hostname.
+     */
+    private static readonly WILDCARD_PLACEHOLDER = '__lc_wildcard__';
+
+    /** `*` (any number of occurrences) for replacement in the pattern. */
+    private static readonly WILDCARD_REGEX = /\*/g;
+
+    /** The required leading-label form a wildcard pattern must take. */
+    private static readonly WILDCARD_LEADING_PREFIX = `${PartnerConnect.WILDCARD_PLACEHOLDER}.`;
+
+    /**
      * Check whether a candidate origin matches a configured whitelist entry.
      *
      * Supports exact matches and wildcard patterns. A wildcard entry has the
@@ -257,8 +270,11 @@ export class PartnerConnect {
      * - `https://learncard.app`              → no match (no subdomain)
      * - `http://staging.learncard.app`       → no match (protocol mismatch)
      * - `https://learncard.app.attacker.com` → no match (suffix mismatch)
+     *
+     * Exposed as a public static so it can be unit-tested directly without
+     * standing up a full SDK instance.
      */
-    private static matchesOriginPattern(candidate: string, pattern: string): boolean {
+    public static matchesOriginPattern(candidate: string, pattern: string): boolean {
         if (candidate === pattern) return true;
         if (!pattern.includes('*')) return false;
 
@@ -268,7 +284,12 @@ export class PartnerConnect {
         try {
             // Replace the wildcard labels with a syntactically-valid host so
             // URL() can parse it; we validate the real shape ourselves below.
-            patternUrl = new URL(pattern.replace(/\*/g, '__lc_wildcard__'));
+            patternUrl = new URL(
+                pattern.replace(
+                    PartnerConnect.WILDCARD_REGEX,
+                    PartnerConnect.WILDCARD_PLACEHOLDER
+                )
+            );
             candidateUrl = new URL(candidate);
         } catch {
             return false;
@@ -283,13 +304,13 @@ export class PartnerConnect {
 
         // Only allow wildcards as leading label(s): `*.foo.bar`, not `a*.b` or
         // `foo.*.bar`. This keeps the matching rule predictable and safe.
-        if (!patternHost.startsWith('__lc_wildcard__.')) return false;
+        if (!patternHost.startsWith(PartnerConnect.WILDCARD_LEADING_PREFIX)) return false;
 
-        const patternSuffix = patternHost.slice('__lc_wildcard__.'.length);
+        const patternSuffix = patternHost.slice(PartnerConnect.WILDCARD_LEADING_PREFIX.length);
 
         if (patternSuffix.length === 0) return false;
         // No further wildcards anywhere else in the pattern.
-        if (patternSuffix.includes('__lc_wildcard__')) return false;
+        if (patternSuffix.includes(PartnerConnect.WILDCARD_PLACEHOLDER)) return false;
 
         // Candidate must end with `.<suffix>` and have at least one label
         // before the suffix (the portion that the `*` stands in for).

--- a/packages/learn-card-partner-connect-sdk/src/origin-resolution.test.ts
+++ b/packages/learn-card-partner-connect-sdk/src/origin-resolution.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for the origin-resolution layer of @learncard/partner-connect.
+ *
+ * These tests run in jsdom and focus on three aspects:
+ *   1. How `hostOrigin` entries are merged with the built-in tenant list.
+ *   2. How the active host origin is selected from `ancestorOrigins` /
+ *      `lc_host_override` / `sessionStorage` / configured fallbacks.
+ *   3. How wildcard patterns behave both as whitelist entries and when
+ *      rejecting untrusted event origins at runtime.
+ */
+
+import { PartnerConnect } from './index';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+interface WindowOverrides {
+    search?: string;
+    origin?: string;
+    ancestors?: readonly string[] | null;
+}
+
+/**
+ * Replace `window.location` and `window.location.ancestorOrigins` for a test.
+ *
+ * jsdom's `location` is read-only in recent versions, so we `defineProperty`
+ * with a brand-new object that carries the pieces `configureActiveOrigin()`
+ * actually reads.
+ */
+function installLocation(overrides: WindowOverrides): void {
+    const {
+        search = '',
+        origin = 'https://partner-app.example.com',
+        ancestors = null,
+    } = overrides;
+
+    const ancestorOrigins: DOMStringList | undefined =
+        ancestors === null
+            ? undefined
+            : ({
+                  length: ancestors.length,
+                  item(index: number): string | null {
+                      return ancestors[index] ?? null;
+                  },
+                  contains(value: string): boolean {
+                      return ancestors.includes(value);
+                  },
+                  // Array index access used by `ancestorOrigins[0]`.
+                  ...Object.fromEntries(ancestors.map((value, i) => [i, value])),
+              } as unknown as DOMStringList);
+
+    const stub: Partial<Location> & { ancestorOrigins?: DOMStringList } = {
+        search,
+        origin,
+        href: `${origin}${search}`,
+        hostname: new URL(origin).hostname,
+        host: new URL(origin).host,
+        protocol: new URL(origin).protocol,
+        ancestorOrigins,
+    };
+
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: stub as Location,
+    });
+}
+
+function clearSessionStorage(): void {
+    try {
+        window.sessionStorage.clear();
+    } catch {
+        /* ignore */
+    }
+}
+
+// Silence expected log output from the SDK in passing tests.
+let consoleLogSpy: jest.SpyInstance;
+let consoleWarnSpy: jest.SpyInstance;
+let consoleErrorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+    clearSessionStorage();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    installLocation({}); // reset for the next test
+});
+
+function getActiveOrigin(sdk: PartnerConnect): string {
+    return (sdk as unknown as { activeHostOrigin: string }).activeHostOrigin;
+}
+
+function getHostOrigins(sdk: PartnerConnect): string[] {
+    return (sdk as unknown as { hostOrigins: string[] }).hostOrigins;
+}
+
+function isValidOrigin(sdk: PartnerConnect, origin: string): boolean {
+    const fn = (sdk as unknown as { isValidOrigin: (o: string) => boolean }).isValidOrigin;
+
+    return fn.call(sdk, origin);
+}
+
+// ---------------------------------------------------------------------------
+// DEFAULT_TRUSTED_TENANTS + disableDefaultTenants
+// ---------------------------------------------------------------------------
+
+describe('default tenant whitelist', () => {
+    test('is merged into hostOrigins by default', () => {
+        installLocation({});
+        const sdk = new PartnerConnect({ hostOrigin: 'https://partner.example.com' });
+
+        const whitelist = getHostOrigins(sdk);
+
+        expect(whitelist[0]).toBe('https://partner.example.com');
+        for (const entry of PartnerConnect.DEFAULT_TRUSTED_TENANTS) {
+            expect(whitelist).toContain(entry);
+        }
+
+        sdk.destroy();
+    });
+
+    test('honors disableDefaultTenants: true', () => {
+        installLocation({});
+        const sdk = new PartnerConnect({
+            hostOrigin: 'https://partner.example.com',
+            disableDefaultTenants: true,
+        });
+
+        expect(getHostOrigins(sdk)).toEqual(['https://partner.example.com']);
+
+        sdk.destroy();
+    });
+
+    test('lets a LearnCard tenant override activate via query param without any partner config', () => {
+        installLocation({ search: '?lc_host_override=https://alpha.vetpass.app' });
+        const sdk = new PartnerConnect(); // no hostOrigin at all
+
+        expect(getActiveOrigin(sdk)).toBe('https://alpha.vetpass.app');
+
+        sdk.destroy();
+    });
+
+    test('rejects an override outside both configured and default whitelists', () => {
+        installLocation({ search: '?lc_host_override=https://evil.com' });
+        const sdk = new PartnerConnect({ hostOrigin: 'https://partner.example.com' });
+
+        expect(getActiveOrigin(sdk)).toBe('https://partner.example.com');
+        expect(consoleWarnSpy).toHaveBeenCalled();
+
+        sdk.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Wildcard pattern matching
+// ---------------------------------------------------------------------------
+
+describe('wildcard pattern matching in hostOrigin', () => {
+    test.each([
+        ['https://staging.learncard.app'],
+        ['https://alpha.learncard.app'],
+        ['https://pr-123.preview.learncard.app'],
+    ])('accepts %s via https://*.learncard.app override', candidate => {
+        installLocation({ search: `?lc_host_override=${encodeURIComponent(candidate)}` });
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://learncard.app', 'https://*.learncard.app'],
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe(candidate);
+
+        sdk.destroy();
+    });
+
+    test.each([
+        // Bare apex must not match `*.learncard.app` — caller must add the exact origin.
+        ['https://learncard.app', 'https://*.learncard.app'],
+        // Protocol mismatch.
+        ['http://staging.learncard.app', 'https://*.learncard.app'],
+        // Suffix confusion: the domain is the attacker's, not LearnCard's.
+        ['https://learncard.app.attacker.com', 'https://*.learncard.app'],
+        // Empty label where the wildcard should go.
+        ['https://.learncard.app', 'https://*.learncard.app'],
+    ])('rejects %s against %s', (candidate, pattern) => {
+        installLocation({ search: `?lc_host_override=${encodeURIComponent(candidate)}` });
+        const sdk = new PartnerConnect({
+            hostOrigin: [pattern],
+            disableDefaultTenants: true,
+            // turn off native-app so localhost/capacitor don't accidentally rescue tests
+            allowNativeAppOrigins: false,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe(pattern);
+
+        sdk.destroy();
+    });
+
+    test('exact-origin entries still match', () => {
+        installLocation({ search: '?lc_host_override=https://learncard.app' });
+        const sdk = new PartnerConnect({
+            hostOrigin: 'https://learncard.app',
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://learncard.app');
+
+        sdk.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Priority: ancestorOrigins > lc_host_override > sessionStorage > fallback
+// ---------------------------------------------------------------------------
+
+describe('active-origin resolution hierarchy', () => {
+    test('prefers ancestorOrigins[0] when it is in the whitelist', () => {
+        installLocation({
+            search: '?lc_host_override=https://learncard.app',
+            ancestors: ['https://alpha.vetpass.app'],
+        });
+
+        const sdk = new PartnerConnect({ hostOrigin: 'https://learncard.app' });
+
+        expect(getActiveOrigin(sdk)).toBe('https://alpha.vetpass.app');
+        // Warn because override disagreed with real parent.
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('lc_host_override does not match'),
+            expect.any(Object)
+        );
+
+        sdk.destroy();
+    });
+
+    test('ignores ancestorOrigins[0] when it is NOT in the whitelist', () => {
+        installLocation({
+            search: '?lc_host_override=https://learncard.app',
+            ancestors: ['https://evil.com'],
+        });
+
+        const sdk = new PartnerConnect({
+            hostOrigin: 'https://learncard.app',
+            disableDefaultTenants: true,
+        });
+
+        // Since the ancestor isn't trusted, we fall through to the override.
+        expect(getActiveOrigin(sdk)).toBe('https://learncard.app');
+
+        sdk.destroy();
+    });
+
+    test('falls back to lc_host_override when ancestorOrigins is unavailable', () => {
+        installLocation({
+            search: '?lc_host_override=https://staging.learncard.app',
+            ancestors: null, // Firefox / top-level context
+        });
+
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://learncard.app', 'https://*.learncard.app'],
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://staging.learncard.app');
+
+        sdk.destroy();
+    });
+
+    test('falls back to sessionStorage when no query param is present', () => {
+        window.sessionStorage.setItem('lc_host_override', 'https://staging.learncard.app');
+
+        installLocation({ search: '' });
+
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://learncard.app', 'https://*.learncard.app'],
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://staging.learncard.app');
+
+        sdk.destroy();
+    });
+
+    test('falls back to the first configured origin when everything else is absent', () => {
+        installLocation({});
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://partner.example.com'],
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://partner.example.com');
+
+        sdk.destroy();
+    });
+
+    test('persists a valid override back into sessionStorage', () => {
+        installLocation({ search: '?lc_host_override=https://staging.learncard.app' });
+
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://learncard.app', 'https://*.learncard.app'],
+            disableDefaultTenants: true,
+        });
+
+        expect(window.sessionStorage.getItem('lc_host_override')).toBe(
+            'https://staging.learncard.app'
+        );
+
+        sdk.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime message validation
+// ---------------------------------------------------------------------------
+
+describe('incoming message validation', () => {
+    test('accepts messages from the active host origin and rejects everything else', () => {
+        installLocation({
+            search: '?lc_host_override=https://alpha.vetpass.app',
+        });
+        const sdk = new PartnerConnect({
+            hostOrigin: ['https://learncard.app', 'https://*.vetpass.app'],
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://alpha.vetpass.app');
+        expect(isValidOrigin(sdk, 'https://alpha.vetpass.app')).toBe(true);
+
+        // Other whitelisted origins must still be rejected — only the single
+        // active origin is trusted for event validation.
+        expect(isValidOrigin(sdk, 'https://learncard.app')).toBe(false);
+        expect(isValidOrigin(sdk, 'https://vetpass.app')).toBe(false);
+        expect(isValidOrigin(sdk, 'https://evil.com')).toBe(false);
+
+        sdk.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Native-app origins
+// ---------------------------------------------------------------------------
+
+describe('native-app origins', () => {
+    test('are accepted by default without being in hostOrigin', () => {
+        installLocation({ search: '?lc_host_override=capacitor://localhost' });
+        const sdk = new PartnerConnect({
+            hostOrigin: 'https://learncard.app',
+            disableDefaultTenants: true,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('capacitor://localhost');
+
+        sdk.destroy();
+    });
+
+    test('can be disabled via allowNativeAppOrigins: false', () => {
+        installLocation({ search: '?lc_host_override=capacitor://localhost' });
+        const sdk = new PartnerConnect({
+            hostOrigin: 'https://learncard.app',
+            disableDefaultTenants: true,
+            allowNativeAppOrigins: false,
+        });
+
+        expect(getActiveOrigin(sdk)).toBe('https://learncard.app');
+
+        sdk.destroy();
+    });
+});

--- a/packages/learn-card-partner-connect-sdk/src/pattern-matching.test.ts
+++ b/packages/learn-card-partner-connect-sdk/src/pattern-matching.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Direct unit tests for `PartnerConnect.matchesOriginPattern`.
+ *
+ * These complement the integration-level tests in `origin-resolution.test.ts`
+ * by exercising the pure pattern matcher in isolation, without spinning up the
+ * full SDK / jsdom location stub. The matcher is the security-critical core
+ * of the whitelist, so it gets its own focused test file.
+ */
+
+import { PartnerConnect } from './index';
+
+const matches = PartnerConnect.matchesOriginPattern.bind(PartnerConnect);
+
+describe('PartnerConnect.matchesOriginPattern', () => {
+    describe('exact matches (no wildcard)', () => {
+        test.each([
+            ['https://learncard.app', 'https://learncard.app'],
+            ['https://vetpass.app', 'https://vetpass.app'],
+            ['http://localhost:3000', 'http://localhost:3000'],
+            ['capacitor://localhost', 'capacitor://localhost'],
+        ])('%s matches itself', (origin, pattern) => {
+            expect(matches(origin, pattern)).toBe(true);
+        });
+
+        test.each([
+            // Different protocol.
+            ['http://learncard.app', 'https://learncard.app'],
+            // Different port.
+            ['https://learncard.app:8443', 'https://learncard.app'],
+            // Different host entirely.
+            ['https://other.com', 'https://learncard.app'],
+            // Trailing path is part of the input — only the origin should match.
+            ['https://learncard.app/foo', 'https://learncard.app'],
+        ])('%s does not match %s', (candidate, pattern) => {
+            expect(matches(candidate, pattern)).toBe(false);
+        });
+    });
+
+    describe('leading-label wildcards', () => {
+        const PATTERN = 'https://*.learncard.app';
+
+        test.each([
+            'https://staging.learncard.app',
+            'https://alpha.learncard.app',
+            'https://pr-123.learncard.app',
+            // Multi-label prefix is allowed.
+            'https://pr-123.preview.learncard.app',
+            'https://a.b.c.learncard.app',
+        ])('matches %s', candidate => {
+            expect(matches(candidate, PATTERN)).toBe(true);
+        });
+
+        test.each([
+            // Apex of the trusted domain — caller must add the bare origin
+            // explicitly if they want to trust it.
+            'https://learncard.app',
+            // Protocol mismatch.
+            'http://staging.learncard.app',
+            // Port mismatch.
+            'https://staging.learncard.app:8443',
+            // Suffix confusion: the trusted suffix is somewhere in the host
+            // string, but the actual eTLD+1 is `attacker.com`.
+            'https://learncard.app.attacker.com',
+            'https://staging.learncard.app.attacker.com',
+            // Trailing dot / double dot edge cases.
+            'https://.learncard.app',
+            // Host with leading `.` after a label is rejected by URL parser
+            // already, but also covered.
+            'https://..learncard.app',
+            // Different domain entirely.
+            'https://staging.vetpass.app',
+        ])('rejects %s', candidate => {
+            expect(matches(candidate, PATTERN)).toBe(false);
+        });
+    });
+
+    describe('disallowed wildcard shapes', () => {
+        // Wildcards may only be a leading label. The matcher must reject any
+        // exotic placement so the rule stays predictable and auditable.
+        test.each([
+            // Wildcard in the middle.
+            ['https://staging.learncard.app', 'https://staging.*.app'],
+            // Wildcard as a partial label.
+            ['https://api-staging.learncard.app', 'https://api-*.learncard.app'],
+            // Wildcard in the TLD position.
+            ['https://learncard.app', 'https://learncard.*'],
+            // Wildcard with no following label.
+            ['https://staging.learncard.app', 'https://*'],
+            // Multiple disjoint wildcards.
+            ['https://a.b.learncard.app', 'https://*.*.learncard.app'],
+        ])('rejects %s against %s', (candidate, pattern) => {
+            expect(matches(candidate, pattern)).toBe(false);
+        });
+    });
+
+    describe('port handling', () => {
+        test('matches when both pattern and candidate share the same port', () => {
+            expect(
+                matches('https://staging.learncard.app:8443', 'https://*.learncard.app:8443')
+            ).toBe(true);
+        });
+
+        test('rejects when only the candidate specifies a port', () => {
+            expect(
+                matches('https://staging.learncard.app:8443', 'https://*.learncard.app')
+            ).toBe(false);
+        });
+
+        test('rejects when only the pattern specifies a port', () => {
+            expect(
+                matches('https://staging.learncard.app', 'https://*.learncard.app:8443')
+            ).toBe(false);
+        });
+    });
+
+    describe('malformed input', () => {
+        test.each([
+            ['', 'https://learncard.app'],
+            ['not a url', 'https://learncard.app'],
+            ['https://staging.learncard.app', ''],
+            ['https://staging.learncard.app', 'not a url'],
+            ['https://staging.learncard.app', 'https://*'],
+        ])('rejects (%s, %s)', (candidate, pattern) => {
+            expect(matches(candidate, pattern)).toBe(false);
+        });
+    });
+
+    describe('cross-protocol wildcards', () => {
+        test('http wildcard pattern only matches http origins', () => {
+            expect(matches('http://staging.dev.local', 'http://*.dev.local')).toBe(true);
+            expect(matches('https://staging.dev.local', 'http://*.dev.local')).toBe(false);
+        });
+    });
+});

--- a/packages/learn-card-partner-connect-sdk/src/types.ts
+++ b/packages/learn-card-partner-connect-sdk/src/types.ts
@@ -15,44 +15,74 @@ export type {
  */
 export interface PartnerConnectOptions {
     /**
-     * The origin(s) of the LearnCard host
+     * The origin(s) of the LearnCard host.
      *
-     * This can be a single string or an array of strings to serve as a whitelist for
-     * the `lc_host_override` query parameter.
+     * Each entry may be either an **exact origin** (`https://learncard.app`) or a
+     * **wildcard pattern** where `*` stands in for a single DNS label portion in
+     * the host portion of the origin (e.g. `https://*.learncard.app`,
+     * `https://*.vetpass.app`). Wildcards are **only** allowed in the host and
+     * only as label(s); the protocol and port must always match exactly.
      *
-     * **Origin Configuration Hierarchy:**
-     * 1. **Hardcoded Default**: `https://learncard.app` (security anchor)
-     * 2. **Query Parameter Override**: `?lc_host_override=https://staging.learncard.app`
-     *    - Checked against whitelist if `hostOrigin` is provided
-     *    - Used for staging/testing environments
-     * 3. **Configured Origin**: First value in array or single string value
+     * Wildcard patterns match any non-empty chain of labels. So
+     * `https://*.learncard.app` matches both `https://staging.learncard.app` and
+     * `https://pr-123.preview.learncard.app`, but **not** `https://learncard.app`
+     * itself (include the bare origin explicitly if you need it) and **not**
+     * `https://evil.learncard.app.attacker.com` (the suffix must match).
      *
-     * **Security Model:**
-     * - The SDK enforces STRICT origin validation
-     * - Incoming messages must EXACTLY match the active host origin
-     * - Prevents origin spoofing: even if malicious query param is added,
-     *   messages from unauthorized origins are rejected
+     * **Origin Configuration Hierarchy at runtime:**
+     * 1. `window.location.ancestorOrigins[0]` (when available) — the real parent
+     *    origin as reported by the browser, validated against the effective
+     *    whitelist. This source cannot be spoofed by a malicious query param.
+     * 2. `?lc_host_override=<origin>` query parameter — validated against the
+     *    whitelist. Used by the LearnCard host to tell the SDK which origin it
+     *    is loading from.
+     * 3. `sessionStorage['lc_host_override']` — a previously-validated override
+     *    persisted across in-iframe navigation.
+     * 4. First value in the configured `hostOrigin` array / single string.
+     * 5. `PartnerConnect.DEFAULT_HOST_ORIGIN` (`https://learncard.app`).
+     *
+     * The partner app's configured whitelist is combined with a small built-in
+     * list of LearnCard tenant domains (see `disableDefaultTenants` to opt out).
+     * This lets a partner app work out-of-the-box inside any current or future
+     * `*.learncard.app`, `*.learncard.ai`, or `*.vetpass.app` tenant without a
+     * re-deploy.
      *
      * **Examples:**
      *
-     * Single origin (production):
+     * Single origin (production only):
      * ```typescript
      * hostOrigin: 'https://learncard.app'
-     * // Uses: https://learncard.app
-     * // Override: ?lc_host_override=https://staging.learncard.app (not validated)
      * ```
      *
-     * Multiple origins (whitelist for staging):
+     * Wildcard whitelist (covers staging + preview):
      * ```typescript
-     * hostOrigin: ['https://learncard.app', 'https://staging.learncard.app']
-     * // Default: https://learncard.app
-     * // Override: ?lc_host_override=https://staging.learncard.app (validated)
-     * // Invalid: ?lc_host_override=https://evil.com (rejected)
+     * hostOrigin: ['https://learncard.app', 'https://*.learncard.app']
+     * ```
+     *
+     * Custom tenant alongside the built-in LearnCard defaults:
+     * ```typescript
+     * hostOrigin: ['https://partner.example.com']
+     * // learncard.app / *.learncard.app / *.learncard.ai / vetpass.app / *.vetpass.app
+     * // are ALSO trusted because disableDefaultTenants is false.
      * ```
      *
      * @default 'https://learncard.app'
      */
     hostOrigin?: string | string[];
+
+    /**
+     * Opt out of the built-in LearnCard tenant whitelist.
+     *
+     * By default, the SDK merges `hostOrigin` with a curated list of LearnCard
+     * and tenant domains (see `PartnerConnect.DEFAULT_TRUSTED_TENANTS`) so that
+     * partner apps work on any LearnCard-managed tenant without reconfiguration.
+     *
+     * Set to `true` if you want the partner app to **only** trust the origins
+     * you pass in `hostOrigin`.
+     *
+     * @default false
+     */
+    disableDefaultTenants?: boolean;
 
     /**
      * Whether to allow native app origins (default: true)


### PR DESCRIPTION
Partner apps built on `@learncard/partner-connect` previously had to enumerate every LearnCard host origin they wanted to support (`learncard.app`, `staging.learncard.ai`, `vetpass.app`, `alpha.vetpass.app`, …) in their `hostOrigin` whitelist. Every new tenant or stage → every partner app re-deploys.

This PR makes partner apps work on any current or future LearnCard-managed tenant with **zero config changes**, while tightening the security model against malicious `lc_host_override` query-param injection.

## What's new

### 1. Built-in tenant whitelist

`PartnerConnect.DEFAULT_TRUSTED_TENANTS` is now merged automatically into the effective whitelist:

```
https://learncard.app
https://*.learncard.app
https://*.learncard.ai
https://vetpass.app
https://*.vetpass.app
```

A partner app that just does [createPartnerConnect()](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-3/packages/learn-card-partner-connect-sdk/src/index.ts:877:0-894:1) now works inside `learncard.app`, every `*.learncard.app` / `*.learncard.ai` stage, `vetpass.app`, `alpha.vetpass.app`, `staging.vetpass.app`, and any future preview/PR subdomain under those families.

Opt out via `disableDefaultTenants: true` to lock the SDK down to only the caller's configured origins.

### 2. Wildcard patterns in `hostOrigin`

Entries may now be exact origins **or** leading-label wildcards:

```ts
hostOrigin: [
    'https://learncard.app',        // exact
    'https://*.learncard.app',      // any non-empty chain of leading labels
]
```

Matching is strict:

| Pattern | Candidate | Result |
|---|---|---|
| `https://*.learncard.app` | `https://staging.learncard.app` | ✅ |
| `https://*.learncard.app` | `https://pr-1.preview.learncard.app` | ✅ |
| `https://*.learncard.app` | `https://learncard.app` (apex) | ❌ |
| `https://*.learncard.app` | `http://staging.learncard.app` (protocol) | ❌ |
| `https://*.learncard.app` | `https://learncard.app.attacker.com` (suffix confusion) | ❌ |

Wildcards are only allowed as leading DNS label(s); protocol and port must match exactly. No `*.foo.*` or `api-*.foo`.

### 3. Prefer `window.location.ancestorOrigins[0]` over the query param

The browser-reported parent origin is **unspoofable** by URL manipulation. The SDK now uses it as the strongest source of truth when it's available (Chromium / WebKit):

```
1. window.location.ancestorOrigins[0]  (if in whitelist)
2. ?lc_host_override=<origin>          (if in whitelist)
3. sessionStorage['lc_host_override']  (if in whitelist)
4. First configured hostOrigin
5. DEFAULT_HOST_ORIGIN (https://learncard.app)
```

If the ancestor origin and the query-param override disagree, the ancestor wins and the SDK logs a warning. Firefox (no `ancestorOrigins`) falls through to the existing query-param flow with no behavior change.

## Why this matters

- **New tenant onboarding** (e.g. a future `foo.learncard.ai` stage) is now a host-side concern only — partner apps don't re-deploy.
- **Defense in depth:** a malicious `lc_host_override` in a tab controlled by an attacker can no longer trick the SDK into trusting evil.com when the real parent is learncard.app.
- **Still strict at runtime:** incoming messages continue to be validated with **exact** equality against the single resolved `activeHostOrigin`. The whitelist only controls *which* origin gets promoted to active.

## Backward compatibility

Non-breaking (released as a **minor** bump via changeset):

- Existing `hostOrigin: string` and `hostOrigin: string[]` configs continue to work exactly as before.
- `allowNativeAppOrigins` / `protocol` / `requestTimeout` are unchanged.
- The outbound `window.parent.postMessage(..., activeHostOrigin)` target is still a single, exact origin.
- The only observable behavior change is that the effective whitelist is *larger* by default; any caller that wants the old strict behavior sets `disableDefaultTenants: true`.

## Test coverage

21 new Jest tests in [src/origin-resolution.test.ts](/packages/learn-card-partner-connect-sdk/src/origin-resolution.test.ts:0:0-0:0) covering:

- **Default tenants:** merged by default, honor `disableDefaultTenants: true`, allow a LearnCard override with no partner config, reject origins outside both configured + default lists.
- **Wildcard matching:** accept legitimate subdomains + multi-label previews; reject apex, wrong protocol, suffix-confusion (`.attacker.com`), empty label.
- **Resolution hierarchy:** ancestor wins over override; untrusted ancestor ignored; Firefox (no ancestors) falls through to override; sessionStorage fallback; configured fallback; sessionStorage persistence.
- **Runtime message validation:** only the single active origin is trusted for incoming events, even for other whitelisted patterns.
- **Native-app origins:** accepted by default, opt-out via `allowNativeAppOrigins: false`.

## Verification

```bash
pnpm exec nx run partner-connect-sdk:typecheck   # ✅
pnpm exec nx run partner-connect-sdk:test        # ✅ 21/21
pnpm exec nx run partner-connect-sdk:build       # ✅
```

## What's intentionally not in this PR

- **Phase 2 — signed tenant registry.** A `.well-known/partner-connect-tenants.json` served by an authoritative origin, fetched at SDK init, would make even a brand-new root domain (e.g. `acme.app`) work without an SDK release. Deferred until tenant churn justifies the infra cost.

## Out-of-the-box usage examples

```ts
// Minimal — works on every current LearnCard tenant.
const learnCard = createPartnerConnect();

// Partner's own custom-hosted environment alongside the defaults.
const learnCard = createPartnerConnect({
    hostOrigin: 'https://my-partner-portal.com',
});

// Strict mode — only trust what I pass.
const learnCard = createPartnerConnect({
    hostOrigin: ['https://my-partner-portal.com'],
    disableDefaultTenants: true,
});
```
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable Partner Connect SDK to work across multiple LearnCard tenants using wildcard patterns and built-in tenant whitelist without re-deployment.

Main changes:
- Added `DEFAULT_TRUSTED_TENANTS` whitelist and `disableDefaultTenants` option to merge configured origins with LearnCard-managed tenant domains automatically
- Implemented wildcard pattern matching for `hostOrigin` entries (e.g., `https://*.learncard.app`) with protocol/port exactness requirements
- Enhanced origin resolution hierarchy to prioritize `window.location.ancestorOrigins[0]` over query parameters for unspoofable parent detection and added comprehensive test coverage

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
