### PR TITLE
fix[LC-1792]: Improve Build My LearnCard upload-success toast UX

### DIFF
--- a/.changeset/lc-1792-toast-improvements.md
+++ b/.changeset/lc-1792-toast-improvements.md
@@ -1,0 +1,5 @@
+---
+'@learncard/learn-card-app': patch
+---
+
+Build My LearnCard: upload-success toast is now persistent, includes the filename and target wallet categories, and appears immediately when parsing finishes (no more 5-6s lag). Also: empty-extraction uploads no longer say "Successfully Parsed" (LC-1792).

--- a/apps/learn-card-app/src/components/learncard/checklist/checklist-steps/CheckListUploadRawVC.tsx
+++ b/apps/learn-card-app/src/components/learncard/checklist/checklist-steps/CheckListUploadRawVC.tsx
@@ -175,11 +175,11 @@ export const CheckListUploadRawVC: React.FC = () => {
                 setRawVcText('');
                 loadRawVCs();
                 presentToast(`Your journey is now reflected in portable, trusted credentials.`, {
-                    title: `JSON VC Successfully Parsed`,
+                    title: `JSON Credential Successfully Added`,
                     hasDismissButton: true,
                     type: ToastTypeEnum.Success,
                     hasCheckmark: true,
-                    duration: 5000,
+                    autoDismiss: false,
                 });
             } else {
                 setRawTextErrors([`Failed to parse JSON VC. ${result?.error}`]);

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -498,12 +498,11 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             const typeLabel = formatTypeLabel(fileType, { plural: fileCount > 1 });
             const fileList = formatFileNameList(filenames);
             const categoryList = formatCategoryList(categories);
-            const filesNoun = fileCount > 1 ? 'files are' : 'file is';
 
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials added. Your ${filesNoun} stored in your wallet.`,
+                        `No credentials were added from ${fileList}.`,
                         {
                             title: `${typeLabel} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
@@ -591,7 +590,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials could be extracted from ${fileList}. Your file is stored in your wallet.`,
+                        `No credentials could be extracted from ${fileList}.`,
                         {
                             title: `${typeLabel} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
@@ -717,12 +716,11 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             const typeLabel = formatTypeLabel(fileType, { plural: fileCount > 1 });
             const fileList = formatFileNameList(filenames);
             const categoryList = formatCategoryList(categories);
-            const filesNoun = fileCount > 1 ? 'files are' : 'file is';
 
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials could be extracted from ${fileList}. Your ${filesNoun} stored in your wallet.`,
+                        `No credentials could be extracted from ${fileList}.`,
                         {
                             title: `${typeLabel} saved`,
                             ...SUCCESS_TOAST_OPTIONS,

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -139,11 +139,10 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
     const [isSaving, setIsSaving] = useState(false);
     const [parsedCredentials, setParsedCredentials] = useState<Array<{ vc: any; metadata?: { name?: string; category?: string } }>>([]);
 
-    const fetchNewContractCredentials = () => {
+    const fetchNewContractCredentials = () =>
         queryClient.refetchQueries({
             queryKey: ['useSyncConsentFlow', switchedDid ?? ''],
         });
-    };
 
     const getFile = async (event: React.ChangeEvent<HTMLInputElement>, uploadType: string) => {
         try {

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -494,24 +494,18 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             const filenames = [rawArtifactVc, ...(additionalRawArtifacts ?? [])].map(
                 (r: any) => r?.rawArtifact?.fileName
             );
-            const typeLabel = formatTypeLabel(fileType);
+            const fileCount = filenames.filter(Boolean).length;
+            const typeLabel = formatTypeLabel(fileType, { plural: fileCount > 1 });
             const fileList = formatFileNameList(filenames);
             const categoryList = formatCategoryList(categories);
+            const filesNoun = fileCount > 1 ? 'files are' : 'file is';
 
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials selected. Your file is stored in your wallet.`,
+                        `No credentials added. Your ${filesNoun} stored in your wallet.`,
                         {
                             title: `${typeLabel} saved`,
-                            ...SUCCESS_TOAST_OPTIONS,
-                        }
-                    );
-                } else if (totalCredentials === 1) {
-                    presentToast(
-                        `Successfully added to ${categoryList}.`,
-                        {
-                            title: `${typeLabel} ${fileList} Successfully Added`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -519,7 +513,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                     presentToast(
                         `Successfully added to ${categoryList}.`,
                         {
-                            title: `${totalCredentials} credentials saved from ${fileList}`,
+                            title: `${totalCredentials} credential${totalCredentials > 1 ? 's' : ''} parsed from ${fileList}`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -603,19 +597,11 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
-                } else if (totalCredentials === 1) {
-                    presentToast(
-                        `Successfully added to ${categoryList}.`,
-                        {
-                            title: `${typeLabel} ${fileList} Successfully Added`,
-                            ...SUCCESS_TOAST_OPTIONS,
-                        }
-                    );
                 } else {
                     presentToast(
                         `Successfully added to ${categoryList}.`,
                         {
-                            title: `${totalCredentials} credentials parsed from ${fileList}`,
+                            title: `${totalCredentials} credential${totalCredentials > 1 ? 's' : ''} parsed from ${fileList}`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -727,25 +713,18 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             aiInsightMutation.mutate();
             closeModal();
 
-            const typeLabel = formatTypeLabel(fileType);
-            const typeLabelPlural = formatTypeLabel(fileType, { plural: true });
+            const fileCount = filenames.filter(Boolean).length;
+            const typeLabel = formatTypeLabel(fileType, { plural: fileCount > 1 });
             const fileList = formatFileNameList(filenames);
             const categoryList = formatCategoryList(categories);
+            const filesNoun = fileCount > 1 ? 'files are' : 'file is';
 
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials could be extracted from ${fileList}. Your file is stored in your wallet.`,
+                        `No credentials could be extracted from ${fileList}. Your ${filesNoun} stored in your wallet.`,
                         {
-                            title: `${typeLabelPlural} saved`,
-                            ...SUCCESS_TOAST_OPTIONS,
-                        }
-                    );
-                } else if (totalCredentials === 1) {
-                    presentToast(
-                        `Successfully added to ${categoryList}.`,
-                        {
-                            title: `${typeLabel} ${fileList} Successfully Added`,
+                            title: `${typeLabel} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -753,7 +732,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                     presentToast(
                         `Successfully added to ${categoryList}.`,
                         {
-                            title: `${totalCredentials} credentials parsed from ${fileList}`,
+                            title: `${totalCredentials} credential${totalCredentials > 1 ? 's' : ''} parsed from ${fileList}`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -462,7 +462,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 const issuedVCs = await Promise.all(
                     selectedVcs.map(async vc => {
                         const issuedVc = await wallet.invoke.issueCredential(vc);
-                        return (await storeAndAddVCToWallet(issuedVc)).result;
+                        const { credentialUri: uri, category } =
+                            await storeAndAddVCToWallet(issuedVc);
+                        return { uri, category };
                     })
                 );
 
@@ -553,7 +555,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 const issuedVCs = await Promise.all(
                     vcs.vcs.map(async ({ vc }) => {
                         const issuedVc = await wallet.invoke.issueCredential(vc);
-                        return (await storeAndAddVCToWallet(issuedVc)).result;
+                        const { credentialUri: uri, category } =
+                            await storeAndAddVCToWallet(issuedVc);
+                        return { uri, category };
                     })
                 );
 
@@ -671,7 +675,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         const issuedVCs = await Promise.all(
                             vcs.vcs.map(async ({ vc }) => {
                                 const issuedVc = await wallet.invoke.issueCredential(vc);
-                                return (await storeAndAddVCToWallet(issuedVc)).result;
+                                const { credentialUri: uri, category } =
+                                    await storeAndAddVCToWallet(issuedVc);
+                                return { uri, category };
                             })
                         );
 

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -502,9 +502,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials were added from ${fileList}.`,
+                        `No credentials could be extracted from ${fileCount > 1 ? 'these files' : 'this file'}.`,
                         {
-                            title: `${typeLabel} saved`,
+                            title: `${typeLabel} ${fileList} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -590,9 +590,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials could be extracted from ${fileList}.`,
+                        `No credentials could be extracted from this file.`,
                         {
-                            title: `${typeLabel} saved`,
+                            title: `${typeLabel} ${fileList} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );
@@ -720,9 +720,9 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             setTimeout(() => {
                 if (totalCredentials === 0) {
                     presentToast(
-                        `No credentials could be extracted from ${fileList}.`,
+                        `No credentials could be extracted from ${fileCount > 1 ? 'these files' : 'this file'}.`,
                         {
-                            title: `${typeLabel} saved`,
+                            title: `${typeLabel} ${fileList} saved`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -644,9 +644,12 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             if (!did) throw new Error('Could not get wallet DID');
 
             const aggregateRecordsByCategory: Partial<Record<CredentialCategory, string[]>> = {};
+            const filenamesWithCreds: string[] = [];
+            const filenamesWithoutCreds: string[] = [];
 
             // Process files sequentially to avoid race conditions
             for (const rawVC of rawArtifactCredentials) {
+                const fname = rawVC?.rawArtifact?.fileName;
                 try {
                     const vcs = await uploadFile({
                         did,
@@ -657,6 +660,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                     await saveFile(rawVC, fileType);
 
                     if (vcs?.vcs?.length > 0) {
+                        if (fname) filenamesWithCreds.push(fname);
                         const issuedVCs = await Promise.all(
                             vcs.vcs.map(async ({ vc }) => {
                                 const issuedVc = await wallet.invoke.issueCredential(vc);
@@ -686,6 +690,8 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                             const existing = aggregateRecordsByCategory[cat as CredentialCategory] ?? [];
                             aggregateRecordsByCategory[cat as CredentialCategory] = [...existing, ...uris];
                         }
+                    } else if (fname) {
+                        filenamesWithoutCreds.push(fname);
                     }
 
                     onFileSettled();
@@ -715,6 +721,8 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             const fileCount = filenames.filter(Boolean).length;
             const typeLabel = formatTypeLabel(fileType, { plural: fileCount > 1 });
             const fileList = formatFileNameList(filenames);
+            const fileListWithCreds = formatFileNameList(filenamesWithCreds);
+            const fileListWithoutCreds = formatFileNameList(filenamesWithoutCreds);
             const categoryList = formatCategoryList(categories);
 
             setTimeout(() => {
@@ -727,10 +735,14 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         }
                     );
                 } else {
+                    const tail =
+                        filenamesWithoutCreds.length > 0
+                            ? ` No credentials were parsed from ${fileListWithoutCreds}.`
+                            : '';
                     presentToast(
-                        `Successfully added to ${categoryList}.`,
+                        `Successfully added to ${categoryList}.${tail}`,
                         {
-                            title: `${totalCredentials} credential${totalCredentials > 1 ? 's' : ''} parsed from ${fileList}`,
+                            title: `${totalCredentials} credential${totalCredentials > 1 ? 's' : ''} parsed from ${fileListWithCreds}`,
                             ...SUCCESS_TOAST_OPTIONS,
                         }
                     );

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -17,6 +17,7 @@ import {
     ToastTypeEnum,
     getCategoryForCredential,
     useSyncAllCredentialsToContractsMutation,
+    categoryMetadata,
 } from 'learn-card-base';
 import { useAiInsightCredentialMutation } from 'learn-card-base/hooks/useAiInsightCredential';
 import { getDefaultCategoryForCredential } from 'learn-card-base/helpers/credentialHelpers';
@@ -36,6 +37,49 @@ export const getFormattedFileSize = (sizeInBytes: number): string => {
     if (sizeInBytes < 1024 * 1024) return `${(sizeInBytes / 1024).toFixed(1)} KB`;
     return `${(sizeInBytes / (1024 * 1024)).toFixed(1)} MB`;
 };
+
+const TYPE_LABEL: Record<UploadTypesEnum, string> = {
+    [UploadTypesEnum.Resume]: 'Resume',
+    [UploadTypesEnum.Certificate]: 'Certificate',
+    [UploadTypesEnum.Diploma]: 'Diploma',
+    [UploadTypesEnum.Transcript]: 'Transcript',
+    [UploadTypesEnum.RawVC]: 'Credential',
+};
+
+const formatTypeLabel = (
+    type: UploadTypesEnum,
+    { plural = false }: { plural?: boolean } = {}
+) => {
+    const base = TYPE_LABEL[type] ?? type;
+    return plural ? `${base}s` : base;
+};
+
+const formatFileNameList = (filenames: (string | undefined)[]): string => {
+    const present = filenames.filter((f): f is string => Boolean(f));
+    if (present.length === 0) return '';
+    if (present.length === 1) return `"${present[0]}"`;
+    if (present.length === 2) return `"${present[0]}" and "${present[1]}"`;
+    return `"${present.slice(0, -1).join('", "')}", and "${present[present.length - 1]}"`;
+};
+
+const formatCategoryList = (categories: string[]): string => {
+    const labels = categories.map(
+        c => categoryMetadata[c as keyof typeof categoryMetadata]?.title ?? c
+    );
+    if (labels.length === 0) return '';
+    if (labels.length === 1) return labels[0];
+    if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+    return `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]}`;
+};
+
+const SUCCESS_TOAST_OPTIONS = {
+    hasDismissButton: true,
+    type: ToastTypeEnum.Success,
+    hasCheckmark: true,
+    autoDismiss: false,
+} as const;
+
+const TOAST_PAUSE_MS = 100;
 
 export const getFileInfo = (file: File) => {
     const match = file.name.match(/\.([0-9a-z]+)(?=[?#])?|(\.)(?:[\w]+)$/i);
@@ -226,18 +270,31 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 addNewCreds(credentialsByCategory);
             }
 
+            const categories = Object.keys(credentialsByCategory);
+            const filenames = fileArray.map(f => f.name);
+            const successCount = totalUploads - failedUploads;
+
             setTimeout(() => {
                 if (failedUploads === 0) {
-                    presentToast(
-                        `Your journey is now reflected in portable, trusted credentials.`,
-                        {
-                            title: `${uploadType} Successfully Parsed`,
-                            hasDismissButton: true,
-                            type: ToastTypeEnum.Success,
-                            hasCheckmark: true,
-                            duration: 5000,
-                        }
-                    );
+                    const fileList = formatFileNameList(filenames);
+                    const categoryList = formatCategoryList(categories);
+                    if (successCount === 1) {
+                        presentToast(
+                            `Successfully added to ${categoryList}.`,
+                            {
+                                title: `Credential ${fileList} Successfully Added`,
+                                ...SUCCESS_TOAST_OPTIONS,
+                            }
+                        );
+                    } else {
+                        presentToast(
+                            `Successfully added to ${categoryList}.`,
+                            {
+                                title: `${successCount} credentials added from ${fileList}`,
+                                ...SUCCESS_TOAST_OPTIONS,
+                            }
+                        );
+                    }
                 } else if (failedUploads === totalUploads) {
                     presentToast(`All uploads failed. Please try again.`, {
                         title: 'Upload Failed',
@@ -260,9 +317,11 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         }
                     );
                 }
-            }, 500);
+            }, TOAST_PAUSE_MS);
 
-            await refetchCheckListStatus();
+            refetchCheckListStatus().catch(err =>
+                console.error('refetchCheckListStatus failed', err)
+            );
             setIsUploading(false);
             checklistStore.set.updateIsParsing(uploadType, false);
 
@@ -397,6 +456,8 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 }
             }
 
+            let recordsByCategory: Partial<Record<CredentialCategory, string[]>> = {};
+
             if (selectedVcs.length > 0) {
                 const wallet = await initWallet();
                 const issuedVCs = await Promise.all(
@@ -406,7 +467,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                     })
                 );
 
-                const recordsByCategory = issuedVCs.reduce<Partial<Record<CredentialCategory, string[]>>>(
+                recordsByCategory = issuedVCs.reduce<Partial<Record<CredentialCategory, string[]>>>(
                     (records, { category, uri }) => {
                         if (!uri) return records;
                         const existing = records[category] ?? [];
@@ -419,26 +480,50 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 newCredsStore.set.addNewCreds(recordsByCategory);
             }
 
-            await refetchCheckListStatus();
+            // Background sync — don't block toast on these
+            refetchCheckListStatus().catch(err =>
+                console.error('refetchCheckListStatus failed', err)
+            );
             syncAll.mutate();
             aiInsightMutation.mutate();
             setParsedCredentials([]);
 
-            const credCount = selectedVcs.length;
+            const totalCredentials = selectedVcs.length;
+            const categories = Object.keys(recordsByCategory);
+            const filenames = [rawArtifactVc, ...(additionalRawArtifacts ?? [])].map(
+                (r: any) => r?.rawArtifact?.fileName
+            );
+            const typeLabel = formatTypeLabel(fileType);
+            const fileList = formatFileNameList(filenames);
+            const categoryList = formatCategoryList(categories);
+
             setTimeout(() => {
-                presentToast(
-                    credCount > 0
-                        ? `${credCount} credential${credCount > 1 ? 's' : ''} saved to your wallet.`
-                        : `${fileType === UploadTypesEnum.Resume ? 'Resume' : fileType.charAt(0).toUpperCase() + fileType.slice(1)} saved, no credentials added to wallet.`,
-                    {
-                        title: credCount > 0 ? 'Credentials Saved' : 'Saved',
-                        hasDismissButton: true,
-                        type: ToastTypeEnum.Success,
-                        hasCheckmark: true,
-                        duration: 5000,
-                    }
-                );
-            }, 500);
+                if (totalCredentials === 0) {
+                    presentToast(
+                        `No credentials selected. Your file is stored in your wallet.`,
+                        {
+                            title: `${typeLabel} saved`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else if (totalCredentials === 1) {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${typeLabel} ${fileList} Successfully Added`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${totalCredentials} credentials saved from ${fileList}`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                }
+            }, TOAST_PAUSE_MS);
         } catch (error) {
             console.error('storeSelectedCredentials::error', error);
             setTimeout(() => {
@@ -463,6 +548,8 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
 
             await saveFile(rawArtifactCredential, fileType);
 
+            let recordsByCategory: Partial<Record<CredentialCategory, string[]>> = {};
+
             if (vcs?.vcs?.length > 0) {
                 const issuedVCs = await Promise.all(
                     vcs.vcs.map(async ({ vc }) => {
@@ -472,7 +559,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 );
 
                 // Group VCs by category and update the store
-                const recordsByCategory = issuedVCs.reduce<
+                recordsByCategory = issuedVCs.reduce<
                     Partial<Record<CredentialCategory, string[]>>
                 >((records, { category, uri }) => {
                     if (!uri) return records;
@@ -487,20 +574,50 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 newCredsStore.set.addNewCreds(recordsByCategory);
             }
 
-            await refetchCheckListStatus();
+            const totalCredentials = vcs?.vcs?.length ?? 0;
+            const categories = Object.keys(recordsByCategory);
+
+            // Background sync — don't block toast on these
+            refetchCheckListStatus().catch(err =>
+                console.error('refetchCheckListStatus failed', err)
+            );
             syncAll.mutate();
             aiInsightMutation.mutate();
             checklistStore.set.updateIsParsing(fileType, false);
             closeModal();
+
+            const typeLabel = formatTypeLabel(fileType);
+            const filename = rawArtifactCredential?.rawArtifact?.fileName;
+            const fileList = formatFileNameList([filename]);
+            const categoryList = formatCategoryList(categories);
+
             setTimeout(() => {
-                presentToast(`Your journey is now reflected in portable, trusted credentials.`, {
-                    title: `${fileType} Successfully Parsed`,
-                    hasDismissButton: true,
-                    type: ToastTypeEnum.Success,
-                    hasCheckmark: true,
-                    duration: 5000,
-                });
-            }, 500);
+                if (totalCredentials === 0) {
+                    presentToast(
+                        `No credentials could be extracted from ${fileList}. Your file is stored in your wallet.`,
+                        {
+                            title: `${typeLabel} saved`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else if (totalCredentials === 1) {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${typeLabel} ${fileList} Successfully Added`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${totalCredentials} credentials parsed from ${fileList}`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                }
+            }, TOAST_PAUSE_MS);
         } catch (error) {
             checklistStore.set.updateIsParsing(fileType, false);
             console.error('handleSaveResume::error', error);
@@ -538,6 +655,8 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
             const did = wallet?.id?.did();
             if (!did) throw new Error('Could not get wallet DID');
 
+            const aggregateRecordsByCategory: Partial<Record<CredentialCategory, string[]>> = {};
+
             // Process files sequentially to avoid race conditions
             for (const rawVC of rawArtifactCredentials) {
                 try {
@@ -571,6 +690,12 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
 
                         // Update the store with the new credentials
                         newCredsStore.set.addNewCreds(recordsByCategory);
+
+                        // Merge into aggregate for the toast
+                        for (const [cat, uris] of Object.entries(recordsByCategory)) {
+                            const existing = aggregateRecordsByCategory[cat as CredentialCategory] ?? [];
+                            aggregateRecordsByCategory[cat as CredentialCategory] = [...existing, ...uris];
+                        }
                     }
 
                     onFileSettled();
@@ -581,21 +706,54 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 }
             }
 
-            // Only update these if all files were processed
-            await fetchNewContractCredentials();
-            await refetchCheckListStatus();
+            const allCategoryValues = Object.values(aggregateRecordsByCategory);
+            const totalCredentials = allCategoryValues.reduce((sum, uris) => sum + uris.length, 0);
+            const categories = Object.keys(aggregateRecordsByCategory);
+            const filenames = rawArtifactCredentials.map(r => r?.rawArtifact?.fileName);
+
+            // Background sync — don't block toast on these
+            fetchNewContractCredentials().catch(err =>
+                console.error('fetchNewContractCredentials failed', err)
+            );
+            refetchCheckListStatus().catch(err =>
+                console.error('refetchCheckListStatus failed', err)
+            );
             syncAll.mutate();
             aiInsightMutation.mutate();
             closeModal();
+
+            const typeLabel = formatTypeLabel(fileType);
+            const typeLabelPlural = formatTypeLabel(fileType, { plural: true });
+            const fileList = formatFileNameList(filenames);
+            const categoryList = formatCategoryList(categories);
+
             setTimeout(() => {
-                presentToast(`Your journey is now reflected in portable, trusted credentials.`, {
-                    title: `${fileType} Successfully Parsed`,
-                    hasDismissButton: true,
-                    type: ToastTypeEnum.Success,
-                    hasCheckmark: true,
-                    duration: 5000,
-                });
-            }, 500);
+                if (totalCredentials === 0) {
+                    presentToast(
+                        `No credentials could be extracted from ${fileList}. Your file is stored in your wallet.`,
+                        {
+                            title: `${typeLabelPlural} saved`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else if (totalCredentials === 1) {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${typeLabel} ${fileList} Successfully Added`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                } else {
+                    presentToast(
+                        `Successfully added to ${categoryList}.`,
+                        {
+                            title: `${totalCredentials} credentials parsed from ${fileList}`,
+                            ...SUCCESS_TOAST_OPTIONS,
+                        }
+                    );
+                }
+            }, TOAST_PAUSE_MS);
         } catch (error) {
             console.error('Error in parseFiles:', error);
             checklistStore.set.updateIsParsing(fileType, false);

--- a/packages/learn-card-base/src/hooks/useWallet.ts
+++ b/packages/learn-card-base/src/hooks/useWallet.ts
@@ -266,7 +266,7 @@ export const useWallet = () => {
         metadata: Partial<{ title: string; imgUrl: string }> = {},
         location: 'SQLite' | 'LearnCloud' = 'LearnCloud',
         skipLCNUser?: boolean // skip steps requiring a LCN account eg didweb
-    ): Promise<{ result: boolean; credentialUri: string }> => {
+    ): Promise<{ result: boolean; credentialUri: string; category: string }> => {
         const { title, imgUrl } = metadata;
         const _id = vc.id || uuidv4();
         let returnUri: string | undefined;
@@ -365,6 +365,7 @@ export const useWallet = () => {
             return {
                 result: result ?? false,
                 credentialUri: returnUri ?? '',
+                category,
             };
         } catch (e) {
             console.error(vc, e);


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Fixes: [LC-1792](https://welibrary.atlassian.net/browse/LC-1792)

#### 📚 What is the context and goal of this PR?

After uploading an artifact in Build My LearnCard, the success toast had four problems: (1) lowercase, bare type label ("certificate Successfully Parsed"); (2) no filename or target wallet category in the body; (3) auto-dismissed after 5s, easy to miss; (4) appeared 5–6s *after* the in-step "Processing finished" UI flipped off. Multi-file uploads also fired a "Successfully Parsed" toast even when zero credentials were actually extracted. Manual testing surfaced three additional bugs that are also fixed here.

#### 🥴 TL; RL:

Capitalize types, include filename + target wallet categories, make the toast persistent, and fire it immediately when parsing completes (run the post-parse query refreshes fire-and-forget). Add an empty-extraction guard. Plus three bug fixes uncovered during testing.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

https://www.loom.com/share/8d7a02808659440ea6bfbccd2167e3b0

**Toast copy & timing** (the headline change):
- New shared toast helpers in `useUploadFile.tsx`: `formatTypeLabel`, `formatFileNameList`, `formatCategoryList`, plus a `SUCCESS_TOAST_OPTIONS` constant and `TOAST_PAUSE_MS = 100`.
- Refactored four toast call sites: `parseFiles` (multi-file Certs/Diplomas), `parseFile` (Resume single), `storeSelectedCredentials` (post-review-modal Resume/Transcript), and `getJsonFiles` (raw VC). Plus the standalone toast in `CheckListUploadRawVC.tsx`.
- Toast fires immediately after parsing finishes; `refetchCheckListStatus`, `fetchNewContractCredentials`, and the sync mutations now run fire-and-forget. The 500ms `setTimeout` is reduced to `TOAST_PAUSE_MS` (100ms).
- Persistent toast (`autoDismiss: false` + `hasDismissButton: true`); error toasts still auto-dismiss at 5s.

**New copy patterns:**

Successful extraction (any path):
> **N credentials parsed from "X.pdf"**
> Successfully added to Achievements, Skills, and Work.

Multi-file with some files contributing and some not:
> **2 credentials parsed from "a.pdf" and "b.pdf"**
> Successfully added to Portfolio. No credentials were parsed from "c.pdf".

Empty extraction (file saved, AI couldn't pull anything from it):
> **Certificate "NavyAchievementMedal.pdf" saved**
> No credentials could be extracted from this file.

Type labels track file count: "Diploma saved" for one file, "Diplomas saved" for multiple. The "Resume "X.pdf" Successfully Added to [Category]" framing from the original JIRA spec was dropped — it conflated artifact PDFs (which aren't categorized) with credentials extracted from them (which are).

**Bug fixes uncovered during manual testing:**

1. `fetchNewContractCredentials` was discarding the promise from `queryClient.refetchQueries()`, so calling `fetchNewContractCredentials().catch(...)` was `undefined.catch()` — a synchronous TypeError that bubbled to the outer `catch` and fired a red "Something went wrong uploading your diploma" toast even when the upload succeeded. Fixed by returning the promise.
2. The success toast was rendering "Successfully added to ." with an empty category list. Root cause: every upload path destructured `(await storeAndAddVCToWallet(issuedVc)).result` (a boolean) as `{ category, uri }`, both undefined, so the reducer guard skipped every entry. Fixed by adding `category` to the `storeAndAddVCToWallet` return object (it already computes it internally) and updating the three call sites in `useUploadFile.tsx` to grab `credentialUri` and `category` from the result.
3. The empty-extraction body line "Your file is stored in your wallet" was misleading — the artifact PDF is saved as part of the wizard step's record, not as a categorized credential the user can find under any wallet category. Removed.



#### 🛠 Important tradeoffs made:

- `refetchCheckListStatus` and `fetchNewContractCredentials` are now fire-and-forget (`.catch(console.error)`). This is the source of the perceived speedup — those are sibling-query refreshes, not user-facing data on this screen, so blocking the toast on them was wrong. If they fail, the next mount or natural refetch will catch up; the wallet itself is the source of truth.
- Empty-extraction toast keeps the success styling (green checkmark) per design call — the file *was* saved, it just didn't yield credentials. Reads kinder than an error toast for what's effectively a "limited result" outcome.
- `storeAndAddVCToWallet` now returns an extra `category` field. Backwards-compatible — existing callers reading `.result` / `.credentialUri` are unaffected; only new callers can opt in.
- Diverged from the JIRA's literal example wording (`Certificate "X.pdf" successfully added to [Category]`) since the artifact-vs-credential mismatch made it inaccurate. Used the JIRA's other example pattern (`Credentials Parsed from "X.pdf"`) consistently across all counts.
- Multi-file uploads still process sequentially — there's a "to avoid race conditions" comment in the loop, and parallelization is out of scope. Worth a follow-up.

#### 🔍 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. LaunchPad → Build My LearnCard.
2. **Single credential auto-extraction (Certs/Diplomas):** upload one Certificate PDF that yields one credential. Toast title: `1 credential parsed from "filename.pdf"`. Body: `Successfully added to [category].` Toast persists until you click X.
3. **Multi-credential review flow (Resume/Transcript):** upload a Resume that yields multiple credentials, confirm in the review modal. Toast title: `N credentials parsed from "filename.pdf"`. Body lists all destination categories.
4. **Multi-file all contribute (Certs/Diplomas):** upload 2–3 PDFs that each yield credentials. Title: `N credentials parsed from "a.pdf", "b.pdf", and "c.pdf"`. Body: `Successfully added to [categories].`
5. **Multi-file mixed (some yield, some don't):** upload 2–3 PDFs where at least one is unparseable. Title only lists contributing files; body appends `No credentials were parsed from "x.pdf".`
6. **Empty extraction, single file:** upload a PDF the AI can't extract anything from (e.g., the diploma supplement that previously triggered a red error). Title: `Diploma "filename.pdf" saved`. Body: `No credentials could be extracted from this file.` Green/success styling, NOT red error.
7. **Empty extraction, multi-file:** upload 2 unparseable PDFs. Title pluralizes: `Diplomas "a.pdf" and "b.pdf" saved`. Body: `No credentials could be extracted from these files.`
8. **Raw VC JSON paste:** paste a JSON VC in the Raw VC step. Toast persists with new copy.
9. **Timing:** in DevTools, throttle the network ("Slow 3G") on the brain-service host. Confirm the toast appears within ~150ms of the in-step "Processing your X in the background…" chip flipping off, *not* 5–6s later.
10. **Persistence:** trigger any of the above. Don't dismiss. Toast stays until you click X or navigate away.

#### 📱 🖥 Which devices would you like help testing on?

Chromium primary (deploy preview Netlify URL). iOS Native / Android Native sanity check welcome.

#### 🧪 Code Coverage

No new tests. Change is UX-timing + copy + an empty-extraction guard + three small bug fixes; all covered by the manual QA above. Existing e2e suite continues to pass.

# Documentation

#### 📝 Documentation Checklist

None of the user-facing or internal docs apply.

#### 💭 Documentation Notes

Internal UX polish + bug fixes; no API, SDK, or documented flow changes. The new `category` field on `storeAndAddVCToWallet` return is additive and not yet documented anywhere; can be picked up in the next docs pass if/when that hook is documented externally.

# ✅ PR Checklist

- [x] Related to a Jira issue
- [x] My code follows **style guidelines** (eslint / prettier)
- [x] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have completed the **Documentation Checklist** above (or explained why N/A)
- [x] I have considered **product analytics** for user-facing features

### 🚀 Ready to squash-and-merge?

- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change.
- [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LC-1792]: https://welibrary.atlassian.net/browse/LC-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ