### PR TITLE
fix: [LC-1788] Bug fest polishes

### DIFF
--- a/.changeset/nice-dogs-battle.md
+++ b/.changeset/nice-dogs-battle.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: [LC-1788] Bug fest polishes

--- a/apps/learn-card-app/src/components/mobile-nav-bar/MobileNavBar.tsx
+++ b/apps/learn-card-app/src/components/mobile-nav-bar/MobileNavBar.tsx
@@ -116,6 +116,7 @@ const MobileNavBar: React.FC = () => {
                             backgroundPosition: 'center top',
                             backgroundRepeat: 'no-repeat',
                         }}
+                        className="!mb-[10px] pb-[5px]"
                     >
                         {/*
                             tab prop is needed to prevent hard refresh...

--- a/apps/learn-card-app/src/components/notifications/AppNotificationToast.tsx
+++ b/apps/learn-card-app/src/components/notifications/AppNotificationToast.tsx
@@ -78,18 +78,24 @@ const AppNotificationToast: React.FC<AppNotificationToastProps> = ({
 
     return (
         <div
-            className={`fixed top-0 left-0 right-0 z-[99999] flex justify-center pointer-events-none px-4 pt-3 transition-all duration-300 ease-out ${
+            className={`fixed top-0 left-0 right-0 z-[99999] flex justify-center pointer-events-none px-4 pt-3 transition-all duration-300 ease-out safe-area-top-margin ${
                 isLeaving ? 'opacity-0 -translate-y-2' : 'opacity-100 translate-y-0'
             }`}
-            style={{ animation: isLeaving ? undefined : 'slideDown 0.35s cubic-bezier(0.16, 1, 0.3, 1)' }}
+            style={{
+                animation: isLeaving ? undefined : 'slideDown 0.35s cubic-bezier(0.16, 1, 0.3, 1)',
+            }}
         >
             <div
                 onClick={handleTap}
-                className={`pointer-events-auto max-w-[420px] w-full rounded-2xl bg-gradient-to-r ${bgGradient} p-[1px] shadow-2xl ring-1 ${ringColor} ${isTappable ? 'cursor-pointer' : ''}`}
+                className={`pointer-events-auto max-w-[420px] w-full rounded-2xl bg-gradient-to-r ${bgGradient} p-[1px] shadow-2xl ring-1 ${ringColor} ${
+                    isTappable ? 'cursor-pointer' : ''
+                }`}
             >
                 <div className="flex items-start gap-3 rounded-2xl bg-white/95 backdrop-blur-xl px-4 py-3">
                     {/* App icon or bell */}
-                    <div className={`flex-shrink-0 w-10 h-10 rounded-xl overflow-hidden flex items-center justify-center bg-gradient-to-br ${bgGradient} shadow-sm`}>
+                    <div
+                        className={`flex-shrink-0 w-10 h-10 rounded-xl overflow-hidden flex items-center justify-center bg-gradient-to-br ${bgGradient} shadow-sm`}
+                    >
                         {notification.appIcon && !iconFailed ? (
                             <img
                                 src={notification.appIcon}

--- a/apps/learn-card-app/src/components/qrcode-scanner-button/QRCodeScannerButton.tsx
+++ b/apps/learn-card-app/src/components/qrcode-scanner-button/QRCodeScannerButton.tsx
@@ -9,13 +9,21 @@ import AdminToolsModal from '../../pages/adminToolsPage/AdminToolsModal/AdminToo
 
 import { BrandingEnum } from 'learn-card-base/components/headerBranding/headerBrandingHelpers';
 import { AdminToolOptionsEnum } from '../../pages/adminToolsPage/AdminToolsModal/admin-tools.helpers';
-import { useModal, ModalTypes, usePathQuery, useGetConnections, useGetCurrentLCNUser } from 'learn-card-base';
+import {
+    useModal,
+    ModalTypes,
+    usePathQuery,
+    useGetConnections,
+    useGetCurrentLCNUser,
+    useCurrentUser,
+} from 'learn-card-base';
 
 export const QRCodeScannerButton: React.FC<{ branding: BrandingEnum }> = ({ branding }) => {
     const query = usePathQuery();
     const history = useHistory();
     const { data: connections } = useGetConnections();
     const { currentLCNUser } = useGetCurrentLCNUser();
+    const currentUser = useCurrentUser();
 
     const showTokenDevTools = query.get('showTokenDevTools');
     const showSigningAuthorityDevTools = query.get('showSigningAuthorityDevTools');
@@ -74,7 +82,7 @@ export const QRCodeScannerButton: React.FC<{ branding: BrandingEnum }> = ({ bran
                     customContainerClass="flex justify-center items-center h-[48px] w-[48px] rounded-full overflow-hidden border-white border-solid border-2 text-white font-medium text-xl min-w-[48px] min-h-[48px]"
                     customImageClass="flex justify-center items-center h-[48px] w-[48px] rounded-full overflow-hidden object-cover border-white border-solid border-2 min-w-[48px] min-h-[48px]"
                     customSize={120}
-                    user={currentLCNUser}
+                    user={currentLCNUser ?? currentUser}
                 />
             </button>
             <button

--- a/apps/learn-card-app/src/pages/launchPad/AppStoreListItem.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/AppStoreListItem.tsx
@@ -15,6 +15,7 @@ import GuardianConsentLaunchModal from './GuardianConsentLaunchModal';
 import AiTutorConnectedView from './AiTutorConnectedView';
 import { useGuardianGate } from '../../hooks/useGuardianGate';
 import { checkAppInstallEligibility } from '@learncard/helpers';
+import { openExternalLink } from '../../helpers/externalLinkHelpers';
 
 type AppStoreListItemProps = {
     listing: AppStoreListing | InstalledApp;
@@ -245,7 +246,7 @@ const AppStoreListItem: React.FC<AppStoreListItemProps> = ({
                 />
             );
         } else if (listing.launch_type === 'DIRECT_LINK' && launchConfig.url) {
-            window.open(launchConfig.url, '_blank');
+            await openExternalLink(launchConfig.url);
         } else if (listing.launch_type === 'SECOND_SCREEN' && launchConfig.url) {
             window.open(launchConfig.url, '_blank');
         } else {

--- a/apps/learn-card-app/src/pages/launchPad/LaunchPadHeader/LaunchPadActionModal.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/LaunchPadHeader/LaunchPadActionModal.tsx
@@ -555,7 +555,7 @@ const LaunchPadActionModal: React.FC<{ showFooterNav?: boolean }> = ({ showFoote
 
     const profileType = switchedProfileStore.use.profileType();
     const isChildProfile = profileType === 'child';
-    const { isAiEnabled } = useAiFeatureGate();
+    const { isAiEnabled, isLoading: isAiFeatureLoading } = useAiFeatureGate();
 
     const selectedBorderColor: Record<LearnCardRolesEnum, string> = {
         [LearnCardRolesEnum.learner]: '#5EEAD4',
@@ -824,51 +824,58 @@ const LaunchPadActionModal: React.FC<{ showFooterNav?: boolean }> = ({ showFoote
             </div>
 
             <div className="mt-1 flex flex-wrap justify-center gap-4">
-                {actions.map((label, i) => (
-                    <ActionButton
-                        key={`${label}-${i}`}
-                        label={label}
-                        bg={
-                            !actionModalButtonColors
-                                ? colorByLabel[label] ?? bgColors[i % bgColors.length]
-                                : ''
-                        }
-                        bgHex={
-                            actionModalButtonColors
-                                ? actionModalButtonColors[i % actionModalButtonColors.length]
-                                : undefined
-                        }
-                        textColor={actionModalTextColor}
-                        borderColor={actionModalButtonBorderColor}
-                        role={activeRole}
-                        onClick={
-                            label === 'View Family' && familyUri
-                                ? () => {
-                                      closeModal();
-                                      newModal(
-                                          <FamilyBoostPreviewWrapper uri={familyUri} />,
-                                          {},
-                                          {
-                                              desktop: ModalTypes.FullScreen,
-                                              mobile: ModalTypes.FullScreen,
-                                          }
-                                      );
-                                      history.push('/families');
-                                  }
-                                : label === 'View Learner Insights'
-                                ? handleViewLearnerInsights
-                                : label === 'View Child Insights'
-                                ? handleViewChildInsights
-                                : label === 'Edit Skills Frameworks'
-                                ? handleEditSkillsFrameworks
-                                : label === 'Request Learner Insights'
-                                ? () => void handleRequestLearnerInsights()
-                                : label === 'Add to LearnCard'
-                                ? handleAddToLearnCard
-                                : undefined
-                        }
-                    />
-                ))}
+                {isAiFeatureLoading
+                    ? Array.from({ length: 6 }).map((_, i) => (
+                          <div
+                              key={`skeleton-${i}`}
+                              className="w-[calc(50%-0.5rem)] md:w-[calc(33.333%-0.67rem)] h-[160px] rounded-[20px] bg-grayscale-200 animate-pulse"
+                          />
+                      ))
+                    : actions.map((label, i) => (
+                          <ActionButton
+                              key={`${label}-${i}`}
+                              label={label}
+                              bg={
+                                  !actionModalButtonColors
+                                      ? colorByLabel[label] ?? bgColors[i % bgColors.length]
+                                      : ''
+                              }
+                              bgHex={
+                                  actionModalButtonColors
+                                      ? actionModalButtonColors[i % actionModalButtonColors.length]
+                                      : undefined
+                              }
+                              textColor={actionModalTextColor}
+                              borderColor={actionModalButtonBorderColor}
+                              role={activeRole}
+                              onClick={
+                                  label === 'View Family' && familyUri
+                                      ? () => {
+                                            closeModal();
+                                            newModal(
+                                                <FamilyBoostPreviewWrapper uri={familyUri} />,
+                                                {},
+                                                {
+                                                    desktop: ModalTypes.FullScreen,
+                                                    mobile: ModalTypes.FullScreen,
+                                                }
+                                            );
+                                            history.push('/families');
+                                        }
+                                      : label === 'View Learner Insights'
+                                      ? handleViewLearnerInsights
+                                      : label === 'View Child Insights'
+                                      ? handleViewChildInsights
+                                      : label === 'Edit Skills Frameworks'
+                                      ? handleEditSkillsFrameworks
+                                      : label === 'Request Learner Insights'
+                                      ? () => void handleRequestLearnerInsights()
+                                      : label === 'Add to LearnCard'
+                                      ? handleAddToLearnCard
+                                      : undefined
+                              }
+                          />
+                      ))}
             </div>
             <div
                 className={`rounded-[15px] shadow-[0_2px_6px_0_rgba(0,0,0,0.25)] py-[10px] ${


### PR DESCRIPTION
# Overview
This PR...

1. Adds `safe-area-top-margin` to AppNotificationToast so on native when a connected app using partner-sdk calls `sendNotification` while the app is open it won't cut off the toast message on top of the screen.
2. On native, opens direct links using the inappbrowser.
3. The profile icon flashes a # sign frequently and flashes. I was only able to test this in production on my phone, so I'm not sure if the fix windsurf came up with will fix it. 
4. I added a loading state with skeleton icons for the action buttons to prevent only two items populating for a learner when useAiFeatureGate() is loading whether or not Ai is enabled for the user. This issue I was also only able to replicate in appetize and not locally.
5. I added margin-bottom and padding-bottom to the mobile nav bar, so its not at the very bottom of the screen.

#### 🎟 Relevant Jira Issues
https://welibrary.atlassian.net/browse/LC-1788

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
https://www.loom.com/share/929ec07b9165432ca40ec07906e7b37b

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [ ] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix multiple UI/UX polish issues including notification toast animations, profile picture fallback logic, and external link handling to improve user experience and visual consistency.

Main changes:
- Add skeleton loading states for action modal buttons while AI feature gate loads to prevent layout shift
- Fix profile picture component to fallback to currentUser when currentLCNUser is unavailable, preventing blank avatars
- Replace direct window.open with openExternalLink helper for DIRECT_LINK launch type to ensure proper external link handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
