### PR TITLE
Fix Didkit Node CI

### DIFF
--- a/.changeset/fix-didkit-node-publish.md
+++ b/.changeset/fix-didkit-node-publish.md
@@ -1,0 +1,6 @@
+---
+"@learncard/didkit-plugin-node": patch
+"@learncard/init": patch
+---
+
+Fix native DIDKit package publishing and make the Node-native package optional for init consumers.

--- a/.github/workflows/didkit-plugin-node-prebuilds.yml
+++ b/.github/workflows/didkit-plugin-node-prebuilds.yml
@@ -177,14 +177,18 @@ jobs:
         needs: build
         if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        env:
+            NPM_CONFIG_PROVENANCE: "true"
         steps:
             - uses: actions/checkout@v4
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
-                  registry-url: 'https://registry.npmjs.org'
+                  node-version: 24.12.0
 
             - name: Install pnpm
               uses: pnpm/action-setup@v2
@@ -197,12 +201,16 @@ jobs:
             - name: Download all artifacts
               uses: actions/download-artifact@v4
               with:
-                  path: packages/plugins/didkit-plugin-node
+                  path: packages/plugins/didkit-plugin-node/artifacts
                   pattern: bindings-*
                   merge-multiple: true
 
             - name: List downloaded binaries
-              run: ls -la packages/plugins/didkit-plugin-node/*.node
+              run: ls -la packages/plugins/didkit-plugin-node/artifacts/*.node
+
+            - name: Create platform package directories
+              working-directory: packages/plugins/didkit-plugin-node
+              run: pnpm create-npm-dir
 
             - name: Move artifacts to platform packages
               working-directory: packages/plugins/didkit-plugin-node
@@ -213,21 +221,8 @@ jobs:
 
             - name: Publish platform packages
               working-directory: packages/plugins/didkit-plugin-node
-              run: pnpm exec napi prepublish -t npm
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: pnpm exec napi prepublish -t npm --skip-gh-release
 
             - name: Publish to npm
-              run: |
-                  cd packages/plugins/didkit-plugin-node
-                  for dir in npm/*; do
-                    if [ -d "$dir" ]; then
-                      echo "Publishing $dir..."
-                      cd "$dir"
-                      npm publish --access public || true
-                      cd ../..
-                    fi
-                  done
-                  npm publish --access public || true
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              working-directory: packages/plugins/didkit-plugin-node
+              run: npm publish --access public --ignore-scripts

--- a/packages/learn-card-init/package.json
+++ b/packages/learn-card-init/package.json
@@ -53,7 +53,6 @@
         "@learncard/crypto-plugin": "workspace:*",
         "@learncard/didkey-plugin": "workspace:*",
         "@learncard/didkit-plugin": "workspace:*",
-        "@learncard/didkit-plugin-node": "workspace:*",
         "@learncard/did-web-plugin": "workspace:*",
         "@learncard/dynamic-loader-plugin": "workspace:*",
         "@learncard/encryption-plugin": "workspace:*",
@@ -68,6 +67,9 @@
         "@learncard/vc-plugin": "workspace:*",
         "@learncard/vc-templates-plugin": "workspace:*",
         "@learncard/vpqr-plugin": "workspace:*"
+    },
+    "optionalDependencies": {
+        "@learncard/didkit-plugin-node": "workspace:*"
     },
     "sideEffects": false
 }

--- a/packages/plugins/didkit-plugin-node/package.json
+++ b/packages/plugins/didkit-plugin-node/package.json
@@ -12,12 +12,12 @@
     "napi": {
         "name": "index",
         "triples": {
-            "defaults": true,
+            "defaults": false,
             "additional": [
                 "x86_64-unknown-linux-gnu",
                 "aarch64-unknown-linux-gnu",
-                "x86_64-unknown-linux-musl",
-                "aarch64-unknown-linux-musl"
+                "x86_64-apple-darwin",
+                "aarch64-apple-darwin"
             ]
         }
     },
@@ -26,10 +26,14 @@
         "build:debug": "napi build --platform --cargo-cwd native && tsc -p tsconfig.json",
         "test": "jest --passWithNoTests",
         "artifacts": "napi artifacts",
-        "prepublishOnly": "napi prepublish -t npm"
+        "create-npm-dir": "napi create-npm-dir -t .",
+        "prepublishOnly": "napi prepublish -t npm --skip-gh-release"
     },
     "author": "Learning Economy Foundation (www.learningeconomy.io)",
     "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/WeLibraryOS/LearnCard.git"

--- a/packages/plugins/didkit-plugin-node/src/plugin.ts
+++ b/packages/plugins/didkit-plugin-node/src/plugin.ts
@@ -42,6 +42,43 @@ interface NativeAddon {
 
 let nativeAddon: NativeAddon | null = null;
 
+function isMusl(): boolean {
+    if (process.platform !== 'linux') return false;
+
+    if (!process.report || typeof process.report.getReport !== 'function') {
+        try {
+            const lddPath = require('child_process').execSync('which ldd').toString().trim();
+            return require('fs').readFileSync(lddPath, 'utf8').includes('musl');
+        } catch {
+            return true;
+        }
+    }
+
+    const report = process.report.getReport() as { header?: { glibcVersionRuntime?: string } };
+    const { glibcVersionRuntime } = report.header ?? {};
+    return !glibcVersionRuntime;
+}
+
+function getNativePackageName(): string | undefined {
+    const packagePrefix = '@learncard/didkit-plugin-node';
+
+    switch (process.platform) {
+        case 'darwin':
+            if (process.arch === 'x64') return `${packagePrefix}-darwin-x64`;
+            if (process.arch === 'arm64') return `${packagePrefix}-darwin-arm64`;
+            return undefined;
+
+        case 'linux':
+            if (isMusl()) return undefined;
+            if (process.arch === 'x64') return `${packagePrefix}-linux-x64-gnu`;
+            if (process.arch === 'arm64') return `${packagePrefix}-linux-arm64-gnu`;
+            return undefined;
+
+        default:
+            return undefined;
+    }
+}
+
 function loadNativeAddon(): NativeAddon {
     if (nativeAddon) return nativeAddon;
 
@@ -55,19 +92,24 @@ function loadNativeAddon(): NativeAddon {
         const packageJson = require.resolve('@learncard/didkit-plugin-node/package.json');
         const packageRoot = path.dirname(packageJson);
 
-        // Try to find the platform-specific .node file
+        // Local CI and service deploys place the compiled binding in this package root.
         const files = fs.readdirSync(packageRoot);
         const nodeFile = files.find((f: string) => f.startsWith('index.') && f.endsWith('.node'));
 
-        if (!nodeFile) {
+        if (nodeFile) {
+            nativeAddon = require(path.join(packageRoot, nodeFile)) as NativeAddon;
+            return nativeAddon;
+        }
+
+        const nativePackageName = getNativePackageName();
+
+        if (!nativePackageName) {
             throw new Error(
-                `No .node binary found in ${packageRoot}. Files: ${files.join(
-                    ', '
-                )}. Run 'pnpm build' to compile.`
+                `No prebuilt binary is available for ${process.platform}/${process.arch}.`
             );
         }
 
-        nativeAddon = require(path.join(packageRoot, nodeFile)) as NativeAddon;
+        nativeAddon = require(nativePackageName) as NativeAddon;
         return nativeAddon;
     } catch (error) {
         throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1898,9 +1898,6 @@ importers:
       '@learncard/didkit-plugin':
         specifier: workspace:*
         version: link:../plugins/didkit
-      '@learncard/didkit-plugin-node':
-        specifier: workspace:*
-        version: link:../plugins/didkit-plugin-node
       '@learncard/dynamic-loader-plugin':
         specifier: workspace:*
         version: link:../plugins/dynamic-loader
@@ -1940,6 +1937,10 @@ importers:
       '@learncard/vpqr-plugin':
         specifier: workspace:*
         version: link:../plugins/vpqr
+    optionalDependencies:
+      '@learncard/didkit-plugin-node':
+        specifier: workspace:*
+        version: link:../plugins/didkit-plugin-node
     devDependencies:
       '@types/jest':
         specifier: ^29.2.2


### PR DESCRIPTION
Fixes #1230

# Overview

#### 🎟 Relevant Jira Issues

N/A

#### 📚 What is the context and goal of this PR?

`@learncard/init@2.3.16` was published with a hard dependency on `@learncard/didkit-plugin-node@0.2.14`, but npm only has `@learncard/didkit-plugin-node@0.2.2` published. That breaks consumers like `npx @learncard/cli` even when they are not using the Node-native DIDKit path.

The mismatch happened because normal releases intentionally exclude `@learncard/didkit-plugin-node`, while the dedicated native prebuild workflow was not publishing successfully. Recent runs either failed during install or appeared green while npm publishing failed behind `|| true`.

This PR fixes the dedicated publish workflow, makes the native DIDKit dependency optional for `@learncard/init`, and updates the native loader to use N-API platform packages when a local `.node` file is not bundled in the root package.

#### 🥴 TL; RL:

Fix DIDKit Node publishing so `0.2.14` can actually be published, and prevent CLI installs from hard-failing when this optional native package lags behind normal releases.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

-   Fixes `.github/workflows/didkit-plugin-node-prebuilds.yml` so artifacts are downloaded where `napi artifacts` expects them.
-   Creates N-API platform package directories before moving artifacts.
-   Removes `|| true` publish masking so failed publishes fail the workflow.
-   Uses npm trusted publishing/provenance permissions instead of relying on the stale token path.
-   Limits advertised native targets to the four targets this workflow actually builds: Linux x64 glibc, Linux arm64 glibc, macOS x64, macOS arm64.
-   Makes `@learncard/didkit-plugin-node` an optional dependency of `@learncard/init`.
-   Adds platform-package fallback loading in `@learncard/didkit-plugin-node` when no local `.node` file exists.

#### 🛠 Important tradeoffs made:

-   MUSL and Windows platform packages are no longer advertised by this package metadata because this workflow is not currently building those binaries.
-   Native DIDKit remains available via `didkit: 'node'`, but package installs no longer fail for users who do not need the native path.
-   The workflow now fails loudly on publish errors, so future native publish breakages should block visibly instead of silently leaving npm behind.

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Merge this PR to `main`.
2. Run the **DIDKit Plugin Node Prebuilds** workflow on `main`.
3. Confirm the workflow publishes `@learncard/didkit-plugin-node@0.2.14` and its platform packages.
4. Confirm `npm view @learncard/didkit-plugin-node version` returns `0.2.14`.
5. Confirm `npx @learncard/cli` no longer fails because of a missing `@learncard/didkit-plugin-node@0.2.14`.

Local checks run:

```bash
npm view @learncard/didkit-plugin-node version versions --json
npm view @learncard/init@2.3.16 dependencies.@learncard/didkit-plugin-node version --json
pnpm build
node -e "const { getDidKitPlugin } = require('./packages/plugins/didkit-plugin-node/dist'); getDidKitPlugin().then(p => console.log(p.name)).catch(err => { console.error(err); process.exit(1); });"
git diff --check
```

#### 📱 🖥 Which devices would you like help testing on?

N/A. This is CI/package publishing work. Useful runtime coverage is Linux x64 glibc, Linux arm64 glibc, macOS x64, and macOS arm64.

#### 🧪 Code Coverage

No new unit tests were added. This change is primarily GitHub Actions publishing configuration plus package metadata and loader fallback logic. The native package TypeScript build and local native load smoke test pass.

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [x] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

No user-facing docs needed. This fixes internal publishing/release plumbing and package install resilience.

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix DIDKit Node native package publishing pipeline and improve runtime platform detection for prebuilt binary loading.

Main changes:
- Added platform detection functions `isMusl()` and `getNativePackageName()` to handle fallback native addon loading across Linux/macOS architectures
- Restructured CI workflow to use npm provenance, explicit artifact paths, and napi prepublish command for proper platform package publishing
- Made `@learncard/didkit-plugin-node` optional dependency in learn-card-init; updated napi config to disable defaults and add macOS targets

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
