### PR TITLE
chore(release): bump @learncard/init + @learncard/cli to deliver didkit-plugin-node@0.2.15 fix

### DIFF
--- a/.changeset/fix-didkit-node-publish.md
+++ b/.changeset/fix-didkit-node-publish.md
@@ -1,6 +1,0 @@
----
-"@learncard/didkit-plugin-node": patch
-"@learncard/init": patch
----
-
-Fix native DIDKit package publishing, publish the Node-native package with rewritten workspace dependencies, and make the Node-native package optional for init consumers.

--- a/packages/learn-card-cli/package.json
+++ b/packages/learn-card-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@learncard/cli",
-    "version": "3.3.174",
+    "version": "3.3.175",
     "description": "Test out learn card!",
     "main": "dist/index.js",
     "bin": "dist/index.js",

--- a/packages/learn-card-init/package.json
+++ b/packages/learn-card-init/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@learncard/init",
-    "version": "2.3.16",
+    "version": "2.3.17",
     "description": "",
     "type": "module",
     "main": "./dist/index.cjs",


### PR DESCRIPTION
## TL;DR

`npx @learncard/cli` is currently broken in the wild with:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

The bad `workspace:*` literal lives in `@learncard/didkit-plugin-node@0.2.14`. Taylor already fixed the publishing pipeline and shipped a clean `0.2.15`, but the latest CLI on npm still transitively resolves to the broken `0.2.14` because of an exact pin in `@learncard/init@2.3.16`. This PR republishes `@learncard/init` (and `@learncard/cli` for a fresh user-facing version) so the fix actually propagates.

## Root cause

The transitive resolution chain for `npx @learncard/cli@latest`:

```
@learncard/cli@3.3.174                                  ✅ clean deps
  └─ "@learncard/init": "^2.3.16"
       resolves → @learncard/init@2.3.16                ⚠️ published 2026-05-12, BEFORE the didkit-node fix
            └─ optionalDependencies:
                 "@learncard/didkit-plugin-node": "0.2.14"   ⚠️ EXACT pin to the broken version
                    resolves → @learncard/didkit-plugin-node@0.2.14   ❌ THE BROKEN ARTIFACT
                         ├─ "@learncard/core":          "workspace:*"   ← literal string
                         ├─ "@learncard/types":         "workspace:*"   ← literal string
                         └─ "@learncard/didkit-plugin": "workspace:*"   ← literal string
```

Because the pin is exact (`0.2.14` not `^0.2.14`), npm cannot float forward to `0.2.15` even though the fix exists. `optionalDependencies` does **not** save us here—the workspace protocol error fires during `buildIdealTree` (dep-graph resolution), before npm even gets to "install or skip". So the whole `npx` install bails out.


