### PR TITLE
fix: CapGo Drift

### DIFF
--- a/.changeset/tidy-clocks-battle.md
+++ b/.changeset/tidy-clocks-battle.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: CapGo Drift

--- a/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
+++ b/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
@@ -41,8 +41,7 @@
 		},
 		"CapacitorUpdater": {
 			"appId": "com.learncard.app",
-			"autoUpdate": true,
-			"defaultChannel": "1.0.6"
+			"autoUpdate": true
 		}
 	},
 	"packageClassList": [

--- a/apps/learn-card-app/environments/vetpass/assets/config/capacitor.config.json
+++ b/apps/learn-card-app/environments/vetpass/assets/config/capacitor.config.json
@@ -41,8 +41,7 @@
 		},
 		"CapacitorUpdater": {
 			"appId": "com.vetpass.app",
-			"autoUpdate": true,
-			"defaultChannel": "1.0.6"
+			"autoUpdate": true
 		}
 	},
 	"packageClassList": [

--- a/apps/learn-card-app/scripts/prepare-native-config.ts
+++ b/apps/learn-card-app/scripts/prepare-native-config.ts
@@ -42,6 +42,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, cpSync, readdirSync, statSync, rmSync } from 'fs';
+import { createRequire } from 'module';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -49,6 +50,11 @@ import { tenantConfigSchema } from 'learn-card-base/src/config/tenantConfigSchem
 import { DEFAULT_LEARNCARD_TENANT_CONFIG } from 'learn-card-base/src/config/tenantDefaults';
 import { deepMerge } from 'learn-card-base/src/config/deepMerge';
 import type { TenantConfig } from 'learn-card-base/src/config/tenantConfigSchema';
+
+const requireFromHere = createRequire(import.meta.url);
+const { readDefaultChannel } = requireFromHere('../../../tools/capgo/readDefaultChannel.cjs') as {
+    readDefaultChannel: (configPath: string) => string | undefined;
+};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -482,33 +488,26 @@ console.log(`   Sections: ${Object.keys(validatedConfig).join(', ')}`);
 
 const nativeConfig = validatedConfig.native;
 
-// SSOT for the Capgo channel is `defaultChannel` in capacitor.config.ts.
-// This regex MUST stay in sync with `tools/capgo/getCapgoChannel.js` (used by CI
-// to pick the OTA upload channel). Tenant asset capacitor.config.json files must
-// NOT specify defaultChannel — they are wholesale-copied over the cap-synced
-// platform JSONs in step 5b, so a tenant override silently drops binaries off
-// the CI upload channel (see PR #1063 incident).
-const readDefaultCapgoChannel = (): string | undefined => {
-    const tsPath = resolve(APP_ROOT, 'capacitor.config.ts');
-
-    if (!existsSync(tsPath)) return undefined;
-
-    const content = readFileSync(tsPath, 'utf-8');
-    const match = content.match(/defaultChannel:\s*['"]([^'"]+)['"]/);
-
-    return match?.[1];
-};
-
-const defaultCapgoChannel = readDefaultCapgoChannel();
+// SSOT for the Capgo channel is `defaultChannel` in capacitor.config.ts; we read
+// it through the shared `tools/capgo/readDefaultChannel.cjs` helper that CI also
+// uses (via tools/capgo/getCapgoChannel.js). Tenant asset capacitor.config.json
+// files must NOT specify defaultChannel — they are wholesale-copied over the
+// cap-synced platform JSONs in step 5b, so a tenant override silently drops
+// installed binaries off the channel CI uploads to (PR #1063 incident).
+const defaultCapgoChannel = readDefaultChannel(resolve(APP_ROOT, 'capacitor.config.ts'));
 
 if (nativeConfig) {
-    console.log('\n⚙️  Patching Capacitor config with tenant native settings...');
-
-    if (defaultCapgoChannel) {
-        console.log(`   Capgo defaultChannel (from capacitor.config.ts): ${defaultCapgoChannel}`);
-    } else {
-        console.warn('   ⚠️  Could not read defaultChannel from capacitor.config.ts — Capgo OTA channel will not be patched');
+    if (!defaultCapgoChannel) {
+        console.error('❌ Failed to read CapacitorUpdater.defaultChannel from capacitor.config.ts.');
+        console.error('   Aborting: writing platform JSONs without a Capgo channel would silently');
+        console.error('   diverge from CI (tools/capgo/getCapgoChannel.js reads the same SSOT for');
+        console.error('   the upload channel — installed binaries would fall back to the plugin');
+        console.error('   default and miss every OTA bundle).');
+        process.exit(1);
     }
+
+    console.log('\n⚙️  Patching Capacitor config with tenant native settings...');
+    console.log(`   Capgo defaultChannel (from capacitor.config.ts): ${defaultCapgoChannel}`);
 
     const patchCapacitorConfigJson = (jsonPath: string): void => {
         if (!existsSync(jsonPath)) return;
@@ -521,10 +520,7 @@ if (nativeConfig) {
 
             if (raw.plugins?.CapacitorUpdater) {
                 raw.plugins.CapacitorUpdater.appId = nativeConfig.bundleId;
-
-                if (defaultCapgoChannel) {
-                    raw.plugins.CapacitorUpdater.defaultChannel = defaultCapgoChannel;
-                }
+                raw.plugins.CapacitorUpdater.defaultChannel = defaultCapgoChannel;
             }
 
             writeFileSync(jsonPath, JSON.stringify(raw, null, 2) + '\n', 'utf-8');

--- a/apps/learn-card-app/scripts/prepare-native-config.ts
+++ b/apps/learn-card-app/scripts/prepare-native-config.ts
@@ -482,8 +482,33 @@ console.log(`   Sections: ${Object.keys(validatedConfig).join(', ')}`);
 
 const nativeConfig = validatedConfig.native;
 
+// SSOT for the Capgo channel is `defaultChannel` in capacitor.config.ts.
+// This regex MUST stay in sync with `tools/capgo/getCapgoChannel.js` (used by CI
+// to pick the OTA upload channel). Tenant asset capacitor.config.json files must
+// NOT specify defaultChannel — they are wholesale-copied over the cap-synced
+// platform JSONs in step 5b, so a tenant override silently drops binaries off
+// the CI upload channel (see PR #1063 incident).
+const readDefaultCapgoChannel = (): string | undefined => {
+    const tsPath = resolve(APP_ROOT, 'capacitor.config.ts');
+
+    if (!existsSync(tsPath)) return undefined;
+
+    const content = readFileSync(tsPath, 'utf-8');
+    const match = content.match(/defaultChannel:\s*['"]([^'"]+)['"]/);
+
+    return match?.[1];
+};
+
+const defaultCapgoChannel = readDefaultCapgoChannel();
+
 if (nativeConfig) {
     console.log('\n⚙️  Patching Capacitor config with tenant native settings...');
+
+    if (defaultCapgoChannel) {
+        console.log(`   Capgo defaultChannel (from capacitor.config.ts): ${defaultCapgoChannel}`);
+    } else {
+        console.warn('   ⚠️  Could not read defaultChannel from capacitor.config.ts — Capgo OTA channel will not be patched');
+    }
 
     const patchCapacitorConfigJson = (jsonPath: string): void => {
         if (!existsSync(jsonPath)) return;
@@ -496,6 +521,10 @@ if (nativeConfig) {
 
             if (raw.plugins?.CapacitorUpdater) {
                 raw.plugins.CapacitorUpdater.appId = nativeConfig.bundleId;
+
+                if (defaultCapgoChannel) {
+                    raw.plugins.CapacitorUpdater.defaultChannel = defaultCapgoChannel;
+                }
             }
 
             writeFileSync(jsonPath, JSON.stringify(raw, null, 2) + '\n', 'utf-8');

--- a/tools/capgo/check-channel-bump.js
+++ b/tools/capgo/check-channel-bump.js
@@ -26,6 +26,7 @@
 const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const { parseDefaultChannel } = require('./readDefaultChannel.cjs');
 
 const args = process.argv.slice(2);
 
@@ -115,13 +116,7 @@ const getChangedFiles = (baseSha, headSha) => {
 
 // --- Extractors -------------------------------------------------------------
 
-const extractDefaultChannel = (configContent) => {
-    if (!configContent) return null;
-
-    const m = configContent.match(/defaultChannel\s*:\s*['"]([^'"]+)['"]/);
-
-    return m ? m[1] : null;
-};
+const extractDefaultChannel = (configContent) => parseDefaultChannel(configContent) ?? null;
 
 const collectNativeDeps = (pkgJsonContent) => {
     if (!pkgJsonContent.trim()) return {};

--- a/tools/capgo/getCapgoChannel.js
+++ b/tools/capgo/getCapgoChannel.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { readDefaultChannel } = require('./readDefaultChannel.cjs');
 
 // ---- CLI ARG PARSING ----
 const args = process.argv.slice(2);
@@ -27,26 +28,18 @@ if (!appConfigPaths[app]) {
 // ROOT OF REPO (the directory this script lives in is tools/capgo/)
 const repoRoot = path.resolve(__dirname, '../../');
 
-// Paths
 const configPath = path.join(repoRoot, appConfigPaths[app]);
 
-// ---- READ FILE ----
 if (!fs.existsSync(configPath)) {
     console.error(`❌ capacitor.config.ts not found at: ${configPath}`);
     process.exit(1);
 }
 
-const configContent = fs.readFileSync(configPath, 'utf8');
+const channel = readDefaultChannel(configPath);
 
-// ---- PARSE CHANNEL ----
-const match = configContent.match(/defaultChannel:\s*['"](.+?)['"]/);
-
-if (!match) {
-    console.error('❌ Could not find "defaultChannel" in capacitor.config.ts');
+if (!channel) {
+    console.error(`❌ Could not find "defaultChannel" in ${configPath}`);
     process.exit(1);
 }
 
-const channel = match[1];
-
-// ---- OUTPUT ----
 console.log(channel);

--- a/tools/capgo/readDefaultChannel.cjs
+++ b/tools/capgo/readDefaultChannel.cjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// tools/capgo/readDefaultChannel.cjs
+//
+// Shared reader for the Capgo `defaultChannel` SSOT in an app's
+// `capacitor.config.ts`. Used by:
+//   - tools/capgo/getCapgoChannel.js (CI — picks OTA upload channel)
+//   - tools/capgo/check-channel-bump.js (CI — detects native compat breaks)
+//   - apps/learn-card-app/scripts/prepare-native-config.ts (build — patches platform JSONs)
+//
+// All consumers MUST go through this helper. Forking the regex re-introduces
+// the silent drift class fixed in PR #1063 (binaries listening on a different
+// channel than CI uploads to).
+
+const fs = require('fs');
+
+// Scoped to inside the `CapacitorUpdater: { ... }` block so a sibling plugin
+// that gains its own `defaultChannel` field can't accidentally shadow ours.
+// `[^}]*?` lazy-matches everything up to the first `}` after CapacitorUpdater.
+const CAPGO_CHANNEL_REGEX = /CapacitorUpdater\s*:\s*\{[^}]*?defaultChannel\s*:\s*['"]([^'"]+)['"]/;
+
+/**
+ * Parse the Capgo `defaultChannel` value out of a Capacitor config source
+ * string. Pure function — use this when the source comes from somewhere
+ * other than the local filesystem (e.g. `git show <sha>:<path>`).
+ *
+ * @param {string} content - capacitor.config.ts source
+ * @returns {string | undefined}
+ */
+function parseDefaultChannel(content) {
+    if (!content) return undefined;
+
+    return content.match(CAPGO_CHANNEL_REGEX)?.[1];
+}
+
+/**
+ * Read the Capgo `defaultChannel` value from a Capacitor config TS file on disk.
+ *
+ * @param {string} configPath - Absolute path to capacitor.config.ts
+ * @returns {string | undefined} - The channel value, or undefined if the file
+ *   can't be read or the regex doesn't match.
+ */
+function readDefaultChannel(configPath) {
+    let content;
+
+    try {
+        content = fs.readFileSync(configPath, 'utf-8');
+    } catch {
+        return undefined;
+    }
+
+    return parseDefaultChannel(content);
+}
+
+module.exports = { readDefaultChannel, parseDefaultChannel, CAPGO_CHANNEL_REGEX };


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [ ] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [ ] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [ ] I have **reviewed** my code
-   [ ] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [ ] Code is backwards compatible
-   [ ] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Capgo OTA channel configuration drift by dynamically reading defaultChannel from capacitor.config.ts instead of hardcoding it in tenant config files.

Main changes:
- Added `readDefaultCapgoChannel()` function to parse defaultChannel from capacitor.config.ts and sync it to CapacitorUpdater plugin config
- Removed hardcoded "defaultChannel": "1.0.6" from learncard and vetpass tenant capacitor.config.json files to prevent CI upload channel misalignment

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
