### PR TITLE
chore: LC-1844 - Central Logging System (LCA/ScoutPass)

### DIFF
--- a/.changeset/dirty-cities-chew.md
+++ b/.changeset/dirty-cities-chew.md
@@ -1,0 +1,7 @@
+---
+"learn-card-app": patch
+"scoutpass-app": patch
+"learn-card-base": patch
+---
+
+chore: LC-1844 - Central Logging System (LCA/ScoutPass)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
         '@typescript-eslint/no-shadow': 'warn',
         'max-len': 'off',
         'comma-dangle': 'off',
-        'no-console': 'off',
+        'no-console': 'off', // overridden per-app below
         'function-paren-newline': 'off',
         'implicit-arrow-linebreak': 'off',
         'arrow-body-style': 'off',
@@ -63,4 +63,13 @@ module.exports = {
         'import/no-extraneous-dependencies': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
     },
+    overrides: [
+        {
+            // Warn on direct console.* usage in app source — use logger from learn-card-base instead
+            files: ['apps/learn-card-app/src/**/*.{ts,tsx}', 'apps/scouts/src/**/*.{ts,tsx}'],
+            rules: {
+                'no-console': 'warn',
+            },
+        },
+    ],
 };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1250,15 +1250,15 @@ GDPR/COPPA-compliant privacy controls based on user age and country. Minors have
 
 ## Logging
 
-Central logger lives at `packages/learn-card-base/src/logging/logger.ts`, exported from `learn-card-base`.
+Central logger lives at `packages/learn-card-base/src/logging/logger.ts`, exported from `learn-card-base`. Full reference: `packages/learn-card-base/src/logging/README.md`.
 
 ### API
 
 ```ts
-import { logger, useLogger } from 'learn-card-base';
+import { logger, getLogger } from 'learn-card-base';
 
-// Module-level or top of a file (not a React hook — safe outside components)
-const log = useLogger('my-feature');
+// Module-level or top of a file
+const log = getLogger('my-feature');
 
 // Object meta
 log.info('user.navigated', { page: 'home' });
@@ -1281,9 +1281,9 @@ logger.withContext(scope => scope.setTag('flow', 'oid4vci'));
 
 ### Levels
 
-| Level | Dev | Prod (Sentry active) |
-|-------|-----|----------------------|
-| `debug` | `console.debug` | **dropped** |
+| Level | Dev / staging | Production (`NODE_ENV === 'production'`) |
+|-------|---------------|------------------------------------------|
+| `debug` | `console.debug` | **dropped** — silent in prod, visible in staging |
 | `info` | `console.info` | Sentry breadcrumb |
 | `warn` | `console.warn` | `console.warn` + Sentry captureMessage |
 | `error` | `console.error` | `console.error` + Sentry captureException / captureMessage |
@@ -1316,7 +1316,7 @@ After `Sentry.init()`, call `configureSentryTransport(adapter)` — both `learn-
 
 ### PII scrubbing
 
-These field names are scrubbed to `[scrubbed]` by default: `email`, `phone`, `name`, `did`, `seed`, `privateKey`, `accessToken`, `idToken`. Any string value matching `/^bearer /i` is also scrubbed. Pass `{ allowPii: true }` in the meta object to bypass (strips the flag before forwarding to Sentry).
+Field names are matched **case-insensitively as substrings**, so variants are caught automatically (`userEmail`, `phoneNumber`, `firstName`, `accessToken`, etc.). Scrubbing is **recursive** — nested objects and arrays are walked. Keywords matched: `email`, `phone`, `name`, `seed`, `password`, `privatekey`, `accesstoken`, `idtoken`, `token`. `did` is matched exactly (too short for safe substring). Any string value starting with `Bearer ` is also scrubbed. Pass `{ allowPii: true }` in the meta object to bypass (flag is stripped before forwarding to Sentry).
 
 ### ESLint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1247,3 +1247,77 @@ GDPR/COPPA-compliant privacy controls based on user age and country. Minors have
 -   Always use `getMinorAgeThreshold()` from `learn-card-base` for minor determination — NOT `getGdprAgeLimit()` from the app's local `gdpr.ts` (that one returns 16 for non-EU, only correct for EU parental consent modals)
 -   Preference fields: `aiEnabled`, `aiAutoDisabled`, `analyticsEnabled`, `analyticsAutoDisabled`, `bugReportsEnabled`, `isMinor` (all optional booleans)
 -   See CLAUDE.md for full architectural details
+
+## Logging
+
+Central logger lives at `packages/learn-card-base/src/logging/logger.ts`, exported from `learn-card-base`.
+
+### API
+
+```ts
+import { logger, useLogger } from 'learn-card-base';
+
+// Module-level or top of a file (not a React hook — safe outside components)
+const log = useLogger('my-feature');
+
+// Object meta
+log.info('user.navigated', { page: 'home' });
+log.warn('cache.miss', { key });
+log.error('wallet.init.failed', err, { userId });
+
+// Primitives and arrays — no wrapper needed
+log.info('isEnabled::', isEnabled);   // boolean
+log.info('retryCount::', 3);          // number
+log.info('flags::', [true, false]);   // array
+
+// Error from a catch block — pass e directly, logger handles it
+try { ... } catch (e) { log.error('unexpected', e); }
+
+// No scope
+logger.debug('verbose detail');
+logger.breadcrumb({ category: 'auth', message: 'token refreshed' });
+logger.withContext(scope => scope.setTag('flow', 'oid4vci'));
+```
+
+### Levels
+
+| Level | Dev | Prod (Sentry active) |
+|-------|-----|----------------------|
+| `debug` | `console.debug` | **dropped** |
+| `info` | `console.info` | Sentry breadcrumb |
+| `warn` | `console.warn` | `console.warn` + Sentry captureMessage |
+| `error` | `console.error` | `console.error` + Sentry captureException / captureMessage |
+
+### Second argument rules
+
+| What you pass | Console output | Sentry |
+|---|---|---|
+| `Error` object | logged directly | `captureException` |
+| Plain object `{ key }` | logged directly | attached as `extra` |
+| Primitive / array | logged directly | wrapped as `{ value: x }` |
+| Nothing | empty object `{}` | no extra |
+
+When passing both an error and extra context: `log.error('msg', err, { userId })`.
+
+### Setup (apps)
+
+After `Sentry.init()`, call `configureSentryTransport(adapter)` — both `learn-card-app` and `scouts` do this in their `constants/sentry.ts`. `useSentryIdentify` calls `configureLoggerContext({ bugReportsEnabled })` automatically when preferences change, so the privacy gate is always in sync. `captureConsoleIntegration` has been removed from both apps — the logger is now the only path to Sentry.
+
+### Do / Don't
+
+| Do | Don't |
+|----|-------|
+| `log.error('wallet.init.failed', err)` | `console.error('wallet init failed', err)` in app src |
+| `log.warn('cache.miss', { key })` | `Sentry.captureException(err)` directly |
+| `log.debug('verbose detail')` | Leave spam `console.log` in production-facing paths |
+| `log.info('isEnabled::', isEnabled)` | `log.info('isEnabled::', { isEnabled })` — primitives work directly |
+| Pass raw catch values: `log.error('msg', e)` | Wrap manually: `e instanceof Error ? e : new Error(String(e))` |
+| `{ allowPii: true }` only for internal debug tooling | Log PII fields without the flag |
+
+### PII scrubbing
+
+These field names are scrubbed to `[scrubbed]` by default: `email`, `phone`, `name`, `did`, `seed`, `privateKey`, `accessToken`, `idToken`. Any string value matching `/^bearer /i` is also scrubbed. Pass `{ allowPii: true }` in the meta object to bypass (strips the flag before forwarding to Sentry).
+
+### ESLint
+
+`no-console: 'warn'` is enabled for `apps/learn-card-app/src/**` and `apps/scouts/src/**` via the root `.eslintrc.js` overrides block. Remaining call sites surface as warnings until migrated.

--- a/apps/learn-card-app/src/AppRouter.tsx
+++ b/apps/learn-card-app/src/AppRouter.tsx
@@ -45,7 +45,9 @@ import { useLaunchDarklyIdentify } from 'learn-card-base/hooks/useLaunchDarklyId
 import { useIsChapiInteraction } from 'learn-card-base/stores/chapiStore';
 import { useSentryIdentify } from './constants/sentry';
 
-import { Modals } from 'learn-card-base';
+import { Modals, useLogger } from 'learn-card-base';
+
+const log = useLogger('app-router');
 import { useSetAnalyticsUserId, useAnalytics } from '@analytics';
 import { useDeviceTypeByWidth } from 'learn-card-base';
 import { redirectStore } from 'learn-card-base/stores/redirectStore';
@@ -364,7 +366,7 @@ const AppRouter: React.FC = () => {
                         queryClient,
                     });
                 } catch (error) {
-                    console.error('Backfill consent error (non-blocking):', error);
+                    log.error('Backfill consent error (non-blocking)', error);
                 }
             }
         };

--- a/apps/learn-card-app/src/AppRouter.tsx
+++ b/apps/learn-card-app/src/AppRouter.tsx
@@ -45,15 +45,15 @@ import { useLaunchDarklyIdentify } from 'learn-card-base/hooks/useLaunchDarklyId
 import { useIsChapiInteraction } from 'learn-card-base/stores/chapiStore';
 import { useSentryIdentify } from './constants/sentry';
 
-import { Modals, useLogger } from 'learn-card-base';
-
-const log = useLogger('app-router');
+import { Modals, getLogger } from 'learn-card-base';
 import { useSetAnalyticsUserId, useAnalytics } from '@analytics';
 import { useDeviceTypeByWidth } from 'learn-card-base';
 import { redirectStore } from 'learn-card-base/stores/redirectStore';
 import { useAutoVerifyContactMethodWithProofOfLogin } from './hooks/useAutoVerifyContactMethodWithProofOfLogin';
 import { useFinalizeInboxCredentials } from './hooks/useFinalizeInboxCredentials';
 import useConsentFlow from './pages/consentFlow/useConsentFlow';
+
+const log = getLogger('app-router');
 
 export const aiRoutes = ['/ai/topics', '/ai/sessions', '/chats'];
 

--- a/apps/learn-card-app/src/FullApp.tsx
+++ b/apps/learn-card-app/src/FullApp.tsx
@@ -16,11 +16,8 @@ import {
     useSQLiteInitWeb,
     sqliteStore,
     ensureReactQueryTableExists,
-    useLogger,
+    getLogger,
 } from 'learn-card-base';
-
-const log = useLogger('cache');
-
 import AppUrlListener from './components/app-url-listener/AppUrlListener';
 import PresentVcModalListener from './components/modalListener/ModalListener';
 import QRCodeScannerListener from './components/qrcode-scanner-listener/QRCodeScannerListener';
@@ -50,6 +47,8 @@ import DevDebugPanel from './components/debug/DevDebugPanel';
 import AuthCoordinatorProvider from './providers/AuthCoordinatorProvider';
 import localforage from 'localforage';
 import { useInitializeTheme } from './theme/hooks/useTheme';
+
+const log = getLogger('cache');
 
 const history = createBrowserHistory();
 
@@ -121,7 +120,7 @@ const persister = createAsyncStoragePersister({
                 try {
                     return localforage.setItem(key, value);
                 } catch (fallbackError) {
-                    log.error('Fallback cache error', fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)));
+                    log.error('Fallback cache error', fallbackError);
                 }
             }
         },
@@ -154,7 +153,7 @@ const persister = createAsyncStoragePersister({
                 try {
                     await localforage.removeItem(key);
                 } catch (fallbackError) {
-                    log.error('Fallback cache removal error', fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)));
+                    log.error('Fallback cache removal error', fallbackError);
                 }
             }
         },

--- a/apps/learn-card-app/src/FullApp.tsx
+++ b/apps/learn-card-app/src/FullApp.tsx
@@ -121,7 +121,7 @@ const persister = createAsyncStoragePersister({
                 try {
                     return localforage.setItem(key, value);
                 } catch (fallbackError) {
-                    log.error('Fallback cache error', fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)));
+                    log.error('Fallback cache error', fallbackError);
                 }
             }
         },

--- a/apps/learn-card-app/src/FullApp.tsx
+++ b/apps/learn-card-app/src/FullApp.tsx
@@ -16,7 +16,10 @@ import {
     useSQLiteInitWeb,
     sqliteStore,
     ensureReactQueryTableExists,
+    useLogger,
 } from 'learn-card-base';
+
+const log = useLogger('cache');
 
 import AppUrlListener from './components/app-url-listener/AppUrlListener';
 import PresentVcModalListener from './components/modalListener/ModalListener';
@@ -81,7 +84,7 @@ const persister = createAsyncStoragePersister({
 
                 return result.values![0].cache;
             } catch (error) {
-                console.error('Error getting from cache', { key, error });
+                log.error('Error getting from cache', error, { key });
                 // Fallback to localforage on error
                 return localforage.getItem(key);
             }
@@ -113,12 +116,12 @@ const persister = createAsyncStoragePersister({
                     await db.close();
                 }
             } catch (error) {
-                console.error('Error setting in cache', { key, value, error });
+                log.error('Error setting in cache', error, { key });
                 // Fallback to localforage on error
                 try {
                     return localforage.setItem(key, value);
                 } catch (fallbackError) {
-                    console.error('Fallback cache error', fallbackError);
+                    log.error('Fallback cache error', fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)));
                 }
             }
         },
@@ -146,12 +149,12 @@ const persister = createAsyncStoragePersister({
                     await db.close();
                 }
             } catch (error) {
-                console.error('Error removing from cache', { key, error });
+                log.error('Error removing from cache', error, { key });
                 // Fallback to localforage on error
                 try {
                     await localforage.removeItem(key);
                 } catch (fallbackError) {
-                    console.error('Fallback cache removal error', fallbackError);
+                    log.error('Fallback cache removal error', fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)));
                 }
             }
         },

--- a/apps/learn-card-app/src/components/app-url-listener/AppUrlListener.tsx
+++ b/apps/learn-card-app/src/components/app-url-listener/AppUrlListener.tsx
@@ -9,6 +9,9 @@ import {
     type ParseClaimInputConfig,
 } from '../../hooks/parseClaimInput';
 import { resolveTenantParseConfig } from '../../hooks/resolveTenantParseConfig';
+import { useLogger } from 'learn-card-base';
+
+const log = useLogger('app-url-listener');
 
 export const AppUrlListener: React.FC = () => {
     const history = useHistory();
@@ -65,7 +68,7 @@ export const AppUrlListener: React.FC = () => {
                         return;
                 }
             } catch (error) {
-                console.error('Error processing deep link:', error);
+                log.error('Error processing deep link', error);
             }
         };
 

--- a/apps/learn-card-app/src/components/app-url-listener/AppUrlListener.tsx
+++ b/apps/learn-card-app/src/components/app-url-listener/AppUrlListener.tsx
@@ -9,9 +9,9 @@ import {
     type ParseClaimInputConfig,
 } from '../../hooks/parseClaimInput';
 import { resolveTenantParseConfig } from '../../hooks/resolveTenantParseConfig';
-import { useLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base';
 
-const log = useLogger('app-url-listener');
+const log = getLogger('app-url-listener');
 
 export const AppUrlListener: React.FC = () => {
     const history = useHistory();

--- a/apps/learn-card-app/src/components/qrcode-scanner-listener/QRCodeScannerListener.tsx
+++ b/apps/learn-card-app/src/components/qrcode-scanner-listener/QRCodeScannerListener.tsx
@@ -8,7 +8,9 @@ import AddContactView, {
 } from '../../pages/addressBook/addContactView/AddContactView';
 import { IonModal, IonContent, IonPage, IonSpinner } from '@ionic/react';
 
-import { useToast, ToastTypeEnum } from 'learn-card-base';
+import { useToast, ToastTypeEnum, useLogger } from 'learn-card-base';
+
+const log = useLogger('qr-scanner');
 
 import QRCodeScannerStore from 'learn-card-base/stores/QRCodeScannerStore';
 
@@ -84,7 +86,7 @@ export const QRCodeScannerListener: React.FC = () => {
             }
             // 'routed' — the router already called history.push; nothing more to do.
         } catch (error) {
-            console.log('❌❌ scanner::error ❌❌', error);
+            log.error('scanner::error', error);
             await handleCancelScanning();
             setLoading(false);
 
@@ -111,11 +113,11 @@ export const QRCodeScannerListener: React.FC = () => {
             if (showScanner) {
                 handleStartScanning()
                     .then(async (res: any) => {
-                        console.log('scan::success', res);
+                        log.debug('scan::success', { rawValue: res?.rawValue });
                         await handleScan(res?.rawValue);
                     })
                     .catch(async error => {
-                        console.log('scan::error', error);
+                        log.error('scan::error', error);
                         await handleCancelScanning();
                     });
             } else if (!showScanner) {

--- a/apps/learn-card-app/src/components/qrcode-scanner-listener/QRCodeScannerListener.tsx
+++ b/apps/learn-card-app/src/components/qrcode-scanner-listener/QRCodeScannerListener.tsx
@@ -8,15 +8,14 @@ import AddContactView, {
 } from '../../pages/addressBook/addContactView/AddContactView';
 import { IonModal, IonContent, IonPage, IonSpinner } from '@ionic/react';
 
-import { useToast, ToastTypeEnum, useLogger } from 'learn-card-base';
-
-const log = useLogger('qr-scanner');
-
+import { useToast, ToastTypeEnum, getLogger } from 'learn-card-base';
 import QRCodeScannerStore from 'learn-card-base/stores/QRCodeScannerStore';
 
 import { AddressBookContact } from '../../pages/addressBook/addressBookHelpers';
 import { VC } from '@learncard/types';
 import { useClaimInputRouter } from '../../hooks/useClaimInputRouter';
+
+const log = getLogger('qr-scanner');
 
 export const QRCodeScannerListener: React.FC = () => {
     const { presentToast } = useToast();

--- a/apps/learn-card-app/src/components/user-profile/UserProfileUpdateForm.tsx
+++ b/apps/learn-card-app/src/components/user-profile/UserProfileUpdateForm.tsx
@@ -112,8 +112,6 @@ const UserProfileUpdateForm: React.FC<UserProfileUpdateFormProps> = ({
     const brandingConfig = useBrandingConfig();
     const { isDesktop, isMobile } = useDeviceTypeByWidth();
 
-    console.log('currentUser', currentUser);
-
     const [name, setName] = useState<string | null | undefined>(currentUser?.name ?? '');
     const [photo, setPhoto] = useState<string | null | undefined>(currentUser?.profileImage ?? '');
     const [email, setEmail] = useState<string | null | undefined>(currentUser?.email ?? '');

--- a/apps/learn-card-app/src/constants/sentry.ts
+++ b/apps/learn-card-app/src/constants/sentry.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import useCurrentUser from 'learn-card-base/hooks/useGetCurrentUser';
 import { useWallet } from 'learn-card-base';
 import { useGetPreferencesForDid } from 'learn-card-base';
+import { configureSentryTransport, configureLoggerContext } from 'learn-card-base';
 import { getResolvedTenantConfig } from '../config/bootstrapTenantConfig';
 
 export type UseSentryIdentifyOptions = {
@@ -52,29 +53,49 @@ export const initSentryFromTenant = (): void => {
         tracePropagationTargets: traceDomains,
         integrations: [
             Sentry.feedbackIntegration({
-                // Additional SDK configuration goes in here, for example:
                 colorScheme: 'system',
                 showBranding: false,
                 autoInject: false,
             }),
             Sentry.reactRouterV5BrowserTracingIntegration({ history }),
             Sentry.replayIntegration({
-                // Additional SDK configuration goes in here, for example:
                 maskAllText: true,
                 blockAllMedia: true,
             }),
-            Sentry.captureConsoleIntegration({
-                levels: ['error'],
-            }),
+            // captureConsoleIntegration removed: logger is now the only path to Sentry,
+            // ensuring PII scrubbing and bugReportsEnabled gate are always applied.
         ],
         // Performance Monitoring
-        tracesSampleRate: 0.5, // Capture 100% of the transactions, reduce in production!
-        // Capture Replay for 10% of all sessions,
-        // plus for 100% of sessions with an error
+        tracesSampleRate: 0.5,
         replaysSessionSampleRate: 0.1,
         replaysOnErrorSampleRate: 1.0,
     });
-}
+
+    // Wire the injectable transport so learn-card-base logger forwards to Sentry.
+    // Each method opens a fresh Sentry scope so tags/extra are scoped to the
+    // single event and don't bleed into unrelated events on the global scope.
+    configureSentryTransport({
+        // Errors: attach logger tags (scope, tenantId) + meta as extras, then capture.
+        captureException: (err, tags, extra) =>
+            Sentry.withScope(scope => {
+                if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+                if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+                Sentry.captureException(err);
+            }),
+        // Warnings / string errors: same tag/extra injection, level forwarded as-is.
+        captureMessage: (msg, level, tags, extra) =>
+            Sentry.withScope(scope => {
+                if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+                if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+                Sentry.captureMessage(msg, level);
+            }),
+        // Info: recorded as a breadcrumb (timeline context), not a captured event.
+        addBreadcrumb: opts => Sentry.addBreadcrumb(opts),
+        // Escape hatch for callers that need direct scope access (e.g. logger.withContext).
+        withScope: fn =>
+            Sentry.withScope(scope => fn({ setTag: scope.setTag.bind(scope), setExtra: scope.setExtra.bind(scope) })),
+    });
+};
 
 export const useSentryIdentify = (options: UseSentryIdentifyOptions = {}) => {
     const currentUser = useCurrentUser();
@@ -84,6 +105,9 @@ export const useSentryIdentify = (options: UseSentryIdentifyOptions = {}) => {
     const bugReportsEnabled = preferences?.bugReportsEnabled ?? true;
 
     useEffect(() => {
+        // Keep logger privacy gate in sync with user preferences
+        configureLoggerContext({ bugReportsEnabled });
+
         if (Sentry.getClient()) {
             if (currentUser && bugReportsEnabled) {
                 if (options.debug) console.debug('Identify user! 🎸', currentUser);
@@ -95,8 +119,6 @@ export const useSentryIdentify = (options: UseSentryIdentifyOptions = {}) => {
 
                         const user = {
                             id: did,
-                            //username: currentUser?.name, // TODO: Hash name
-                            //email: sha256(currentUser?.email),
                         };
                         if (options.debug) console.debug('🔍 Sentry User Context Identified', user);
 

--- a/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
@@ -686,7 +686,7 @@ const AuthSessionManager: React.FC<{
             return vpJwt;
         } catch (e) {
             log.error('[signDidAuthVp] error', e);
-            throw e;
+            throw e instanceof Error ? e : new Error(String(e));
         }
     }, []);
 

--- a/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
@@ -53,12 +53,14 @@ import {
     SocialLoginTypes,
     getAuthConfig,
     getSSSConfig,
+    useLogger,
     type AuthCoordinatorContextValue,
     type AuthProvider,
     type AuthUser,
     type DebugEventLevel,
     type KeyDerivationStrategy,
 } from 'learn-card-base';
+
 import currentUserStore from 'learn-card-base/stores/currentUserStore';
 import { walletStore, switchedProfileStore } from 'learn-card-base/stores/walletStore';
 import { pushUtilities } from 'learn-card-base/utils/pushUtilities';
@@ -117,6 +119,8 @@ import { RecoverySetupModal } from '../components/recovery/RecoverySetupModal';
 import { DeviceLinkModal } from '../components/device-link/DeviceLinkModal';
 import ReAuthOverlay from '../components/auth/ReAuthOverlay';
 
+const log = useLogger('auth-coordinator');
+
 // ---------------------------------------------------------------------------
 // DeviceLinkOverlay — fetches the device share then renders the approver modal
 // ---------------------------------------------------------------------------
@@ -152,10 +156,9 @@ const DeviceLinkOverlay: React.FC<{
                 // Fetch the share version if the strategy supports it
                 const version = await keyDerivation.getLocalShareVersion?.();
 
-                console.debug(
-                    '[Device Link] approver local shareVersion:',
-                    version ?? '(none — will not be sent to Device B)'
-                );
+                log.debug('[Device Link] approver local shareVersion:', {
+                    shareVersion: version ?? '(none — will not be sent to Device B)',
+                });
 
                 if (!cancelled && version != null) {
                     setShareVersion(version);
@@ -285,9 +288,7 @@ registerAuthProviderFactory('firebase', () =>
                           const { user } = await FirebaseAuthentication.getCurrentUser();
 
                           if (user) {
-                              console.debug(
-                                  '[Auth] Native Firebase user found — using NATIVE token'
-                              );
+                              log.debug('[Auth] Native Firebase user found — using NATIVE token');
                               const result = await FirebaseAuthentication.getIdToken({
                                   forceRefresh: forceRefresh ?? false,
                               });
@@ -320,7 +321,7 @@ registerAuthProviderFactory('firebase', () =>
                 try {
                     await FirebaseAuthentication.signOut();
                 } catch (e) {
-                    console.warn('Native FirebaseAuthentication.signOut failed', e);
+                    log.warn('Native FirebaseAuthentication.signOut failed', e);
                 }
             }
 
@@ -583,12 +584,10 @@ const AuthSessionManager: React.FC<{
 
         const applyQrShare = async () => {
             try {
-                console.debug(
-                    '[QR Login Pickup] received share:',
-                    qrShare.substring(0, 8) + '...',
-                    '| shareVersion raw:',
-                    qrVersionStr
-                );
+                log.debug('[QR Login Pickup] received share', {
+                    sharePrefix: qrShare.substring(0, 8) + '...',
+                    shareVersionRaw: qrVersionStr,
+                });
 
                 await keyDerivation.storeLocalKey(qrShare);
 
@@ -597,21 +596,18 @@ const AuthSessionManager: React.FC<{
                     const version = parseInt(qrVersionStr, 10);
 
                     if (!isNaN(version)) {
-                        console.debug('[QR Login Pickup] storing shareVersion:', version);
+                        log.debug('[QR Login Pickup] storing shareVersion', { shareVersion: version });
                         await keyDerivation.storeLocalShareVersion?.(version);
                     } else {
-                        console.warn(
-                            '[QR Login Pickup] shareVersion is not a valid number:',
-                            qrVersionStr
-                        );
+                        log.warn('[QR Login Pickup] shareVersion is not a valid number', { qrVersionStr });
                     }
                 } else {
-                    console.warn('[QR Login Pickup] no shareVersion received from approver device');
+                    log.warn('[QR Login Pickup] no shareVersion received from approver device');
                 }
 
                 await coordinator.initialize();
             } catch (e) {
-                console.warn('[QR Login Pickup] failed', e);
+                log.warn('[QR Login Pickup] failed', e);
             }
         };
 
@@ -683,18 +679,14 @@ const AuthSessionManager: React.FC<{
             const vpJwt = await lc.invoke.getDidAuthVp({ proofFormat: 'jwt' });
 
             if (!vpJwt || typeof vpJwt !== 'string') {
-                console.error(
-                    '[signDidAuthVp] getDidAuthVp returned non-string:',
-                    typeof vpJwt,
-                    vpJwt
-                );
+                log.error('[signDidAuthVp] getDidAuthVp returned non-string', { type: typeof vpJwt });
                 throw new Error('Failed to sign DID-Auth VP JWT');
             }
 
             return vpJwt;
         } catch (e) {
-            console.error('[signDidAuthVp] error:', e);
-            throw e instanceof Error ? e : new Error(String(e));
+            log.error('[signDidAuthVp] error', e);
+            throw e;
         }
     }, []);
 
@@ -893,7 +885,7 @@ const AuthSessionManager: React.FC<{
                 const newWallet = await getBespokeLearnCard(privateKey, persistedSwitchedDid);
 
                 if (!newWallet) {
-                    console.error('Failed to initialize wallet from private key');
+                    log.error('Failed to initialize wallet from private key');
                     return;
                 }
 
@@ -907,7 +899,7 @@ const AuthSessionManager: React.FC<{
                     try {
                         await setPlatformPrivateKey(privateKey);
                     } catch (e) {
-                        console.warn('Failed to persist private key to secure storage', e);
+                        log.warn('Failed to persist private key to secure storage', e);
                     }
                 }
 
@@ -929,7 +921,7 @@ const AuthSessionManager: React.FC<{
                 try {
                     await pushUtilities.syncPushToken();
                 } catch (e) {
-                    console.warn('Push token sync failed', e);
+                    log.warn('Push token sync failed', e);
                 }
 
                 setWallet(newWallet);
@@ -975,7 +967,7 @@ const AuthSessionManager: React.FC<{
                     }
                 }
             } catch (e) {
-                console.error('Wallet initialization failed', e);
+                log.error('Wallet initialization failed', e);
                 walletInitRef.current = false;
             }
         };
@@ -1042,7 +1034,7 @@ const AuthSessionManager: React.FC<{
                 setLcnProfile(cachedProfile ?? null);
             }
         } catch (e) {
-            console.warn('LCN profile fetch failed', e);
+            log.warn('LCN profile fetch failed', e);
             setLcnProfile(null);
         } finally {
             setLcnProfileLoading(false);
@@ -1187,15 +1179,10 @@ const AuthSessionManager: React.FC<{
                             await keyDerivation.storeLocalKey(deviceShare);
 
                             if (shareVersion != null) {
-                                console.debug(
-                                    '[Recovery via Device] storing shareVersion:',
-                                    shareVersion
-                                );
+                                log.debug('[Recovery via Device] storing shareVersion', { shareVersion });
                                 await keyDerivation.storeLocalShareVersion?.(shareVersion);
                             } else {
-                                console.warn(
-                                    '[Recovery via Device] no shareVersion received from approver device'
-                                );
+                                log.warn('[Recovery via Device] no shareVersion received from approver device');
                             }
 
                             await coordinator.initialize();
@@ -1321,10 +1308,7 @@ const AuthSessionManager: React.FC<{
                                     newEmail
                                 );
                             } catch (e) {
-                                console.warn(
-                                    'Email backup share after upgrade failed (non-fatal):',
-                                    e
-                                );
+                                log.warn('Email backup share after upgrade failed (non-fatal)', e);
                             }
                         }
 
@@ -1428,12 +1412,10 @@ const AuthSessionManager: React.FC<{
                             providerType: string;
                         } | null
                     ) => {
-                        console.debug(
-                            '[setupMethod] starting, privateKey length:',
-                            currentPrivateKey?.length,
-                            'method:',
-                            input.method
-                        );
+                        log.debug('[setupMethod] starting', {
+                            privateKeyLength: currentPrivateKey?.length,
+                            method: input.method,
+                        });
 
                         let token: string;
 
@@ -1447,11 +1429,7 @@ const AuthSessionManager: React.FC<{
 
                         const providerType = authProvider.getProviderType();
 
-                        console.debug(
-                            '[setupMethod] got token, providerType:',
-                            providerType,
-                            'calling setupRecoveryMethod'
-                        );
+                        log.debug('[setupMethod] got token, calling setupRecoveryMethod', { providerType });
 
                         return keyDerivation.setupRecoveryMethod!({
                             token,
@@ -1590,7 +1568,7 @@ const getCachedPrivateKey = async (): Promise<string | null> => {
     try {
         return await getCurrentUserPrivateKey();
     } catch (e) {
-        console.warn('getCachedPrivateKey failed', e);
+        log.warn('getCachedPrivateKey failed', e);
         return null;
     }
 };
@@ -1660,7 +1638,7 @@ export const AuthCoordinatorProvider: React.FC<AppAuthCoordinatorProviderProps> 
         try {
             await queryClient.clear();
         } catch (e) {
-            console.warn('Failed to clear query cache', e);
+            log.warn('Failed to clear query cache', e);
         }
 
         walletStore.set.wallet(null);
@@ -1678,7 +1656,7 @@ export const AuthCoordinatorProvider: React.FC<AppAuthCoordinatorProviderProps> 
         try {
             await clearDBRef.current();
         } catch (e) {
-            console.warn('Failed to clear SQLite DB', e);
+            log.warn('Failed to clear SQLite DB', e);
         }
 
         currentUserStore.set.currentUser(null);
@@ -1694,19 +1672,19 @@ export const AuthCoordinatorProvider: React.FC<AppAuthCoordinatorProviderProps> 
         try {
             await clearPlatformPrivateKey();
         } catch (e) {
-            console.warn('Failed to clear platform private key', e);
+            log.warn('Failed to clear platform private key', e);
         }
 
         try {
             await clearWebSecureAll();
         } catch (e) {
-            console.warn('Failed to clear secure storage', e);
+            log.warn('Failed to clear secure storage', e);
         }
 
         try {
             await clearAllIndexedDB(keyDerivation);
         } catch (e) {
-            console.warn('Failed to clear IndexedDB', e);
+            log.warn('Failed to clear IndexedDB', e);
         }
     }, [queryClient, keyDerivation]);
 

--- a/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
@@ -53,7 +53,7 @@ import {
     SocialLoginTypes,
     getAuthConfig,
     getSSSConfig,
-    useLogger,
+    getLogger,
     type AuthCoordinatorContextValue,
     type AuthProvider,
     type AuthUser,
@@ -119,7 +119,7 @@ import { RecoverySetupModal } from '../components/recovery/RecoverySetupModal';
 import { DeviceLinkModal } from '../components/device-link/DeviceLinkModal';
 import ReAuthOverlay from '../components/auth/ReAuthOverlay';
 
-const log = useLogger('auth-coordinator');
+const log = getLogger('auth-coordinator');
 
 // ---------------------------------------------------------------------------
 // DeviceLinkOverlay — fetches the device share then renders the approver modal

--- a/apps/scouts/src/components/app-url-listener/AppUrlListener.tsx
+++ b/apps/scouts/src/components/app-url-listener/AppUrlListener.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { App, URLOpenListenerEvent } from '@capacitor/app';
 import { PluginListenerHandle } from '@capacitor/core';
-import { useLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base';
 
-const log = useLogger('scouts/app-url-listener');
+const log = getLogger('scouts/app-url-listener');
 
 export const AppUrlListener: React.FC = () => {
     const history = useHistory();

--- a/apps/scouts/src/components/app-url-listener/AppUrlListener.tsx
+++ b/apps/scouts/src/components/app-url-listener/AppUrlListener.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { App, URLOpenListenerEvent } from '@capacitor/app';
 import { PluginListenerHandle } from '@capacitor/core';
+import { useLogger } from 'learn-card-base';
+
+const log = useLogger('scouts/app-url-listener');
 
 export const AppUrlListener: React.FC = () => {
     const history = useHistory();
@@ -33,7 +36,7 @@ export const AppUrlListener: React.FC = () => {
                     }
                 }
             } catch (error) {
-                console.error('Error processing deep link:', error);
+                log.error('Error processing deep link', error);
             }
         };
 

--- a/apps/scouts/src/constants/sentry.ts
+++ b/apps/scouts/src/constants/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
 import useCurrentUser from 'learn-card-base/hooks/useGetCurrentUser';
 import { useWallet } from 'learn-card-base';
+import { configureSentryTransport, configureLoggerContext } from 'learn-card-base';
 
 export type UseSentryIdentifyOptions = {
     debug?: boolean;
@@ -33,14 +34,34 @@ export const initSentry = () => {
                 maskAllText: false,
                 blockAllMedia: true,
             }),
-            Sentry.captureConsoleIntegration({
-                levels: ['error'],
-            }),
+            // captureConsoleIntegration removed: logger is now the only path to Sentry,
+            // ensuring PII scrubbing and bugReportsEnabled gate are always applied.
         ],
         // Performance Monitoring
-        tracesSampleRate: 0.5, // Capture 50% of transactions
-        replaysSessionSampleRate: 0.1, // Replay 10% of all sessions
-        replaysOnErrorSampleRate: 1.0, // Replay 100% of error sessions
+        tracesSampleRate: 0.5,
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+    });
+
+    if (!isSentryEnabled) return;
+
+    // Wire the injectable transport so learn-card-base logger forwards to Sentry
+    configureSentryTransport({
+        captureException: (err, tags, extra) =>
+            Sentry.withScope(scope => {
+                if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+                if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+                Sentry.captureException(err);
+            }),
+        captureMessage: (msg, level, tags, extra) =>
+            Sentry.withScope(scope => {
+                if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+                if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+                Sentry.captureMessage(msg, level);
+            }),
+        addBreadcrumb: opts => Sentry.addBreadcrumb(opts),
+        withScope: fn =>
+            Sentry.withScope(scope => fn({ setTag: scope.setTag.bind(scope), setExtra: scope.setExtra.bind(scope) })),
     });
 };
 
@@ -53,6 +74,9 @@ export const useSentryIdentify = (options: UseSentryIdentifyOptions = {}) => {
     const { getDID } = useWallet();
 
     useEffect(() => {
+        // Scouts has no per-user bugReportsEnabled pref; default enabled in prod
+        configureLoggerContext({ bugReportsEnabled: !!isSentryEnabled });
+
         if (isSentryEnabled) {
             if (currentUser) {
                 if (options.debug) console.debug('Identify user! 🎸', currentUser);
@@ -60,8 +84,6 @@ export const useSentryIdentify = (options: UseSentryIdentifyOptions = {}) => {
                     .then(did => {
                         const user = {
                             id: did,
-                            // username: currentUser?.name, // TODO: Hash name
-                            // email: sha256(currentUser?.email),
                         };
                         if (options.debug) console.debug('🔍 Sentry User Context Identified', user);
 

--- a/apps/scouts/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/scouts/src/providers/AuthCoordinatorProvider.tsx
@@ -43,6 +43,7 @@ import {
     SocialLoginTypes,
     getAuthConfig,
     getSSSConfig,
+    useLogger,
     type AuthCoordinatorContextValue,
     type AuthProvider,
     type AuthUser,
@@ -86,6 +87,8 @@ import {
 import { RecoveryFlowModal } from '../components/recovery/RecoveryFlowModal';
 import { RecoverySetupModal } from '../components/recovery/RecoverySetupModal';
 import ReAuthOverlay from '../components/auth/ReAuthOverlay';
+
+const log = useLogger('scouts/auth-coordinator');
 
 // ---------------------------------------------------------------------------
 // DeviceLinkOverlay — fetches device share then renders the approver modal
@@ -178,7 +181,7 @@ const ScoutsDeviceLinkOverlay: React.FC<{
                 const requested = await BarcodeScanner.requestPermissions();
 
                 if (requested.camera !== 'granted') {
-                    console.warn('[ScoutPass] Camera permission denied');
+                    log.warn('[ScoutPass] Camera permission denied');
                     return null;
                 }
             }
@@ -196,7 +199,7 @@ const ScoutsDeviceLinkOverlay: React.FC<{
                 });
             });
         } catch (e) {
-            console.warn('[ScoutPass] QR scan failed:', e);
+            log.warn('[ScoutPass] QR scan failed', e);
             await BarcodeScanner.removeAllListeners();
             await BarcodeScanner.stopScan();
             return null;
@@ -264,7 +267,7 @@ registerAuthProviderFactory('firebase', () =>
                         const { user } = await FirebaseAuthentication.getCurrentUser();
 
                         if (user) {
-                            console.debug('[Auth] Native Firebase user found — using NATIVE token');
+                            log.debug('[Auth] Native Firebase user found — using NATIVE token');
                             const result = await FirebaseAuthentication.getIdToken({ forceRefresh: forceRefresh ?? false });
                             return result.token;
                         }
@@ -293,7 +296,7 @@ registerAuthProviderFactory('firebase', () =>
                 try {
                     await FirebaseAuthentication.signOut();
                 } catch (e) {
-                    console.warn('[ScoutPass] Native FirebaseAuthentication.signOut failed', e);
+                    log.warn('[ScoutPass] Native FirebaseAuthentication.signOut failed', e);
                 }
             }
 
@@ -514,7 +517,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
 
                 await coordinator.initialize();
             } catch (e) {
-                console.warn('[ScoutPass] QR login device share pickup failed', e);
+                log.warn('[ScoutPass] QR login device share pickup failed', e);
             }
         };
 
@@ -572,14 +575,14 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
             const vpJwt = await lc.invoke.getDidAuthVp({ proofFormat: 'jwt' });
 
             if (!vpJwt || typeof vpJwt !== 'string') {
-                console.error('[ScoutPass][signDidAuthVp] getDidAuthVp returned non-string:', typeof vpJwt, vpJwt);
+                log.error('[ScoutPass][signDidAuthVp] getDidAuthVp returned non-string', { type: typeof vpJwt });
                 throw new Error('Failed to sign DID-Auth VP JWT');
             }
 
             return vpJwt;
         } catch (e) {
-            console.error('[ScoutPass][signDidAuthVp] error:', e);
-            throw e instanceof Error ? e : new Error(String(e));
+            log.error('[ScoutPass][signDidAuthVp] error', e);
+            throw e;
         }
     }, []);
 
@@ -722,7 +725,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                 const newWallet = await getBespokeLearnCard(privateKey);
 
                 if (!newWallet) {
-                    console.error('[ScoutPass] Failed to initialize wallet from private key');
+                    log.error('[ScoutPass] Failed to initialize wallet from private key');
                     return;
                 }
 
@@ -735,7 +738,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                     try {
                         await setPlatformPrivateKey(privateKey);
                     } catch (e) {
-                        console.warn('[ScoutPass] Failed to persist private key to secure storage', e);
+                        log.warn('[ScoutPass] Failed to persist private key to secure storage', e);
                     }
                 }
 
@@ -754,7 +757,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                 try {
                     await pushUtilities.syncPushToken();
                 } catch (e) {
-                    console.warn('[ScoutPass] Push token sync failed', e);
+                    log.warn('[ScoutPass] Push token sync failed', e);
                 }
 
                 setWallet(newWallet);
@@ -790,7 +793,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                     }
                 }
             } catch (e) {
-                console.error('[ScoutPass] Wallet initialization failed', e);
+                log.error('[ScoutPass] Wallet initialization failed', e);
                 walletInitRef.current = false;
             }
         };
@@ -851,7 +854,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                 setLcnProfile(cachedProfile ?? null);
             }
         } catch (e) {
-            console.warn('[ScoutPass] LCN profile fetch failed', e);
+            log.warn('[ScoutPass] LCN profile fetch failed', e);
             setLcnProfile(null);
         } finally {
             setLcnProfileLoading(false);
@@ -970,10 +973,10 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                             await keyDerivation.storeLocalKey(deviceShare);
 
                             if (shareVersion != null) {
-                                console.debug('[ScoutPass][Recovery via Device] storing shareVersion:', shareVersion);
+                                log.debug('[ScoutPass][Recovery via Device] storing shareVersion', { shareVersion });
                                 await keyDerivation.storeLocalShareVersion?.(shareVersion);
                             } else {
-                                console.warn('[ScoutPass][Recovery via Device] no shareVersion received from approver device');
+                                log.warn('[ScoutPass][Recovery via Device] no shareVersion received from approver device');
                             }
 
                             await coordinator.initialize();
@@ -1091,7 +1094,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                                     freshToken, authProvider.getProviderType(), pk, newEmail
                                 );
                             } catch (e) {
-                                console.warn('Email backup share after upgrade failed (non-fatal):', e);
+                                log.warn('Email backup share after upgrade failed (non-fatal)', e);
                             }
                         }
 
@@ -1179,7 +1182,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
                 const currentPrivateKey = coordinator.state.status === 'ready' ? coordinator.state.privateKey : '';
 
                 const setupMethod = async (input: RecoverySetupInput, authUser?: { id: string; email?: string; phone?: string; providerType: string } | null) => {
-                    console.debug('[ScoutPass][setupMethod] starting, privateKey length:', currentPrivateKey?.length, 'method:', input.method);
+                    log.debug('[ScoutPass][setupMethod] starting', { privateKeyLength: currentPrivateKey?.length, method: input.method });
 
                     let token: string;
 
@@ -1191,7 +1194,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
 
                     const providerType = authProvider.getProviderType();
 
-                    console.debug('[ScoutPass][setupMethod] got token, providerType:', providerType, 'calling setupRecoveryMethod');
+                    log.debug('[ScoutPass][setupMethod] got token, calling setupRecoveryMethod', { providerType });
 
                     return keyDerivation.setupRecoveryMethod!({
                         token,
@@ -1299,7 +1302,7 @@ const getCachedPrivateKey = async (): Promise<string | null> => {
     try {
         return await getCurrentUserPrivateKey();
     } catch (e) {
-        console.warn('[ScoutPass] getCachedPrivateKey failed', e);
+        log.warn('[ScoutPass] getCachedPrivateKey failed', e);
         return null;
     }
 };
@@ -1364,7 +1367,7 @@ export const AuthCoordinatorProvider: React.FC<ScoutsAuthCoordinatorProviderProp
 
     // Unified logout cleanup — called by the coordinator after its own signOut + clearLocalKeys.
     const handleAppLogout = useCallback(async () => {
-        try { await queryClient.clear(); } catch (e) { console.warn('[ScoutPass] Failed to clear query cache', e); }
+        try { await queryClient.clear(); } catch (e) { log.warn('[ScoutPass] Failed to clear query cache', e); }
 
         walletStore.set.wallet(null);
         web3AuthStore.set.web3Auth(null);
@@ -1378,7 +1381,7 @@ export const AuthCoordinatorProvider: React.FC<ScoutsAuthCoordinatorProviderProp
         clearAuthServiceProvider();
         unsetAuthToken();
 
-        try { await clearDBRef.current(); } catch (e) { console.warn('[ScoutPass] Failed to clear SQLite DB', e); }
+        try { await clearDBRef.current(); } catch (e) { log.warn('[ScoutPass] Failed to clear SQLite DB', e); }
 
         currentUserStore.set.currentUser(null);
         currentUserStore.set.currentUserPK(null);
@@ -1390,11 +1393,11 @@ export const AuthCoordinatorProvider: React.FC<ScoutsAuthCoordinatorProviderProp
         firstStartupStore.set.introSlidesCompleted(true);
         firstStartupStore.set.firstStart(false);
 
-        try { await clearPlatformPrivateKey(); } catch (e) { console.warn('[ScoutPass] Failed to clear platform private key', e); }
+        try { await clearPlatformPrivateKey(); } catch (e) { log.warn('[ScoutPass] Failed to clear platform private key', e); }
 
-        try { await clearWebSecureAll(); } catch (e) { console.warn('[ScoutPass] Failed to clear secure storage', e); }
+        try { await clearWebSecureAll(); } catch (e) { log.warn('[ScoutPass] Failed to clear secure storage', e); }
 
-        try { await clearAllIndexedDB(keyDerivation); } catch (e) { console.warn('[ScoutPass] Failed to clear IndexedDB', e); }
+        try { await clearAllIndexedDB(keyDerivation); } catch (e) { log.warn('[ScoutPass] Failed to clear IndexedDB', e); }
     }, [queryClient, keyDerivation]);
 
     return (

--- a/apps/scouts/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/scouts/src/providers/AuthCoordinatorProvider.tsx
@@ -43,7 +43,7 @@ import {
     SocialLoginTypes,
     getAuthConfig,
     getSSSConfig,
-    useLogger,
+    getLogger,
     type AuthCoordinatorContextValue,
     type AuthProvider,
     type AuthUser,
@@ -88,7 +88,7 @@ import { RecoveryFlowModal } from '../components/recovery/RecoveryFlowModal';
 import { RecoverySetupModal } from '../components/recovery/RecoverySetupModal';
 import ReAuthOverlay from '../components/auth/ReAuthOverlay';
 
-const log = useLogger('scouts/auth-coordinator');
+const log = getLogger('scouts/auth-coordinator');
 
 // ---------------------------------------------------------------------------
 // DeviceLinkOverlay — fetches device share then renders the approver modal
@@ -582,7 +582,7 @@ const AuthSessionManager: React.FC<{ children: React.ReactNode; authProvider: Au
             return vpJwt;
         } catch (e) {
             log.error('[ScoutPass][signDidAuthVp] error', e);
-            throw e;
+            throw e instanceof Error ? e : new Error(String(e));
         }
     }, []);
 

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -267,3 +267,4 @@ export * from './svgs/navbar/formal/navbarFormalIcons';
 export * from './svgs/ScoutsLogo';
 export * from './svgs/ScoutLogoAndText';
 export * from './svgs/Compass';
+export * from './logging/logger';

--- a/packages/learn-card-base/src/logging/README.md
+++ b/packages/learn-card-base/src/logging/README.md
@@ -5,9 +5,9 @@ Central logger for all LearnCard apps. Provides structured, PII-safe logging wit
 ## Quick start
 
 ```ts
-import { useLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base';
 
-const log = useLogger('my-feature');
+const log = getLogger('my-feature');
 
 log.debug('wallet ready');
 log.info('profile loaded', { profileId: '123' });
@@ -15,18 +15,16 @@ log.warn('cache miss', { key });
 log.error('sign-in failed', err);
 ```
 
-> `useLogger` is **not** a React hook — it is a plain factory and is safe to call at module level, outside any component.
-
 ---
 
 ## API
 
-### `useLogger(scope: string): Logger`
+### `getLogger(scope: string): Logger`
 
 Returns a logger that prefixes every console output with `[scope]` and attaches a `scope` tag to every Sentry event.
 
 ```ts
-const log = useLogger('auth-coordinator');
+const log = getLogger('auth-coordinator');
 ```
 
 ### `logger`
@@ -43,14 +41,14 @@ logger.info('app boot');
 
 ## Log levels
 
-| Method | Dev (no transport) | Prod (Sentry active) |
-|---|---|---|
-| `log.debug(msg, ...)` | `console.debug` | **dropped** — never reaches Sentry |
-| `log.info(msg, ...)` | `console.info` | Sentry breadcrumb (timeline context) |
-| `log.warn(msg, ...)` | `console.warn` | `console.warn` + Sentry `captureMessage` |
+| Method                | Dev / staging   | Production (`NODE_ENV === 'production'`)                        |
+| --------------------- | --------------- | --------------------------------------------------------------- |
+| `log.debug(msg, ...)` | `console.debug` | **dropped** — never reaches Sentry or console                   |
+| `log.info(msg, ...)`  | `console.info`  | Sentry breadcrumb (timeline context)                            |
+| `log.warn(msg, ...)`  | `console.warn`  | `console.warn` + Sentry `captureMessage`                        |
 | `log.error(msg, ...)` | `console.error` | `console.error` + Sentry `captureException` or `captureMessage` |
 
-> `debug` is intentionally silenced in production. Use `info` if you need the event to appear in Sentry's breadcrumb trail.
+> `debug` is silenced only in production builds (`NODE_ENV === 'production'`). Staging builds with a Sentry transport configured still show debug output in devtools. Use `info` if you need the event to appear in Sentry's breadcrumb trail.
 
 ---
 
@@ -58,13 +56,13 @@ logger.info('app boot');
 
 The second argument is flexible — pass whatever you have without wrapping:
 
-| What you pass | Console output | Sentry |
-|---|---|---|
-| `Error` object | logged directly | `captureException(err)` |
-| Plain object `{ key: value }` | logged directly | attached as `extra` |
-| Primitive — `boolean`, `number`, `string` | logged directly | wrapped as `{ value: x }` |
-| Array | logged directly | wrapped as `{ value: [...] }` |
-| Nothing | empty `{}` | no extra |
+| What you pass                             | Console output  | Sentry                        |
+| ----------------------------------------- | --------------- | ----------------------------- |
+| `Error` object                            | logged directly | `captureException(err)`       |
+| Plain object `{ key: value }`             | logged directly | attached as `extra`           |
+| Primitive — `boolean`, `number`, `string` | logged directly | wrapped as `{ value: x }`     |
+| Array                                     | logged directly | wrapped as `{ value: [...] }` |
+| Nothing                                   | empty `{}`      | no extra                      |
 
 ### Examples
 
@@ -80,15 +78,15 @@ log.error('sign-in failed', err, { userId, provider: 'firebase' });
 
 // Primitives — no object wrapper needed
 const isEnabled = false;
-log.info('feature flag', isEnabled);    // ✓ logs false directly
-log.info('retry count', 3);             // ✓ logs 3 directly
-log.info('active flags', ['a', 'b']);   // ✓ logs array directly
+log.info('feature flag', isEnabled); // ✓ logs false directly
+log.info('retry count', 3); // ✓ logs 3 directly
+log.info('active flags', ['a', 'b']); // ✓ logs array directly
 
 // Raw catch block value — logger coerces it internally
 try {
     await riskyOperation();
 } catch (e) {
-    log.error('operation failed', e);   // ✓ pass e directly, no wrapping needed
+    log.error('operation failed', e); // ✓ pass e directly, no wrapping needed
 }
 ```
 
@@ -96,25 +94,35 @@ try {
 
 ## PII scrubbing
 
-The following field names are **automatically scrubbed** to `[scrubbed]` before reaching Sentry:
+Field names are matched **case-insensitively as substrings**, so common variants are caught automatically:
 
-| Field |
-|---|
-| `email` |
-| `phone` |
-| `name` |
-| `did` |
-| `seed` |
-| `privateKey` |
-| `accessToken` |
-| `idToken` |
+| Keyword matched | Examples scrubbed                                          |
+| --------------- | ---------------------------------------------------------- |
+| `email`         | `email`, `userEmail`, `emailAddress`, `contactEmail`       |
+| `phone`         | `phone`, `phoneNumber`, `mobilePhone`                      |
+| `name`          | `name`, `firstName`, `lastName`, `displayName`, `fullName` |
+| `did`           | `did` (exact match only — too short for safe substring)    |
+| `seed`          | `seed`                                                     |
+| `password`      | `password`, `hashedPassword`                               |
+| `privatekey`    | `privateKey`, `privatekey`                                 |
+| `accesstoken`   | `accessToken`, `accesstoken`                               |
+| `idtoken`       | `idToken`, `idtoken`                                       |
+| `token`         | `token`, `bearerToken`, `authToken`, `refreshToken`        |
 
-Any string **value** matching `/^bearer /i` (leaked auth header) is also scrubbed.
+Scrubbing is **recursive** — nested objects and arrays are walked automatically, with a depth cap of 10 and cycle detection. Any string **value** starting with `Bearer ` (case-insensitive) is also scrubbed regardless of key name.
 
 ```ts
-// email is scrubbed automatically
+// Top-level field
 log.error('lookup failed', { email: 'user@example.com', code: 404 });
 // Sentry extra → { email: '[scrubbed]', code: 404 }
+
+// Nested field — also scrubbed
+log.error('lookup failed', { user: { email: 'user@example.com' }, code: 404 });
+// Sentry extra → { user: { email: '[scrubbed]' }, code: 404 }
+
+// Variant key name — also scrubbed
+log.error('lookup failed', { userEmail: 'user@example.com', code: 404 });
+// Sentry extra → { userEmail: '[scrubbed]', code: 404 }
 
 // Bypass scrubbing for internal debug tooling only
 log.warn('debug identity', { email: 'user@example.com', allowPii: true });
@@ -162,13 +170,13 @@ configureSentryTransport({
 
 ## Do / Don't
 
-| Do | Don't |
-|---|---|
-| `log.error('wallet.init.failed', err)` | `console.error('wallet init failed', err)` in app src |
-| `log.info('isEnabled', isEnabled)` | `log.info('isEnabled', { isEnabled })` — primitives work directly |
-| `log.error('failed', e)` in catch blocks | `log.error('failed', e instanceof Error ? e : new Error(String(e)))` — handled internally |
-| `log.warn('...', { key })` | `Sentry.captureException(err)` directly |
-| `{ allowPii: true }` in debug tooling only | Log raw PII fields without the flag |
+| Do                                         | Don't                                                                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `log.error('wallet.init.failed', err)`     | `console.error('wallet init failed', err)` in app src                                     |
+| `log.info('isEnabled', isEnabled)`         | `log.info('isEnabled', { isEnabled })` — primitives work directly                         |
+| `log.error('failed', e)` in catch blocks   | `log.error('failed', e instanceof Error ? e : new Error(String(e)))` — handled internally |
+| `log.warn('...', { key })`                 | `Sentry.captureException(err)` directly                                                   |
+| `{ allowPii: true }` in debug tooling only | Log raw PII fields without the flag                                                       |
 
 ---
 

--- a/packages/learn-card-base/src/logging/README.md
+++ b/packages/learn-card-base/src/logging/README.md
@@ -1,0 +1,177 @@
+# Logging
+
+Central logger for all LearnCard apps. Provides structured, PII-safe logging with an injectable Sentry transport — `learn-card-base` never imports `@sentry/react` directly.
+
+## Quick start
+
+```ts
+import { useLogger } from 'learn-card-base';
+
+const log = useLogger('my-feature');
+
+log.debug('wallet ready');
+log.info('profile loaded', { profileId: '123' });
+log.warn('cache miss', { key });
+log.error('sign-in failed', err);
+```
+
+> `useLogger` is **not** a React hook — it is a plain factory and is safe to call at module level, outside any component.
+
+---
+
+## API
+
+### `useLogger(scope: string): Logger`
+
+Returns a logger that prefixes every console output with `[scope]` and attaches a `scope` tag to every Sentry event.
+
+```ts
+const log = useLogger('auth-coordinator');
+```
+
+### `logger`
+
+Module-level singleton with no scope prefix. Use when a scope doesn't add value.
+
+```ts
+import { logger } from 'learn-card-base';
+
+logger.info('app boot');
+```
+
+---
+
+## Log levels
+
+| Method | Dev (no transport) | Prod (Sentry active) |
+|---|---|---|
+| `log.debug(msg, ...)` | `console.debug` | **dropped** — never reaches Sentry |
+| `log.info(msg, ...)` | `console.info` | Sentry breadcrumb (timeline context) |
+| `log.warn(msg, ...)` | `console.warn` | `console.warn` + Sentry `captureMessage` |
+| `log.error(msg, ...)` | `console.error` | `console.error` + Sentry `captureException` or `captureMessage` |
+
+> `debug` is intentionally silenced in production. Use `info` if you need the event to appear in Sentry's breadcrumb trail.
+
+---
+
+## Second argument
+
+The second argument is flexible — pass whatever you have without wrapping:
+
+| What you pass | Console output | Sentry |
+|---|---|---|
+| `Error` object | logged directly | `captureException(err)` |
+| Plain object `{ key: value }` | logged directly | attached as `extra` |
+| Primitive — `boolean`, `number`, `string` | logged directly | wrapped as `{ value: x }` |
+| Array | logged directly | wrapped as `{ value: [...] }` |
+| Nothing | empty `{}` | no extra |
+
+### Examples
+
+```ts
+// Error object
+log.error('wallet init failed', err);
+
+// Plain object (structured context)
+log.warn('slow request', { ms: 450, endpoint: '/trpc/getProfile' });
+
+// Error + extra context together
+log.error('sign-in failed', err, { userId, provider: 'firebase' });
+
+// Primitives — no object wrapper needed
+const isEnabled = false;
+log.info('feature flag', isEnabled);    // ✓ logs false directly
+log.info('retry count', 3);             // ✓ logs 3 directly
+log.info('active flags', ['a', 'b']);   // ✓ logs array directly
+
+// Raw catch block value — logger coerces it internally
+try {
+    await riskyOperation();
+} catch (e) {
+    log.error('operation failed', e);   // ✓ pass e directly, no wrapping needed
+}
+```
+
+---
+
+## PII scrubbing
+
+The following field names are **automatically scrubbed** to `[scrubbed]` before reaching Sentry:
+
+| Field |
+|---|
+| `email` |
+| `phone` |
+| `name` |
+| `did` |
+| `seed` |
+| `privateKey` |
+| `accessToken` |
+| `idToken` |
+
+Any string **value** matching `/^bearer /i` (leaked auth header) is also scrubbed.
+
+```ts
+// email is scrubbed automatically
+log.error('lookup failed', { email: 'user@example.com', code: 404 });
+// Sentry extra → { email: '[scrubbed]', code: 404 }
+
+// Bypass scrubbing for internal debug tooling only
+log.warn('debug identity', { email: 'user@example.com', allowPii: true });
+// Sentry extra → { email: 'user@example.com' }  (allowPii itself is stripped)
+```
+
+> Never use `allowPii: true` in production code paths.
+
+---
+
+## Privacy gate
+
+When `bugReportsEnabled` is `false` (user opted out), **no events reach Sentry**. Console output is unaffected. The gate is wired automatically — `useSentryIdentify` calls `configureLoggerContext({ bugReportsEnabled })` whenever user preferences change.
+
+---
+
+## Sentry setup (apps)
+
+Both `learn-card-app` and `scouts` wire up the transport in `constants/sentry.ts` immediately after `Sentry.init()`:
+
+```ts
+import { configureSentryTransport } from 'learn-card-base';
+
+Sentry.init({ ... });
+
+configureSentryTransport({
+    captureException: (err, tags, extra) =>
+        Sentry.withScope(scope => {
+            if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+            if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+            Sentry.captureException(err);
+        }),
+    captureMessage: (msg, level, tags, extra) =>
+        Sentry.withScope(scope => {
+            if (tags) Object.entries(tags).forEach(([k, v]) => scope.setTag(k, v));
+            if (extra) Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+            Sentry.captureMessage(msg, level);
+        }),
+    addBreadcrumb: opts => Sentry.addBreadcrumb(opts),
+    withScope: fn => Sentry.withScope(scope => fn({ setTag: scope.setTag.bind(scope), setExtra: scope.setExtra.bind(scope) })),
+});
+```
+
+---
+
+## Do / Don't
+
+| Do | Don't |
+|---|---|
+| `log.error('wallet.init.failed', err)` | `console.error('wallet init failed', err)` in app src |
+| `log.info('isEnabled', isEnabled)` | `log.info('isEnabled', { isEnabled })` — primitives work directly |
+| `log.error('failed', e)` in catch blocks | `log.error('failed', e instanceof Error ? e : new Error(String(e)))` — handled internally |
+| `log.warn('...', { key })` | `Sentry.captureException(err)` directly |
+| `{ allowPii: true }` in debug tooling only | Log raw PII fields without the flag |
+
+---
+
+## ESLint
+
+`no-console: 'warn'` is enabled for `apps/learn-card-app/src/**` and `apps/scouts/src/**`. Any remaining `console.*` call in those directories will surface as a lint warning until migrated to the logger.

--- a/packages/learn-card-base/src/logging/logger.test.ts
+++ b/packages/learn-card-base/src/logging/logger.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import {
     logger,
     configureSentryTransport,
     configureLoggerContext,
-    useLogger,
+    getLogger,
     type SentryTransport,
 } from './logger';
 
@@ -33,6 +33,11 @@ beforeEach(() => {
     // Pass null (not undefined) to actually clear tenantId between tests
     configureLoggerContext({ bugReportsEnabled: true, tenantId: null });
     vi.restoreAllMocks();
+});
+
+afterAll(() => {
+    configureSentryTransport(null);
+    configureLoggerContext({ bugReportsEnabled: true, tenantId: null });
 });
 
 // ---------------------------------------------------------------------------
@@ -92,6 +97,47 @@ describe('PII scrubbing', () => {
         expect(extra.email).toBe('user@example.com');
         expect('allowPii' in extra).toBe(false);
     });
+
+    it('scrubs PII nested inside an object', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('lookup failed', { user: { email: 'user@example.com', code: 404 } });
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        const extra = call!.args[3] as Record<string, { email: unknown; code: unknown }>;
+        expect(extra.user.email).toBe('[scrubbed]');
+        expect(extra.user.code).toBe(404);
+    });
+
+    it('scrubs PII nested inside an array of objects', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('batch failed', { items: [{ accessToken: 'tok-1' }, { accessToken: 'tok-2' }] });
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        const extra = call!.args[3] as Record<string, { accessToken: unknown }[]>;
+        expect(extra.items[0].accessToken).toBe('[scrubbed]');
+        expect(extra.items[1].accessToken).toBe('[scrubbed]');
+    });
+
+    it('scrubs PII variant key names (userEmail, phoneNumber, firstName)', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('variant keys', { userEmail: 'a@b.com', phoneNumber: '555', firstName: 'Bob', code: 1 });
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        const extra = call!.args[3] as Record<string, unknown>;
+        expect(extra.userEmail).toBe('[scrubbed]');
+        expect(extra.phoneNumber).toBe('[scrubbed]');
+        expect(extra.firstName).toBe('[scrubbed]');
+        expect(extra.code).toBe(1);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -139,9 +185,9 @@ describe('privacy gate', () => {
 // ---------------------------------------------------------------------------
 
 describe('scope prefixing', () => {
-    it('useLogger prefixes console output with [scope]', () => {
+    it('getLogger prefixes console output with [scope]', () => {
         const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const log = useLogger('wallet/claim');
+        const log = getLogger('wallet/claim');
         log.warn('something happened');
 
         expect(spy).toHaveBeenCalledWith('[wallet/claim]', 'something happened', {});
@@ -151,7 +197,7 @@ describe('scope prefixing', () => {
         const transport = makeMockTransport();
         configureSentryTransport(transport);
 
-        const log = useLogger('credential/issue');
+        const log = getLogger('credential/issue');
         vi.spyOn(console, 'error').mockImplementation(() => {});
         log.error('failed');
 
@@ -192,7 +238,7 @@ describe('scope prefixing', () => {
 describe('primitives and arrays', () => {
     it('logs a boolean directly to console', () => {
         const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
-        const log = useLogger('feature');
+        const log = getLogger('feature');
         log.info('isEnabled::', false);
 
         expect(spy).toHaveBeenCalledWith('[feature]', 'isEnabled::', false);
@@ -200,7 +246,7 @@ describe('primitives and arrays', () => {
 
     it('logs a number directly to console', () => {
         const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
-        const log = useLogger('feature');
+        const log = getLogger('feature');
         log.info('count::', 42);
 
         expect(spy).toHaveBeenCalledWith('[feature]', 'count::', 42);
@@ -208,7 +254,7 @@ describe('primitives and arrays', () => {
 
     it('logs a string directly to console (not wrapped as Error)', () => {
         const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
-        const log = useLogger('feature');
+        const log = getLogger('feature');
         log.info('status::', 'active');
 
         expect(spy).toHaveBeenCalledWith('[feature]', 'status::', 'active');
@@ -216,7 +262,7 @@ describe('primitives and arrays', () => {
 
     it('logs an array directly to console', () => {
         const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const log = useLogger('feature');
+        const log = getLogger('feature');
         log.warn('items::', [1, 2, 3]);
 
         expect(spy).toHaveBeenCalledWith('[feature]', 'items::', [1, 2, 3]);
@@ -261,15 +307,16 @@ describe('primitives and arrays', () => {
 // ---------------------------------------------------------------------------
 
 describe('dev vs prod transport', () => {
-    it('debug is dropped when Sentry transport is active', () => {
+    it('debug reaches console in non-production even when Sentry transport is active', () => {
+        // NODE_ENV is 'test' in Vitest, not 'production', so debug is not dropped.
         const transport = makeMockTransport();
         configureSentryTransport(transport);
 
         const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
         logger.debug('verbose detail');
 
-        expect(spy).not.toHaveBeenCalled();
-        expect(transport.calls).toHaveLength(0);
+        expect(spy).toHaveBeenCalledOnce();
+        expect(transport.calls).toHaveLength(0); // debug never goes to Sentry
     });
 
     it('debug reaches console when no transport is registered', () => {

--- a/packages/learn-card-base/src/logging/logger.test.ts
+++ b/packages/learn-card-base/src/logging/logger.test.ts
@@ -30,7 +30,8 @@ function makeMockTransport(): SentryTransport & {
 
 beforeEach(() => {
     configureSentryTransport(null);
-    configureLoggerContext({ bugReportsEnabled: true, tenantId: undefined });
+    // Pass null (not undefined) to actually clear tenantId between tests
+    configureLoggerContext({ bugReportsEnabled: true, tenantId: null });
     vi.restoreAllMocks();
 });
 
@@ -39,7 +40,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('PII scrubbing', () => {
-    it('redacts known PII field names', () => {
+    it('scrubs known PII field names', () => {
         const transport = makeMockTransport();
         configureSentryTransport(transport);
 
@@ -69,7 +70,7 @@ describe('PII scrubbing', () => {
         expect(extra.safeField).toBe('visible');
     });
 
-    it('redacts bearer token strings in values', () => {
+    it('scrubs bearer token strings in values', () => {
         const transport = makeMockTransport();
         configureSentryTransport(transport);
 
@@ -89,7 +90,6 @@ describe('PII scrubbing', () => {
         const call = transport.calls.find(c => c.method === 'captureMessage');
         const extra = call!.args[3] as Record<string, unknown>;
         expect(extra.email).toBe('user@example.com');
-        // allowPii itself should not appear in extra
         expect('allowPii' in extra).toBe(false);
     });
 });
@@ -170,6 +170,90 @@ describe('scope prefixing', () => {
         const call = transport.calls.find(c => c.method === 'captureMessage');
         expect(call!.args[2]).toMatchObject({ tenantId: 'acme' });
     });
+
+    it('clears tenantId when passed null', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+        configureLoggerContext({ tenantId: 'acme' });
+        configureLoggerContext({ tenantId: null });
+
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        logger.warn('test');
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect((call!.args[2] as Record<string, string>).tenantId).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Primitives and arrays
+// ---------------------------------------------------------------------------
+
+describe('primitives and arrays', () => {
+    it('logs a boolean directly to console', () => {
+        const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const log = useLogger('feature');
+        log.info('isEnabled::', false);
+
+        expect(spy).toHaveBeenCalledWith('[feature]', 'isEnabled::', false);
+    });
+
+    it('logs a number directly to console', () => {
+        const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const log = useLogger('feature');
+        log.info('count::', 42);
+
+        expect(spy).toHaveBeenCalledWith('[feature]', 'count::', 42);
+    });
+
+    it('logs a string directly to console (not wrapped as Error)', () => {
+        const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const log = useLogger('feature');
+        log.info('status::', 'active');
+
+        expect(spy).toHaveBeenCalledWith('[feature]', 'status::', 'active');
+    });
+
+    it('logs an array directly to console', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const log = useLogger('feature');
+        log.warn('items::', [1, 2, 3]);
+
+        expect(spy).toHaveBeenCalledWith('[feature]', 'items::', [1, 2, 3]);
+    });
+
+    it('sends primitive as { value } in Sentry breadcrumb (info)', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        logger.info('flag::', true);
+
+        expect(transport.calls[0].method).toBe('addBreadcrumb');
+        const data = (transport.calls[0].args[0] as { data: Record<string, unknown> }).data;
+        expect(data.value).toBe(true);
+    });
+
+    it('sends primitive as { value } in Sentry captureMessage (warn)', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        logger.warn('flag::', false);
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect((call!.args[3] as Record<string, unknown>).value).toBe(false);
+    });
+
+    it('sends primitive as { value } in Sentry captureMessage (error, no Error object)', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('count::', 99);
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect((call!.args[3] as Record<string, unknown>).value).toBe(99);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -202,9 +286,7 @@ describe('dev vs prod transport', () => {
         logger.info('user navigated', { page: 'home' });
 
         expect(transport.calls[0].method).toBe('addBreadcrumb');
-        expect((transport.calls[0].args[0] as { message: string }).message).toBe(
-            'user navigated'
-        );
+        expect((transport.calls[0].args[0] as { message: string }).message).toBe('user navigated');
     });
 
     it('info reaches console in dev (no transport)', () => {
@@ -240,7 +322,7 @@ describe('dev vs prod transport', () => {
         expect(call!.args[0]).toBe(err);
     });
 
-    it('error without Error calls captureMessage', () => {
+    it('error without Error object calls captureMessage', () => {
         const transport = makeMockTransport();
         configureSentryTransport(transport);
 

--- a/packages/learn-card-base/src/logging/logger.test.ts
+++ b/packages/learn-card-base/src/logging/logger.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    logger,
+    configureSentryTransport,
+    configureLoggerContext,
+    useLogger,
+    type SentryTransport,
+} from './logger';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockTransport(): SentryTransport & {
+    calls: { method: string; args: unknown[] }[];
+} {
+    const calls: { method: string; args: unknown[] }[] = [];
+    return {
+        calls,
+        captureException: (...args) => calls.push({ method: 'captureException', args }),
+        captureMessage: (...args) => calls.push({ method: 'captureMessage', args }),
+        addBreadcrumb: (...args) => calls.push({ method: 'addBreadcrumb', args }),
+        withScope: (...args) => calls.push({ method: 'withScope', args }),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Reset module state between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    configureSentryTransport(null);
+    configureLoggerContext({ bugReportsEnabled: true, tenantId: undefined });
+    vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// PII scrubbing
+// ---------------------------------------------------------------------------
+
+describe('PII scrubbing', () => {
+    it('redacts known PII field names', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        logger.error('test error', new Error('boom'), {
+            email: 'user@example.com',
+            phone: '555-1234',
+            name: 'Alice',
+            did: 'did:key:abc',
+            seed: 'supersecret',
+            privateKey: 'pk-abc',
+            accessToken: 'tok-xyz',
+            idToken: 'id-tok',
+            safeField: 'visible',
+        });
+
+        const call = transport.calls.find(c => c.method === 'captureException');
+        expect(call).toBeDefined();
+        const extra = call!.args[2] as Record<string, unknown>;
+        expect(extra.email).toBe('[scrubbed]');
+        expect(extra.phone).toBe('[scrubbed]');
+        expect(extra.name).toBe('[scrubbed]');
+        expect(extra.did).toBe('[scrubbed]');
+        expect(extra.seed).toBe('[scrubbed]');
+        expect(extra.privateKey).toBe('[scrubbed]');
+        expect(extra.accessToken).toBe('[scrubbed]');
+        expect(extra.idToken).toBe('[scrubbed]');
+        expect(extra.safeField).toBe('visible');
+    });
+
+    it('redacts bearer token strings in values', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        logger.warn('bearer test', { authHeader: 'Bearer eyJhbGci...' });
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        const extra = call!.args[3] as Record<string, unknown>;
+        expect(extra.authHeader).toBe('[scrubbed]');
+    });
+
+    it('passes through all fields when allowPii is true', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        logger.warn('pii allowed', { email: 'user@example.com', allowPii: true });
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        const extra = call!.args[3] as Record<string, unknown>;
+        expect(extra.email).toBe('user@example.com');
+        // allowPii itself should not appear in extra
+        expect('allowPii' in extra).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Privacy gate
+// ---------------------------------------------------------------------------
+
+describe('privacy gate', () => {
+    it('suppresses Sentry transport when bugReportsEnabled is false', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+        configureLoggerContext({ bugReportsEnabled: false });
+
+        logger.error('should not reach sentry', new Error('boom'));
+
+        expect(transport.calls).toHaveLength(0);
+    });
+
+    it('still logs to console when bugReportsEnabled is false', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+        configureLoggerContext({ bugReportsEnabled: false });
+
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('still console', new Error('boom'));
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(transport.calls).toHaveLength(0);
+    });
+
+    it('re-enables Sentry when bugReportsEnabled flips back to true', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+        configureLoggerContext({ bugReportsEnabled: false });
+        configureLoggerContext({ bugReportsEnabled: true });
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('back on', new Error('boom'));
+
+        expect(transport.calls).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scope prefixing
+// ---------------------------------------------------------------------------
+
+describe('scope prefixing', () => {
+    it('useLogger prefixes console output with [scope]', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const log = useLogger('wallet/claim');
+        log.warn('something happened');
+
+        expect(spy).toHaveBeenCalledWith('[wallet/claim]', 'something happened', {});
+    });
+
+    it('attaches scope tag to Sentry events', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        const log = useLogger('credential/issue');
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        log.error('failed');
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect(call!.args[2]).toMatchObject({ scope: 'credential/issue' });
+    });
+
+    it('attaches tenantId tag when configured', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+        configureLoggerContext({ tenantId: 'acme' });
+
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        logger.warn('test');
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect(call!.args[2]).toMatchObject({ tenantId: 'acme' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Dev-vs-prod transport selection
+// ---------------------------------------------------------------------------
+
+describe('dev vs prod transport', () => {
+    it('debug is dropped when Sentry transport is active', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        logger.debug('verbose detail');
+
+        expect(spy).not.toHaveBeenCalled();
+        expect(transport.calls).toHaveLength(0);
+    });
+
+    it('debug reaches console when no transport is registered', () => {
+        const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        logger.debug('dev debug');
+
+        expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('info becomes a Sentry breadcrumb in prod', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        logger.info('user navigated', { page: 'home' });
+
+        expect(transport.calls[0].method).toBe('addBreadcrumb');
+        expect((transport.calls[0].args[0] as { message: string }).message).toBe(
+            'user navigated'
+        );
+    });
+
+    it('info reaches console in dev (no transport)', () => {
+        const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        logger.info('dev info');
+
+        expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('warn captures Sentry message and logs to console in prod', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        logger.warn('slow request', { ms: 500 });
+
+        expect(spy).toHaveBeenCalledOnce();
+        const sentryCall = transport.calls.find(c => c.method === 'captureMessage');
+        expect(sentryCall).toBeDefined();
+        expect(sentryCall!.args[1]).toBe('warning');
+    });
+
+    it('error with Error calls captureException', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        const err = new Error('oops');
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('exploded', err);
+
+        const call = transport.calls.find(c => c.method === 'captureException');
+        expect(call).toBeDefined();
+        expect(call!.args[0]).toBe(err);
+    });
+
+    it('error without Error calls captureMessage', () => {
+        const transport = makeMockTransport();
+        configureSentryTransport(transport);
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        logger.error('string error only');
+
+        const call = transport.calls.find(c => c.method === 'captureMessage');
+        expect(call).toBeDefined();
+        expect(call!.args[1]).toBe('error');
+    });
+});

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -1,0 +1,272 @@
+// ---------------------------------------------------------------------------
+// PII scrubbing
+// ---------------------------------------------------------------------------
+
+const PII_FIELDS = [
+    'email',
+    'phone',
+    'name',
+    'did',
+    'seed',
+    'privateKey',
+    'accessToken',
+    'idToken',
+];
+const BEARER_RE = /^bearer /i;
+
+// Replaces PII values with '[scrubbed]'. Two triggers:
+//   1. Key name is in PII_FIELDS (e.g. "email", "did")
+//   2. String value starts with "Bearer " (leaked auth header)
+// Pass allowPii: true in meta to skip scrubbing for internal debug calls.
+const scrub = (meta: Record<string, unknown>, allowPii = false): Record<string, unknown> => {
+    if (allowPii) return meta;
+    return Object.fromEntries(
+        Object.entries(meta).map(([key, value]) => {
+            const isPii =
+                PII_FIELDS.includes(key) || (typeof value === 'string' && BEARER_RE.test(value));
+
+            return [key, isPii ? '[scrubbed]' : value];
+        })
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Injectable Sentry transport — avoids adding @sentry/react as a dep here.
+// The host app (learn-card-app, scouts) calls configureSentryTransport() once
+// during Sentry.init(), and configureLoggerContext() whenever user preferences
+// change (wired inside useSentryIdentify).
+// ---------------------------------------------------------------------------
+
+export type SentryLevel = 'debug' | 'info' | 'warning' | 'error' | 'fatal';
+
+export interface SentryTransport {
+    captureException(
+        err: unknown,
+        tags?: Record<string, string>,
+        extra?: Record<string, unknown>
+    ): void;
+    captureMessage(
+        msg: string,
+        level: 'warning' | 'error',
+        tags?: Record<string, string>,
+        extra?: Record<string, unknown>
+    ): void;
+    addBreadcrumb(opts: {
+        category?: string;
+        message: string;
+        data?: Record<string, unknown>;
+        level?: SentryLevel;
+    }): void;
+    withScope(
+        fn: (scope: {
+            setTag(k: string, v: string): void;
+            setExtra(k: string, v: unknown): void;
+        }) => void
+    ): void;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level config
+// ---------------------------------------------------------------------------
+
+let _transport: SentryTransport | null = null; // null = dev mode, no Sentry forwarding
+let _bugReportsEnabled = true; // mirrors user's bugReportsEnabled preference; default true so existing users without stored prefs are unaffected
+let _tenantId: string | undefined; // included as a Sentry tag on every captured event
+
+/** Call after Sentry.init() so the logger can forward events. */
+export const configureSentryTransport = (t: SentryTransport | null): void => {
+    _transport = t;
+};
+
+/** Called by useSentryIdentify whenever preferences / tenantId change. */
+export const configureLoggerContext = (opts: {
+    bugReportsEnabled?: boolean;
+    tenantId?: string;
+}): void => {
+    if (opts.bugReportsEnabled !== undefined) _bugReportsEnabled = opts.bugReportsEnabled;
+    if (opts.tenantId !== undefined) _tenantId = opts.tenantId;
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Structured metadata bag that may carry an opt-in PII bypass flag.
+type Meta = Record<string, unknown> & { allowPii?: boolean };
+
+// Guards against accidental Error objects being treated as metadata bags.
+const isMeta = (x: unknown): x is Meta => {
+    return typeof x === 'object' && x !== null && !(x instanceof Error);
+};
+
+// Normalises the overloaded second argument accepted by every log method.
+// Accepts `unknown` so callers can pass a raw catch-block value without
+// wrapping it themselves — the coercion to Error happens here, once.
+//
+//   log.error('msg', err)          → [err, {}, false]
+//   log.error('msg', err, { key }) → [err, { key }, false]
+//   log.error('msg', { key })      → [undefined, { key }, false]
+//   log.error('msg', unknownValue) → [Error(String(unknownValue)), {}, false]
+//
+// Strips allowPii before returning so it never reaches Sentry as an extra field.
+const parseMeta = (
+    metaOrError?: unknown,
+    meta?: Meta
+): [Error | undefined, Record<string, unknown>, boolean] => {
+    let err: Error | undefined;
+    let raw: Record<string, unknown> = {};
+
+    if (metaOrError instanceof Error) {
+        err = metaOrError;
+        raw = meta ?? {};
+    } else if (metaOrError && isMeta(metaOrError)) {
+        raw = metaOrError;
+    } else if (metaOrError !== undefined) {
+        // Auto-wrap primitives and non-Error objects thrown in catch blocks
+        err = new Error(String(metaOrError));
+        raw = meta ?? {};
+    }
+
+    const { allowPii, ...rest } = raw as Meta;
+    return [err, scrub(rest, allowPii), allowPii ?? false];
+};
+
+// True only when a Sentry transport is registered AND the user has opted in.
+// When false the logger falls back to console-only (dev mode or privacy gate active).
+const sentryActive = (): boolean => _transport !== null && _bugReportsEnabled;
+
+// Assembles the Sentry tags that are attached to every captured event.
+// scope identifies which feature/module logged the event; tenantId enables per-tenant filtering.
+const buildTags = (scope?: string): Record<string, string> => {
+    const tags: Record<string, string> = {};
+    if (scope) tags['scope'] = scope;
+    if (_tenantId) tags['tenantId'] = _tenantId;
+    return tags;
+};
+
+// ---------------------------------------------------------------------------
+// Logger factory
+// ---------------------------------------------------------------------------
+
+export interface Logger {
+    debug(msg: string, metaOrError?: unknown, meta?: Meta): void;
+    info(msg: string, metaOrError?: unknown, meta?: Meta): void;
+    warn(msg: string, metaOrError?: unknown, meta?: Meta): void;
+    error(msg: string, metaOrError?: unknown, meta?: Meta): void;
+    breadcrumb(opts: {
+        category: string;
+        message: string;
+        data?: Record<string, unknown>;
+        level?: SentryLevel;
+    }): void;
+    withContext(
+        fn: (scope: {
+            setTag(k: string, v: string): void;
+            setExtra(k: string, v: unknown): void;
+        }) => void
+    ): void;
+}
+
+const createLogger = (scope?: string): Logger => {
+    const prefix = scope ? `[${scope}]` : ''; // log prefix
+    const tags = () => buildTags(scope);
+
+    return {
+        debug(msg, metaOrError?, meta?) {
+            // Dropped when Sentry transport is active (production)
+            if (sentryActive()) return;
+            const [err, extra] = parseMeta(metaOrError, meta);
+            if (err) console.debug(prefix, msg, err, extra);
+            else console.debug(prefix, msg, extra);
+        },
+
+        info(msg, metaOrError?, meta?) {
+            const [err, extra] = parseMeta(metaOrError, meta);
+            if (sentryActive()) {
+                _transport!.addBreadcrumb({
+                    category: scope,
+                    message: msg,
+                    data: { ...extra, ...(err ? { error: String(err) } : {}) },
+                    level: 'info',
+                });
+            } else {
+                if (err) console.info(prefix, msg, err, extra);
+                else console.info(prefix, msg, extra);
+            }
+        },
+
+        warn(msg, metaOrError?, meta?) {
+            const [err, extra] = parseMeta(metaOrError, meta);
+            // Always log to console so devs see warnings in both envs
+            if (err) console.warn(prefix, msg, err, extra);
+            else console.warn(prefix, msg, extra);
+            if (sentryActive()) {
+                _transport!.captureMessage(msg, 'warning', tags(), extra);
+            }
+        },
+
+        error(msg, metaOrError?, meta?) {
+            const [err, extra] = parseMeta(metaOrError, meta);
+            if (err) console.error(prefix, msg, err, extra);
+            else console.error(prefix, msg, extra);
+            if (sentryActive()) {
+                if (err) _transport!.captureException(err, tags(), extra);
+                else _transport!.captureMessage(msg, 'error', tags(), extra);
+            }
+        },
+
+        breadcrumb(opts) {
+            if (sentryActive()) _transport!.addBreadcrumb(opts);
+        },
+
+        withContext(fn) {
+            if (sentryActive()) _transport!.withScope(fn);
+        },
+    };
+};
+
+// ---------------------------------------------------------------------------
+// Public exports
+// ---------------------------------------------------------------------------
+
+/** Module-level logger — use for non-React contexts. */
+export const logger = createLogger();
+
+/**
+ * Returns a logger whose messages are prefixed with `[scope]`.
+ * Stable across renders since createLogger is pure and lightweight.
+ *
+ * Despite the `use` prefix this is NOT a React hook — it is a plain factory
+ * and may be called at module level or inside components alike.
+ *
+ * @example
+ * Module-level (outside any component)
+ * const log = useLogger('auth-coordinator');
+ *
+ * log.debug('wallet ready');
+ * → console.debug('[auth-coordinator]', 'wallet ready', {})   (dev only)
+ *
+ * log.info('profile loaded', { profileId: '123' });
+ * → console.info('[auth-coordinator]', 'profile loaded', { profileId: '123' })
+ * → Sentry breadcrumb { category: 'auth-coordinator', message: 'profile loaded', data: { profileId: '123' } }
+ *
+ * log.warn('token expiring soon', { expiresIn: 60 });
+ * → console.warn('[auth-coordinator]', 'token expiring soon', { expiresIn: 60 })
+ * → Sentry captureMessage('token expiring soon', 'warning', { scope: 'auth-coordinator' }, { expiresIn: 60 })
+
+ * log.error('sign-in failed', error);
+ * → console.error('[auth-coordinator]', 'sign-in failed', Error('...'), {})
+ * → Sentry captureException(error, { scope: 'auth-coordinator' })
+ *
+ * PII fields are automatically scrubbed from meta objects
+ * log.error('lookup failed', { email: 'user@example.com', code: 404 });
+ * → Sentry extra: { email: '[scrubbed]', code: 404 }
+ *
+ * Pass a raw catch-block value — logger wraps it in Error() internally
+ * try { ... } catch (e) { log.error('unexpected', e); }
+ *
+ * Opt out of PII scrubbing for internal debug calls (never use in prod paths)
+ * log.warn('debug identity', { email: 'user@example.com', allowPii: true });
+ * → Sentry extra: { email: 'user@example.com' }   // allowPii itself is stripped
+ */
+export const useLogger = (scope: string): Logger => createLogger(scope);

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -78,13 +78,13 @@ export const configureSentryTransport = (t: SentryTransport | null): void => {
     _transport = t;
 };
 
-/** Called by useSentryIdentify whenever preferences / tenantId change. */
+/** Called by useSentryIdentify whenever preferences / tenantId change. Pass null to clear tenantId (e.g. on logout). */
 export const configureLoggerContext = (opts: {
     bugReportsEnabled?: boolean;
-    tenantId?: string;
+    tenantId?: string | null;
 }): void => {
     if (opts.bugReportsEnabled !== undefined) _bugReportsEnabled = opts.bugReportsEnabled;
-    if (opts.tenantId !== undefined) _tenantId = opts.tenantId;
+    if (opts.tenantId !== undefined) _tenantId = opts.tenantId ?? undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -94,41 +94,44 @@ export const configureLoggerContext = (opts: {
 // Structured metadata bag that may carry an opt-in PII bypass flag.
 type Meta = Record<string, unknown> & { allowPii?: boolean };
 
-// Guards against accidental Error objects being treated as metadata bags.
+// Guards against accidental Error objects and arrays being treated as metadata bags.
 const isMeta = (x: unknown): x is Meta => {
-    return typeof x === 'object' && x !== null && !(x instanceof Error);
+    return typeof x === 'object' && x !== null && !(x instanceof Error) && !Array.isArray(x);
 };
 
 // Normalises the overloaded second argument accepted by every log method.
-// Accepts `unknown` so callers can pass a raw catch-block value without
-// wrapping it themselves — the coercion to Error happens here, once.
+// Accepts `unknown` so callers can pass any value without wrapping it first.
+// Primitives and arrays are surfaced as-is for console output and wrapped in
+// { value } for Sentry — no object wrapper required at the call site.
 //
-//   log.error('msg', err)          → [err, {}, false]
-//   log.error('msg', err, { key }) → [err, { key }, false]
-//   log.error('msg', { key })      → [undefined, { key }, false]
-//   log.error('msg', unknownValue) → [Error(String(unknownValue)), {}, false]
+//   log.error('msg', err)          → [err,       {},      undefined]
+//   log.error('msg', err, { key }) → [err,       { key }, undefined]
+//   log.error('msg', { key })      → [undefined, { key }, undefined]
+//   log.info('flag', false)        → [undefined, {},      false]
+//   log.info('items', [1, 2])      → [undefined, {},      [1, 2]]
 //
 // Strips allowPii before returning so it never reaches Sentry as an extra field.
 const parseMeta = (
     metaOrError?: unknown,
     meta?: Meta
-): [Error | undefined, Record<string, unknown>, boolean] => {
+): [Error | undefined, Record<string, unknown>, unknown?] => {
     let err: Error | undefined;
     let raw: Record<string, unknown> = {};
+    let primitive: unknown;
 
     if (metaOrError instanceof Error) {
         err = metaOrError;
         raw = meta ?? {};
-    } else if (metaOrError && isMeta(metaOrError)) {
+    } else if (isMeta(metaOrError)) {
         raw = metaOrError;
     } else if (metaOrError !== undefined) {
-        // Auto-wrap primitives and non-Error objects thrown in catch blocks
-        err = new Error(String(metaOrError));
+        // Primitive (boolean, number, string, bigint) or array — display directly
+        primitive = metaOrError;
         raw = meta ?? {};
     }
 
     const { allowPii, ...rest } = raw as Meta;
-    return [err, scrub(rest, allowPii), allowPii ?? false];
+    return [err, scrub(rest, allowPii), primitive];
 };
 
 // True only when a Sentry transport is registered AND the user has opted in.
@@ -168,50 +171,68 @@ export interface Logger {
 }
 
 const createLogger = (scope?: string): Logger => {
-    const prefix = scope ? `[${scope}]` : ''; // log prefix
+    const prefix = scope ? `[${scope}]` : '';
     const tags = () => buildTags(scope);
 
     return {
         debug(msg, metaOrError?, meta?) {
             // Dropped when Sentry transport is active (production)
             if (sentryActive()) return;
-            const [err, extra] = parseMeta(metaOrError, meta);
+            const [err, extra, primitive] = parseMeta(metaOrError, meta);
             if (err) console.debug(prefix, msg, err, extra);
+            else if (primitive !== undefined) console.debug(prefix, msg, primitive);
             else console.debug(prefix, msg, extra);
         },
 
         info(msg, metaOrError?, meta?) {
-            const [err, extra] = parseMeta(metaOrError, meta);
+            const [err, extra, primitive] = parseMeta(metaOrError, meta);
             if (sentryActive()) {
                 _transport!.addBreadcrumb({
                     category: scope,
                     message: msg,
-                    data: { ...extra, ...(err ? { error: String(err) } : {}) },
+                    data: {
+                        ...(primitive !== undefined ? { value: primitive } : extra),
+                        ...(err ? { error: String(err) } : {}),
+                    },
                     level: 'info',
                 });
             } else {
                 if (err) console.info(prefix, msg, err, extra);
+                else if (primitive !== undefined) console.info(prefix, msg, primitive);
                 else console.info(prefix, msg, extra);
             }
         },
 
         warn(msg, metaOrError?, meta?) {
-            const [err, extra] = parseMeta(metaOrError, meta);
+            const [err, extra, primitive] = parseMeta(metaOrError, meta);
             // Always log to console so devs see warnings in both envs
             if (err) console.warn(prefix, msg, err, extra);
+            else if (primitive !== undefined) console.warn(prefix, msg, primitive);
             else console.warn(prefix, msg, extra);
             if (sentryActive()) {
-                _transport!.captureMessage(msg, 'warning', tags(), extra);
+                _transport!.captureMessage(
+                    msg,
+                    'warning',
+                    tags(),
+                    primitive !== undefined ? { value: primitive } : extra
+                );
             }
         },
 
         error(msg, metaOrError?, meta?) {
-            const [err, extra] = parseMeta(metaOrError, meta);
+            const [err, extra, primitive] = parseMeta(metaOrError, meta);
             if (err) console.error(prefix, msg, err, extra);
+            else if (primitive !== undefined) console.error(prefix, msg, primitive);
             else console.error(prefix, msg, extra);
             if (sentryActive()) {
                 if (err) _transport!.captureException(err, tags(), extra);
-                else _transport!.captureMessage(msg, 'error', tags(), extra);
+                else
+                    _transport!.captureMessage(
+                        msg,
+                        'error',
+                        tags(),
+                        primitive !== undefined ? { value: primitive } : extra
+                    );
             }
         },
 
@@ -262,7 +283,13 @@ export const logger = createLogger();
  * log.error('lookup failed', { email: 'user@example.com', code: 404 });
  * → Sentry extra: { email: '[scrubbed]', code: 404 }
  *
- * Pass a raw catch-block value — logger wraps it in Error() internally
+ * Primitives and arrays are displayed as-is — no object wrapper needed
+ * log.info('isEnabled::', false)   → console.info('[scope]', 'isEnabled::', false)
+ * log.info('count::', 42)          → console.info('[scope]', 'count::', 42)
+ * log.info('items::', [1, 2, 3])   → console.info('[scope]', 'items::', [1, 2, 3])
+ * → Sentry breadcrumb data: { value: false / 42 / [...] }
+ *
+ * Pass a raw catch-block value — logger handles it internally
  * try { ... } catch (e) { log.error('unexpected', e); }
  *
  * Opt out of PII scrubbing for internal debug calls (never use in prod paths)

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -4,7 +4,7 @@
 
 // Keys containing these substrings (case-insensitive) are treated as PII,
 // catching common variants: userEmail, phoneNumber, firstName, accessToken, etc.
-const PII_SUBSTRINGS = ['email', 'phone', 'name', 'seed', 'password', 'privatekey', 'accesstoken', 'idtoken', 'token'];
+const PII_SUBSTRINGS = ['email', 'phone', 'name', 'seed', 'password', 'privatekey', 'accesstoken', 'idtoken'];
 // Short/ambiguous keywords matched exactly (case-insensitive) to avoid false positives.
 const PII_EXACT_LC = new Set(['did']);
 const BEARER_RE = /^bearer /i;

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -2,32 +2,47 @@
 // PII scrubbing
 // ---------------------------------------------------------------------------
 
-const PII_FIELDS = [
-    'email',
-    'phone',
-    'name',
-    'did',
-    'seed',
-    'privateKey',
-    'accessToken',
-    'idToken',
-];
+// Keys containing these substrings (case-insensitive) are treated as PII,
+// catching common variants: userEmail, phoneNumber, firstName, accessToken, etc.
+const PII_SUBSTRINGS = ['email', 'phone', 'name', 'seed', 'password', 'privatekey', 'accesstoken', 'idtoken', 'token'];
+// Short/ambiguous keywords matched exactly (case-insensitive) to avoid false positives.
+const PII_EXACT_LC = new Set(['did']);
 const BEARER_RE = /^bearer /i;
 
-// Replaces PII values with '[scrubbed]'. Two triggers:
-//   1. Key name is in PII_FIELDS (e.g. "email", "did")
+const isPiiKey = (key: string): boolean => {
+    const lc = key.toLowerCase();
+    return PII_EXACT_LC.has(lc) || PII_SUBSTRINGS.some(sub => lc.includes(sub));
+};
+
+// Recursively replaces PII values with '[scrubbed]'. Three triggers:
+//   1. Key name matches a PII pattern (isPiiKey)
 //   2. String value starts with "Bearer " (leaked auth header)
+//   3. Nested object/array contains either of the above
+// Uses a seen-set to guard against circular references and a depth cap of 10.
 // Pass allowPii: true in meta to skip scrubbing for internal debug calls.
+const scrubValue = (value: unknown, depth: number, seen: Set<object>): unknown => {
+    if (depth > 10) return value;
+    if (Array.isArray(value)) {
+        if (seen.has(value)) return '[circular]';
+        seen.add(value);
+        return value.map(item => scrubValue(item, depth + 1, seen));
+    }
+    if (typeof value === 'object' && value !== null && !(value instanceof Error)) {
+        if (seen.has(value)) return '[circular]';
+        seen.add(value);
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).map(([k, v]) => {
+                if (isPiiKey(k) || (typeof v === 'string' && BEARER_RE.test(v))) return [k, '[scrubbed]'];
+                return [k, scrubValue(v, depth + 1, seen)];
+            })
+        );
+    }
+    return value;
+};
+
 const scrub = (meta: Record<string, unknown>, allowPii = false): Record<string, unknown> => {
     if (allowPii) return meta;
-    return Object.fromEntries(
-        Object.entries(meta).map(([key, value]) => {
-            const isPii =
-                PII_FIELDS.includes(key) || (typeof value === 'string' && BEARER_RE.test(value));
-
-            return [key, isPii ? '[scrubbed]' : value];
-        })
-    );
+    return scrubValue(meta, 0, new Set()) as Record<string, unknown>;
 };
 
 // ---------------------------------------------------------------------------
@@ -176,8 +191,8 @@ const createLogger = (scope?: string): Logger => {
 
     return {
         debug(msg, metaOrError?, meta?) {
-            // Dropped when Sentry transport is active (production)
-            if (sentryActive()) return;
+            // Dropped in production (transport active + non-dev environment) to avoid noise.
+            if (sentryActive() && process.env.NODE_ENV === 'production') return;
             const [err, extra, primitive] = parseMeta(metaOrError, meta);
             if (err) console.debug(prefix, msg, err, extra);
             else if (primitive !== undefined) console.debug(prefix, msg, primitive);
@@ -257,12 +272,11 @@ export const logger = createLogger();
  * Returns a logger whose messages are prefixed with `[scope]`.
  * Stable across renders since createLogger is pure and lightweight.
  *
- * Despite the `use` prefix this is NOT a React hook — it is a plain factory
- * and may be called at module level or inside components alike.
+ * May be called at module level or inside components alike.
  *
  * @example
  * Module-level (outside any component)
- * const log = useLogger('auth-coordinator');
+ * const log = getLogger('auth-coordinator');
  *
  * log.debug('wallet ready');
  * → console.debug('[auth-coordinator]', 'wallet ready', {})   (dev only)
@@ -274,12 +288,12 @@ export const logger = createLogger();
  * log.warn('token expiring soon', { expiresIn: 60 });
  * → console.warn('[auth-coordinator]', 'token expiring soon', { expiresIn: 60 })
  * → Sentry captureMessage('token expiring soon', 'warning', { scope: 'auth-coordinator' }, { expiresIn: 60 })
-
+ *
  * log.error('sign-in failed', error);
  * → console.error('[auth-coordinator]', 'sign-in failed', Error('...'), {})
  * → Sentry captureException(error, { scope: 'auth-coordinator' })
  *
- * PII fields are automatically scrubbed from meta objects
+ * PII fields are automatically scrubbed from meta objects (including nested)
  * log.error('lookup failed', { email: 'user@example.com', code: 404 });
  * → Sentry extra: { email: '[scrubbed]', code: 404 }
  *
@@ -296,4 +310,7 @@ export const logger = createLogger();
  * log.warn('debug identity', { email: 'user@example.com', allowPii: true });
  * → Sentry extra: { email: 'user@example.com' }   // allowPii itself is stripped
  */
-export const useLogger = (scope: string): Logger => createLogger(scope);
+export const getLogger = (scope: string): Logger => createLogger(scope);
+
+/** @deprecated Use getLogger instead — avoids react-hooks/rules-of-hooks false positives at module level. */
+export const useLogger = getLogger;

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -2,10 +2,21 @@
 // PII scrubbing
 // ---------------------------------------------------------------------------
 
-// Keys containing these substrings (case-insensitive) are treated as PII,
-// catching common variants: userEmail, phoneNumber, firstName, accessToken, etc.
-const PII_SUBSTRINGS = ['email', 'phone', 'name', 'seed', 'password', 'privatekey', 'accesstoken', 'idtoken', 'token'];
-// Short/ambiguous keywords matched exactly (case-insensitive) to avoid false positives.
+// Keys are checked case-insensitively as substrings, catching common variants:
+//   email → userEmail, emailAddress   phone → phoneNumber, mobilePhone
+//   name  → firstName, lastName       token → accessToken, bearerToken, authToken
+const PII_SUBSTRINGS = [
+    'email',
+    'phone',
+    'name',
+    'seed',
+    'password',
+    'privatekey',
+    'accesstoken',
+    'idtoken',
+    'token',
+];
+// 'did' is too short for safe substring matching (would match "additional", "edited"), so exact only.
 const PII_EXACT_LC = new Set(['did']);
 const BEARER_RE = /^bearer /i;
 
@@ -32,7 +43,8 @@ const scrubValue = (value: unknown, depth: number, seen: Set<object>): unknown =
         seen.add(value);
         return Object.fromEntries(
             Object.entries(value as Record<string, unknown>).map(([k, v]) => {
-                if (isPiiKey(k) || (typeof v === 'string' && BEARER_RE.test(v))) return [k, '[scrubbed]'];
+                if (isPiiKey(k) || (typeof v === 'string' && BEARER_RE.test(v)))
+                    return [k, '[scrubbed]'];
                 return [k, scrubValue(v, depth + 1, seen)];
             })
         );
@@ -311,6 +323,3 @@ export const logger = createLogger();
  * → Sentry extra: { email: 'user@example.com' }   // allowPii itself is stripped
  */
 export const getLogger = (scope: string): Logger => createLogger(scope);
-
-/** @deprecated Use getLogger instead — avoids react-hooks/rules-of-hooks false positives at module level. */
-export const useLogger = getLogger;

--- a/packages/learn-card-base/src/logging/logger.ts
+++ b/packages/learn-card-base/src/logging/logger.ts
@@ -157,7 +157,8 @@ const parseMeta = (
         raw = meta ?? {};
     }
 
-    const { allowPii, ...rest } = raw as Meta;
+    const { allowPii: allowPiiFromRaw, ...rest } = raw as Meta;
+    const allowPii = allowPiiFromRaw ?? (meta as Meta | undefined)?.allowPii;
     return [err, scrub(rest, allowPii), primitive];
 };
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Introduces a structured, PII-safe logger for `learn-card-app` and `scouts` built on an injectable Sentry transport. Replaces scattered `console.*` calls and direct `Sentry.captureException` calls in key infrastructure files with a single, consistent logging API.

---

## What changed

### New: `packages/learn-card-base/src/logging/logger.ts`

Core logger implementation exported from `learn-card-base`. Key design decisions:

- **Injectable transport** — `learn-card-base` never imports `@sentry/react`. Apps register a `SentryTransport` adapter after `Sentry.init()` via `configureSentryTransport()`.
- **Privacy gate** — when `bugReportsEnabled === false`, all Sentry forwarding is suppressed. Console output is unaffected. Gate stays in sync via `configureLoggerContext({ bugReportsEnabled })` called from `useSentryIdentify`.
- **PII scrubbing** — fields named `email`, `phone`, `name`, `did`, `seed`, `privateKey`, `accessToken`, `idToken`, or any string value matching `/^bearer /i` are replaced with `[scrubbed]` before reaching Sentry. Opt out with `{ allowPii: true }`.
- **Ergonomic second argument** — pass an `Error`, a plain object, or a bare primitive/array. The logger normalises internally so call sites need no wrapping.
- **`useLogger(scope)`** — plain factory (not a React hook) safe at module level or inside components.

#### Log level behaviour

| Level | Dev | Prod (Sentry active) |
|---|---|---|
| `debug` | `console.debug` | **dropped** |
| `info` | `console.info` | Sentry breadcrumb |
| `warn` | `console.warn` | `console.warn` + `captureMessage` |
| `error` | `console.error` | `console.error` + `captureException` / `captureMessage` |

---

### New: `packages/learn-card-base/src/logging/logger.test.ts`

24 unit tests covering:

- PII scrubbing (all field names, bearer tokens, `allowPii` bypass)
- Privacy gate (suppress / restore Sentry, console always fires)
- Scope prefixing (console prefix, Sentry tags, `tenantId` attach/clear)
- Primitives and arrays (direct console output, `{ value }` wrapping in Sentry)
- Dev vs prod transport selection (all four levels)

---

### Updated: `apps/learn-card-app/src/constants/sentry.ts` & `apps/scouts/src/constants/sentry.ts`

- Removed `captureConsoleIntegration` — the logger is now the only path to Sentry, ensuring PII scrubbing and the privacy gate are always applied.
- Wired `configureSentryTransport(adapter)` after `Sentry.init()`.
- `useSentryIdentify` now calls `configureLoggerContext({ bugReportsEnabled })` to keep the privacy gate in sync with user preferences.

---
### Updated: `.eslintrc.js`

Added `no-console: 'warn'` override for `apps/learn-card-app/src/**` and `apps/scouts/src/**`. Remaining unmigrated call sites surface as lint warnings to guide incremental cleanup.

---

### Docs

- **`packages/learn-card-base/src/logging/README.md`** — full usage guide with examples, level table, second-argument rules, PII scrubbing reference, Sentry setup snippet, and do/don't table.
- **`AGENTS.md`** — logging section added with API examples, level table, second-argument table, setup instructions, do/don't, and PII scrubbing reference.

---

## Testing

```bash
# Run logger unit tests
cd packages/learn-card-base && pnpm exec vitest run src/logging/logger.test.ts
# 24/24 passed
```


#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

## Usage Examples

Import from `learn-card-base`. `useLogger` is **not** a React hook — safe at module level or inside components.

```ts
import { useLogger, logger } from 'learn-card-base';

// Scoped logger — prefixes console with [scope] and tags every Sentry event
const log = useLogger('my-feature');

// No scope
logger.info('app boot');
```

---

### Basic logging

```ts
const log = useLogger('wallet');

log.debug('initialising');                          // dev only, dropped in prod
log.info('profile loaded', { profileId: '123' });   // breadcrumb in Sentry
log.warn('cache miss', { key });                    // console + Sentry warning
log.error('init failed', err);                      // console + Sentry exception
```

---

### Primitives & arrays — no wrapping needed

```ts
const isEnabled = false;
const retryCount = 3;
const flags = ['feature-a', 'feature-b'];

log.info('isEnabled', isEnabled);    // ✓  logs false directly
log.info('retryCount', retryCount);  // ✓  logs 3 directly
log.info('flags', flags);            // ✓  logs array directly

// Before (noisy)
log.info('isEnabled', { isEnabled });
```

---

### Errors from catch blocks

```ts
// Pass e directly — no instanceof check needed
try {
    await riskyOperation();
} catch (e) {
    log.error('operation failed', e);  // ✓
}

// Error + extra context together
try {
    await signIn(provider);
} catch (e) {
    log.error('sign-in failed', e, { provider, userId });
}

// Before (noisy — no longer needed)
log.error('failed', e instanceof Error ? e : new Error(String(e)));
```

---

### PII scrubbing

Fields `email`, `phone`, `name`, `did`, `seed`, `privateKey`, `accessToken`, `idToken` and any `Bearer …` token value are scrubbed automatically before reaching Sentry.

```ts
log.error('lookup failed', { email: 'user@example.com', code: 404 });
// Sentry extra → { email: '[scrubbed]', code: 404 }

// Opt out for internal debug tooling only
log.warn('debug identity', { email: 'user@example.com', allowPii: true });
// Sentry extra → { email: 'user@example.com' }
```

---

### Breadcrumbs & scope context

```ts
log.breadcrumb({ category: 'auth', message: 'token refreshed' });

log.withContext(scope => {
    scope.setTag('flow', 'oid4vci');
    scope.setExtra('step', 3);
});
```

---

### Level → Sentry mapping

| Method | Dev | Prod |
|---|---|---|
| `debug` | `console.debug` | dropped |
| `info` | `console.info` | Sentry breadcrumb |
| `warn` | `console.warn` | `console.warn` + `captureMessage` |
| `error` | `console.error` | `console.error` + `captureException` / `captureMessage` |


#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [X] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [X] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [X] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [X] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [X] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [X] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [X] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [X] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement central logging system with PII scrubbing and injectable Sentry transport across LearnCard apps (learn-card-app, scouts).

Main changes:
- Created `logger.ts` module with structured logging API (debug/info/warn/error), automatic PII field scrubbing, and injectable Sentry transport integration
- Replaced all direct `console.*` calls with scoped logger throughout auth, cache, deep linking, and QR scanning components
- Configured Sentry transport integration in both app `constants/sentry.ts` files, removed `captureConsoleIntegration`, wired privacy gate via `configureLoggerContext`

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
