### PR TITLE
test(e2e):  fix E2E tests - drill through LaunchPadActionModal in wallet-credentials tests

### DIFF
--- a/.changeset/mighty-sails-beam.md
+++ b/.changeset/mighty-sails-beam.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: test(e2e): drill through LaunchPadActionModal in wallet-credentials

--- a/apps/learn-card-app/tests/test.helpers.ts
+++ b/apps/learn-card-app/tests/test.helpers.ts
@@ -36,14 +36,29 @@ export const joinNetworkIfNeeded = async (page: Page, profileId: string) => {
 };
 
 /**
+ * Clicks the side-menu's "Add to LearnCard" and drills through the desktop
+ * LaunchPadActionModal intermediate (#1243) if it appears, leaving the
+ * AddToLearnCardMenu open with `Boost Someone` ready to click.
+ */
+export const openAddToLearnCardMenu = async (page: Page) => {
+    await page.getByRole('button', { name: 'Add to LearnCard' }).click({ timeout: 30_000 });
+
+    // Desktop opens LaunchPadActionModal first; click its inner tile to reach
+    // AddToLearnCardMenu. Mobile skips this step.
+    const actionModalHeading = page.getByRole('heading', { name: 'What would you like to do?' });
+    if (await locatorExists(actionModalHeading, 2_000)) {
+        await page.getByRole('button', { name: 'Add to LearnCard' }).nth(1).click({ timeout: 30_000 });
+    }
+};
+
+/**
  * Issues a credential to the current user via the UI.
  *
  * Flow: Add to LearnCard → Boost Someone → pick template → fill form →
  *       Next → Publish & Issue → Plus → Boost Myself → Save
  */
 export const issueCredentialToSelf = async (page: Page, timeout = 60_000) => {
-    // Open the "Add to LearnCard" menu
-    await page.getByRole('button', { name: 'Add to LearnCard' }).click({ timeout: 30_000 });
+    await openAddToLearnCardMenu(page);
 
     // Select "Boost Someone"
     await page.getByRole('button', { name: 'Boost Someone' }).click({ timeout: 30_000 });

--- a/apps/learn-card-app/tests/wallet-credentials.spec.ts
+++ b/apps/learn-card-app/tests/wallet-credentials.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
 import {
     issueCredentialToSelf,
+    openAddToLearnCardMenu,
     TEST_CREDENTIAL_TITLE,
     waitForAuthenticatedState,
 } from './test.helpers';
@@ -69,7 +70,7 @@ test.describe('Wallet Credentials', () => {
         // (waitForAuthenticatedState already lands on /wallet)
 
         // User 1: Create a credential and send to user 2
-        await page.getByRole('button', { name: 'Add to LearnCard' }).click({ timeout: 30_000 });
+        await openAddToLearnCardMenu(page);
         await page.getByRole('button', { name: 'Boost Someone' }).click({ timeout: 30_000 });
 
         // Select the first available template


### PR DESCRIPTION
## Summary

- **#1243 (LC-1843)** changed `SideMenu.handleBoost` so that on **desktop** the side-menu \`Add to LearnCard\` button opens the new \`LaunchPadActionModal\` (\"What would you like to do?\") instead of going straight to \`AddToLearnCardMenu\`. Mobile is unchanged.
- The wallet-credentials Playwright tests were written for the old one-step flow and now time out on \`getByRole('button', { name: 'Boost Someone' }).click()\` because that button doesn't exist until a second \`Add to LearnCard\` click drills through the launcher modal.
- Adds a small \`openAddToLearnCardMenu\` helper that clicks the side-menu button, detects the launcher modal via its \"What would you like to do?\" heading, and clicks the inner \`Add to LearnCard\` tile when it appears. Mobile skips the extra click. Used in both \`Issue credential to yourself\` and \`Issue credential to someone else\`.
- App behavior is unchanged — gating still fires on \`useLCNGatedAction.gate()\` before either modal opens.

## Test plan

- [ ] Trigger the e2e-runner action against this branch and confirm both wallet-credentials tests pass on desktop Firefox
- [ ] Confirm consent-flow-race + app-store specs still pass (they don't touch this flow but ran in the prior failing suite)
- [ ] Spot-check mobile manually if convenient — the heading check should make the helper a no-op when \`LaunchPadActionModal\` doesn't render

🤖 Generated with [Claude Code](https://claude.com/claude-code)