### PR TITLE
fix: test(e2e): fix E2E failing test - scope launcher-modal Add to LearnCard click instead of .nth(1)

### DIFF
--- a/.changeset/hip-jobs-fly.md
+++ b/.changeset/hip-jobs-fly.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+test(e2e): scope launcher-modal Add to LearnCard click instead of .nth(1)

--- a/apps/learn-card-app/tests/test.helpers.ts
+++ b/apps/learn-card-app/tests/test.helpers.ts
@@ -45,9 +45,13 @@ export const openAddToLearnCardMenu = async (page: Page) => {
 
     // Desktop opens LaunchPadActionModal first; click its inner tile to reach
     // AddToLearnCardMenu. Mobile skips this step.
-    const actionModalHeading = page.getByRole('heading', { name: 'What would you like to do?' });
-    if (await locatorExists(actionModalHeading, 2_000)) {
-        await page.getByRole('button', { name: 'Add to LearnCard' }).nth(1).click({ timeout: 30_000 });
+    const launcherModal = page.getByRole('complementary').filter({
+        has: page.getByRole('heading', { name: 'What would you like to do?' }),
+    });
+    if (await locatorExists(launcherModal, 2_000)) {
+        await launcherModal
+            .getByRole('button', { name: 'Add to LearnCard' })
+            .click({ timeout: 30_000 });
     }
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #1262. That PR added \`openAddToLearnCardMenu\` to drill through the new \`LaunchPadActionModal\` on desktop, using \`.nth(1)\` to pick the inner tile after the first click — but \`.nth(1)\` resolves to the **side-nav** \`Add to LearnCard\` (wrapped in \`<ion-menu-toggle>\`), not the modal's tile, because the launcher modal renders inside \`complementary [ref=e3]\` which precedes the nav in DOM order. The click then times out trying to interact with a button covered by the modal overlay.

Replace the \`.nth(1)\` index math with a scoped selector — find the launcher modal by its \`complementary\` role filtered to the \"What would you like to do?\" heading, then click \`Add to LearnCard\` inside it. Mobile still no-ops because the modal isn't rendered there.

## Test plan

- [ ] Trigger the e2e-runner against this branch and confirm both \`wallet-credentials\` tests pass on desktop Firefox
- [ ] Confirm \`consent-flow-race\` and \`app-store\` specs still pass alongside

🤖 Generated with [Claude Code](https://claude.com/claude-code)