### PR TITLE
Fix age-gate-first onboarding: EU guardian email + under-13 redirect

### DIFF
--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
@@ -48,6 +48,7 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
         photo: currentUser?.profileImage ?? '',
         usMinorConsent: false,
         euParentalConsentRequested: false,
+        guardianEmail: '',
         profileId: '',
     });
 
@@ -145,9 +146,11 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
 
     const routeChildToParentFlow = useCallback(() => {
         closeModal();
+        // The child is logged out here; LoginPage's `redirectTo` query handling sends the
+        // guardian to family creation once they log in. (No `underageFamily` flag — that
+        // triggered a second logout that bounced the freshly-logged-in guardian.)
         handleLogout({
-            overrideRedirectUrl:
-                '/login?underageFamily=1&redirectTo=%2Ffamilies%3FcreateFamily%3Dtrue',
+            overrideRedirectUrl: '/login?redirectTo=%2Ffamilies%3FcreateFamily%3Dtrue',
         });
     }, [closeModal, handleLogout]);
 
@@ -163,7 +166,7 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
 
         const familyInviteUrl = `${
             window.location.origin
-        }/login?underageFamily=1&redirectTo=${encodeURIComponent('/families?createFamily=true')}`;
+        }/login?redirectTo=${encodeURIComponent('/families?createFamily=true')}`;
 
         newModal(
             <UnderageModalContent
@@ -209,8 +212,12 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
                 dob={formData.dob}
                 country={formData.country}
                 onClose={closeModal}
+                onSubmit={guardianEmail => {
+                    // Defer the actual send — the profile this approval is keyed to doesn't
+                    // exist yet. OnboardingNetworkForm sends it after createProfile.
+                    updateFormData({ euParentalConsentRequested: true, guardianEmail });
+                }}
                 onComplete={async () => {
-                    updateFormData({ euParentalConsentRequested: true });
                     closeModal();
                     if (await prepareNewUserKey()) {
                         setStep(OnboardingStepsEnum.selectRole);

--- a/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/OnboardingNetworkForm.tsx
+++ b/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/OnboardingNetworkForm.tsx
@@ -90,6 +90,7 @@ type OnboardingNetworkFormProps = {
         photo: string | null | undefined;
         usMinorConsent: boolean;
         euParentalConsentRequested: boolean;
+        guardianEmail?: string;
         profileId: string | null | undefined;
     };
     updateFormData: (updates: Partial<OnboardingNetworkFormProps['formData']>) => void;
@@ -126,8 +127,16 @@ const OnboardingNetworkForm: React.FC<OnboardingNetworkFormProps> = ({
     const { updateCurrentUser } = useSQLiteStorage();
     const { handleLogout, isLoggingOut } = useLogout();
     const { autoConsentLearnCardAi } = useAutoConsentLearnCardAi();
-    const { name, dob, country, photo, usMinorConsent, euParentalConsentRequested, profileId } =
-        formData;
+    const {
+        name,
+        dob,
+        country,
+        photo,
+        usMinorConsent,
+        euParentalConsentRequested,
+        guardianEmail,
+        profileId,
+    } = formData;
 
     const handleNameChange = (value: string) => {
         updateFormData({ name: value ?? '' });
@@ -323,10 +332,23 @@ const OnboardingNetworkForm: React.FC<OnboardingNetworkFormProps> = ({
                     role: role ?? '',
                     dob: dob ?? '',
                     country: country ?? '',
+                    // EU minors stay unapproved until a guardian approves via email; the
+                    // existing `profile.approved === false` re-prompt keeps gating them.
+                    ...(euParentalConsentRequested ? { approved: false } : {}),
                     authToken,
                 });
 
                 if (didWeb) {
+                    // Now that the profile exists, send the guardian approval email. This is
+                    // deferred to here because sendGuardianApprovalEmail is keyed to the
+                    // requester's profileId, which doesn't exist at the age-gate step.
+                    if (euParentalConsentRequested && guardianEmail) {
+                        try {
+                            await wallet.invoke.sendGuardianApprovalEmail({ guardianEmail });
+                        } catch (err) {
+                            console.error('Failed to send guardian approval email:', err);
+                        }
+                    }
                     // Initialize privacy preferences based on age at signup
                     const age = dob ? calculateAge(dob) : null;
                     const limit = getMinorAgeThreshold(country);

--- a/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/components/EUParentalConsentModalContent.tsx
+++ b/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/components/EUParentalConsentModalContent.tsx
@@ -12,14 +12,19 @@ export type EUParentalConsentModalContentProps = {
     country?: string | undefined;
     onClose: () => void;
     onComplete?: () => void;
+    /**
+     * Optional override for how the guardian email is submitted. When provided, the modal
+     * calls this instead of sending the approval email directly. The onboarding age-gate flow
+     * uses it to *defer* the send, since the user's network profile (which the approval is
+     * keyed to) doesn't exist yet — the email is sent later, after createProfile.
+     */
+    onSubmit?: (guardianEmail: string) => void | Promise<void>;
 };
 
 const EUParentalConsentModalContent: React.FC<EUParentalConsentModalContentProps> = ({
-    name,
-    dob,
-    country,
     onClose,
     onComplete,
+    onSubmit,
 }) => {
     const { initWallet } = useWallet();
 
@@ -37,23 +42,15 @@ const EUParentalConsentModalContent: React.FC<EUParentalConsentModalContentProps
         setError('');
         setLoading(true);
         try {
-            const wallet = await initWallet();
-            if (!wallet) throw new Error('Wallet not initialized');
+            if (onSubmit) {
+                await onSubmit(email.trim());
+            } else {
+                const wallet = await initWallet();
+                if (!wallet) throw new Error('Wallet not initialized');
 
-            const response = await wallet.invoke.sendGuardianApprovalEmail({
-                guardianEmail: email.trim(),
-            });
+                await wallet.invoke.sendGuardianApprovalEmail({ guardianEmail: email.trim() });
+            }
 
-            const payload = {
-                email: email.trim(),
-                name: name ?? '',
-                dob: dob ?? '',
-                country: country ?? '',
-                createdAt: new Date().toISOString(),
-                approvalUrl: response?.approvalUrl,
-            };
-
-            localStorage.setItem('eu_parental_consent_request', JSON.stringify(payload));
             setSent(true);
         } catch (e) {
             console.error('Failed to send guardian approval email:', e);

--- a/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/components/EUParentalConsentModalContent.tsx
+++ b/apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/components/EUParentalConsentModalContent.tsx
@@ -132,8 +132,12 @@ const EUParentalConsentModalContent: React.FC<EUParentalConsentModalContentProps
                         <button
                             type="button"
                             onClick={() => {
-                                onComplete?.();
-                                onClose();
+                                // onComplete (age-gate flow) closes the modal itself and then
+                                // advances onboarding. Only fall back to onClose when there's no
+                                // onComplete (re-prompt callers) — calling both closes one modal
+                                // too many and tears down the underlying onboarding modal.
+                                if (onComplete) onComplete();
+                                else onClose();
                             }}
                             className=" shadow-button-bottom font-semibold flex-1 py-[10px] text-[17px] bg-emerald-700 rounded-[40px] text-white shadow-box-bottom"
                         >


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #1267 (LC-1621), which moves the age gate to run **before** key/profile creation. That reordering broke two first-time-user flows that depended on a profile (or a login redirect) which no longer exists at that point. Branched off `lc-1621-streamline-signup`; targets that branch.

## What changed

**Fix 1 — EU teen guardian-approval flow (defer email to post-profile)**
- `EUParentalConsentModalContent.tsx` gains an optional `onSubmit(guardianEmail)` override. The age-gate flow uses it to *collect* the parent email without sending — the network profile the approval is keyed to doesn't exist yet. Re-prompt callers (which run after a profile exists) keep the existing internal `sendGuardianApprovalEmail` behavior.
- `OnboardingContainer.tsx` stores `guardianEmail` in `formData` and advances onboarding after consent.
- `OnboardingNetworkForm.tsx` creates the EU minor's profile with `approved: false` and, once `createProfile` succeeds, sends the deferred `sendGuardianApprovalEmail` (try/catch, non-fatal). Profile now exists → send + later guardian approval succeed instead of throwing "Requester profile not found".

**Fix 2 — under-13 "I'm an Adult" logout/redirect**
- Dropped the stale `underageFamily=1` param from `routeChildToParentFlow` and `familyInviteUrl`. The child is already logged out, so we rely on the existing `redirectTo` query handling, which fires correctly once the guardian logs in (the old param triggered a second logout that bounced the freshly-logged-in guardian).

**Fix 3 — EU consent modal double `closeModal`**
- The Done button called both `onComplete()` and `onClose()`. Since `onComplete` (age-gate flow) already closes the modal, the extra `onClose()` popped the underlying onboarding modal too, so onboarding never advanced and no profile/email was created. Now calls `onComplete` when present, else falls back to `onClose`.

## Test plan

- [ ] **EU 14yo / Germany:** age gate → enter parent email → Done → onboarding advances to role selection → profile created with `approved=false` → guardian email actually sent → guardian approval link succeeds (no "Requester profile not found").
- [ ] **Under-13 → "I'm an Adult":** child logged out → lands on `/login?redirectTo=/families?createFamily=true` → guardian logs in → lands on `/families?createFamily=true` (no second logout). Repeat via copied `familyInviteUrl`.
- [ ] **Regressions:** US 13–17, non-EU, 18+, and existing-account login unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)