### PR TITLE
fix: `useIsLoggedIn` reactivity

### DIFF
--- a/.changeset/twenty-pillows-lead.md
+++ b/.changeset/twenty-pillows-lead.md
@@ -1,0 +1,5 @@
+---
+"learn-card-base": patch
+---
+
+Fix use logged in reactivity

--- a/packages/learn-card-base/src/stores/currentUserStore.ts
+++ b/packages/learn-card-base/src/stores/currentUserStore.ts
@@ -44,9 +44,12 @@ export const currentUserStore = createStore('currentUserStore')<{
         },
     }
 )
-    .extendSelectors((_state, get) => ({
-        currentUserIsLoggedIn: () => !!get.currentUser(),
-        parentUserProfileId: () => get.parentUserDid()?.split(':').at(-1),
+    .extendSelectors((state, _get) => ({
+        // Must read the tracked `state`, NOT `get.*()`. Reading via `get` makes
+        // react-tracked record zero deps, so `useIsLoggedIn()` won't re-render
+        // when `currentUser` is set after first mount (breaks native auth boot).
+        currentUserIsLoggedIn: () => !!state.currentUser,
+        parentUserProfileId: () => state.parentUserDid?.split(':').at(-1),
     }))
     .extendActions((set, get) => ({
         updateCurrentUserNameAndImage: (name: string, profileImage: string) => {


### PR DESCRIPTION
### Problem

On Android native, after a cold boot the app reaches a mixed auth state: credentials load from LearnCloud and apps appear, but the profile shows "Complete Profile" (no name/image), and tapping the plus button prompts the user to create an account — even though the user has a valid network profile.

### Root cause

`useIsLoggedIn` is the `currentUserStore.useTracked.currentUserIsLoggedIn` selector. The selector body read through the store's non-reactive getter:

```ts
currentUserIsLoggedIn: () => !!get.currentUser(),
```

With `react-tracked`, a hook only re-renders when a state key it **accessed during render** later changes. Because the selector read via `get.*()` (a plain `store.getState()` read) instead of the tracked `state` argument, react-tracked recorded **zero dependencies** — so `useIsLoggedIn()` never re-rendered when `currentUser` was populated.

This only surfaces on native because the wallet/profile become ready *after* the passport page first renders (the AuthCoordinator private-key-first path sets `currentUserStore.currentUser` post-mount). The stale `isLoggedIn === false` then cascades: `useGetProfile` skips its wallet branch → `useIsCurrentUserLCNUser` returns `false` → "Complete Profile" + "create account" UI. On web, `currentUser` is already set before these components mount, so the staleness never shows.

### Change

`packages/learn-card-base/src/stores/currentUserStore.ts` — read the tracked `state` arg instead of `get`:

```ts
.extendSelectors((state, _get) => ({
    currentUserIsLoggedIn: () => !!state.currentUser,
    parentUserProfileId: () => state.parentUserDid?.split(':').at(-1),
}))
```

This registers `currentUser` / `parentUserDid` as dependencies, so the hooks re-render when those change. Non-React call sites (`get`/`use`) are unaffected — zustood passes the correct state into the builder for each access mode.

### How to review

- Single-file diff. Confirm the selectors now reference the `state` parameter, not the `get` getter.
- The inline comment documents the foot-gun (it's easy to "simplify" back to `get.currentUser()` and silently reintroduce the bug).
- Sanity-check that nothing relies on `currentUserIsLoggedIn` diverging from `!!currentUser`. The only writes to the raw `currentUserIsLoggedIn` field are explicit `set.*(true/false)` calls, which were already shadowed by this selector — no behavior change there.

### How to manually test

1. Build and run on an Android native device/emulator.
2. Sign in, then fully close and cold-boot the app.
3. **Expected:** passport page shows the user's name and profile image; no "Complete Profile" button.
4. Tap the plus button → **expected:** normal options, no "create an account" prompt.
5. Web regression check: sign in on web, confirm logged-in UI still renders correctly.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix `useIsLoggedIn` reactivity by ensuring react-tracked correctly records state dependencies during selector evaluation.

Main changes:
- Changed `extendSelectors` to read directly from `state` parameter instead of `get` to ensure react-tracked captures dependencies
- Added explanatory comment documenting why direct state access is required for proper dependency tracking and re-rendering

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
