### PR TITLE
[LC-1621] Age gate signup follow up

### DIFF
--- a/.changeset/bold-rules-flash.md
+++ b/.changeset/bold-rules-flash.md
@@ -1,0 +1,5 @@
+---
+'learn-card-app': patch
+---
+
+fix double age gate

--- a/.changeset/lovely-ties-battle.md
+++ b/.changeset/lovely-ties-battle.md
@@ -1,0 +1,5 @@
+---
+'learn-card-app': major
+---
+
+Follow up fix for age gate signup

--- a/.changeset/lovely-ties-battle.md
+++ b/.changeset/lovely-ties-battle.md
@@ -1,5 +1,0 @@
----
-'learn-card-app': major
----
-
-Follow up fix for age gate signup

--- a/apps/learn-card-app/src/AppRouter.tsx
+++ b/apps/learn-card-app/src/AppRouter.tsx
@@ -379,29 +379,39 @@ const AppRouter: React.FC = () => {
         handleBackfillConsent();
     }, [currentLCNUser, currentLCNUserLoading, currentUser, isAiEnabled]);
 
-    if (initLoading) return <LoginLoadingPage />;
-
+    // NOTE: <Modals /> must stay mounted across the `initLoading` splash. During
+    // new-user key setup the coordinator transitions needs_setup → deriving_key →
+    // ready, flipping `initLoading` true for a moment. If <Modals /> were torn down
+    // (e.g. behind an early `return <LoginLoadingPage />`), any open modal — like the
+    // onboarding flow — would have its component instance destroyed and recreated,
+    // resetting its internal step state (bouncing the user back to the age gate).
+    // Keeping it as a persistent sibling of the loader/app content preserves the
+    // live modal instance across the transition.
     return (
         <GenericErrorBoundary>
-            <div id="app-router" style={{ display: `${showScanner ? 'none' : 'block'}` }}>
-                <IonSplitPane
-                    contentId="main"
-                    className={
-                        collapsed
-                            ? 'side-menu-split-pane-container-collapsed'
-                            : 'side-menu-split-pane-container-visible'
-                    }
-                >
-                    <GenericErrorBoundary>
-                        {isLoggedIn && !hideSideMenu && (
-                            <SideMenu branding={BrandingEnum.learncard} />
-                        )}
-                        <div id="main" className="w-full">
-                            <MobileNavBar />
-                        </div>
-                    </GenericErrorBoundary>
-                </IonSplitPane>
-            </div>
+            {initLoading ? (
+                <LoginLoadingPage />
+            ) : (
+                <div id="app-router" style={{ display: `${showScanner ? 'none' : 'block'}` }}>
+                    <IonSplitPane
+                        contentId="main"
+                        className={
+                            collapsed
+                                ? 'side-menu-split-pane-container-collapsed'
+                                : 'side-menu-split-pane-container-visible'
+                        }
+                    >
+                        <GenericErrorBoundary>
+                            {isLoggedIn && !hideSideMenu && (
+                                <SideMenu branding={BrandingEnum.learncard} />
+                            )}
+                            <div id="main" className="w-full">
+                                <MobileNavBar />
+                            </div>
+                        </GenericErrorBoundary>
+                    </IonSplitPane>
+                </div>
+            )}
             <Modals />
         </GenericErrorBoundary>
     );

--- a/apps/learn-card-app/src/components/network-prompts/hooks/useJoinLCNetworkModal.tsx
+++ b/apps/learn-card-app/src/components/network-prompts/hooks/useJoinLCNetworkModal.tsx
@@ -2,6 +2,7 @@ import JoinNetworkPrompt from '../JoinNetworkPrompt';
 
 import { ModalTypes, useIsCurrentUserLCNUser, useIsLoggedIn, useModal } from 'learn-card-base';
 import OnboardingContainer from '../../onboarding/OnboardingContainer';
+import redirectStore from 'learn-card-base/stores/redirectStore';
 import deletingAccountStore from 'learn-card-base/stores/deletingAccountStore';
 
 export const JoinNetworkModalWrapper: React.FC<{
@@ -25,6 +26,8 @@ export const useJoinLCNetworkModal = (onDismiss?: () => void) => {
     });
 
     const presentNetworkModal = (onSuccess?: () => void) => {
+        redirectStore.set.isOnboardingOpen(true);
+
         newModal(
             <OnboardingContainer onSuccess={onSuccess} />,
             {},

--- a/apps/learn-card-app/src/components/network-prompts/hooks/useJoinLCNetworkModal.tsx
+++ b/apps/learn-card-app/src/components/network-prompts/hooks/useJoinLCNetworkModal.tsx
@@ -26,6 +26,7 @@ export const useJoinLCNetworkModal = (onDismiss?: () => void) => {
     });
 
     const presentNetworkModal = (onSuccess?: () => void) => {
+        // OnboardingContainer unmount owns the `isOnboardingOpen(false)` reset.
         redirectStore.set.isOnboardingOpen(true);
 
         newModal(

--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.test.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.test.tsx
@@ -273,4 +273,34 @@ describe('OnboardingContainer school-code bypass', () => {
 
         expect(screen.queryByTestId('age-gate')).toBeNull();
     });
+
+    it('does not bounce a freshly keyed user back to age gate when the profile is sparse', async () => {
+        mockCalculateAge.mockReturnValue(18);
+        mockCurrentLCNUser = {
+            displayName: 'Test User',
+            image: 'https://example.com/avatar.png',
+        };
+
+        render(<OnboardingContainer />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'set dob' }));
+        fireEvent.click(screen.getByRole('button', { name: 'set country' }));
+        fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+
+        await waitFor(() => {
+            expect(mockGenerateEd25519PrivateKey).toHaveBeenCalledTimes(1);
+            expect(mockSetupNewKey).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            mockAuthState = { status: 'ready' };
+            setupNewKeyDeferred.resolve(true);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('onboarding-roles')).toBeInTheDocument();
+        });
+
+        expect(screen.queryByTestId('age-gate')).toBeNull();
+    });
 });

--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
@@ -114,7 +114,8 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
     }, [coordinatorState.status, currentLCNUserCountry, currentLCNUserDob, currentLCNUserLoading]);
 
     useEffect(() => {
-        // Set flag so AppListingPage's auto-trigger waits until onboarding closes
+        // Set the open flag eagerly; this container's unmount cleanup owns the reset.
+        // This also keeps AppListingPage's auto-trigger from firing while onboarding is active.
         redirectStore.set.isOnboardingOpen(true);
 
         // LC-1853 (review #8): stamp the onboarding-entry timestamp at the very

--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
@@ -100,6 +100,10 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
             return;
         }
 
+        if (didPrepareNewKeyRef.current) {
+            return;
+        }
+
         if (!currentLCNUser) {
             return;
         }

--- a/apps/learn-card-app/src/hooks/useAutosave.test.ts
+++ b/apps/learn-card-app/src/hooks/useAutosave.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useAutosave } from './useAutosave';
 
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
+
 const STORAGE_KEY = 'test_autosave';
 const STORAGE_VERSION = 1;
 

--- a/apps/learn-card-app/src/hooks/useAutosave.test.ts
+++ b/apps/learn-card-app/src/hooks/useAutosave.test.ts
@@ -3,12 +3,9 @@ import { renderHook, act } from '@testing-library/react';
 import { useAutosave } from './useAutosave';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 const STORAGE_KEY = 'test_autosave';

--- a/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.test.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.test.tsx
@@ -132,6 +132,12 @@ vi.mock('@analytics', () => ({
 }));
 
 vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
     useWallet: () => ({ initWallet: mockFns.initWallet }),
     ProfilePicture: () => <div data-testid="profile-picture" />,
     pushUtilities: { revokePushToken: vi.fn() },

--- a/apps/learn-card-app/src/pages/login/LoginPage.tsx
+++ b/apps/learn-card-app/src/pages/login/LoginPage.tsx
@@ -104,6 +104,7 @@ export const LoginContent: React.FC = () => {
 
     const openOnboardingModal = useCallback(
         (initialStep?: OnboardingStepsEnum) => {
+            // OnboardingContainer unmount owns the `isOnboardingOpen(false)` reset.
             redirectStore.set.isOnboardingOpen(true);
 
             newModal(

--- a/apps/learn-card-app/src/pages/login/LoginPage.tsx
+++ b/apps/learn-card-app/src/pages/login/LoginPage.tsx
@@ -104,6 +104,8 @@ export const LoginContent: React.FC = () => {
 
     const openOnboardingModal = useCallback(
         (initialStep?: OnboardingStepsEnum) => {
+            redirectStore.set.isOnboardingOpen(true);
+
             newModal(
                 <OnboardingContainer initialStep={initialStep} />,
                 {},
@@ -116,6 +118,10 @@ export const LoginContent: React.FC = () => {
     // Removed unnecessary LC network redirect helper; inline push is sufficient.
 
     const handlePromptOnboarding = useCallback(async () => {
+        if (redirectStore.get.isOnboardingOpen()) {
+            return;
+        }
+
         if (coordinatorState.status === 'needs_setup') {
             openOnboardingModal(OnboardingStepsEnum.ageGate);
             return;

--- a/apps/learn-card-app/src/pages/pathways/events/pathwayProgressReactor.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/events/pathwayProgressReactor.test.ts
@@ -11,6 +11,15 @@ import type {
 import { createPathwayProgressReactor } from './pathwayProgressReactor';
 import { createWalletEventBus } from './walletEventBus';
 
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/apps/learn-card-app/src/pages/pathways/events/pathwayProgressReactor.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/events/pathwayProgressReactor.test.ts
@@ -12,12 +12,9 @@ import { createPathwayProgressReactor } from './pathwayProgressReactor';
 import { createWalletEventBus } from './walletEventBus';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/learn-card-app/src/pages/pathways/events/walletEventBus.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/events/walletEventBus.test.ts
@@ -5,12 +5,9 @@ import type { CredentialIngestedEvent, WalletEvent } from '../types';
 import { createWalletEventBus } from './walletEventBus';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/learn-card-app/src/pages/pathways/events/walletEventBus.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/events/walletEventBus.test.ts
@@ -4,6 +4,15 @@ import type { CredentialIngestedEvent, WalletEvent } from '../types';
 
 import { createWalletEventBus } from './walletEventBus';
 
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/buildShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/buildShowcase.test.ts
@@ -26,12 +26,9 @@ import { detectCollections } from '../../map/collectionDetection';
 import { computeSuggestedRoute } from '../../map/route';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 import {

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/buildShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/buildShowcase.test.ts
@@ -18,12 +18,21 @@
  *      (pure function, deterministic under id injection).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PathwaySchema } from '../../types';
 import { validatePathway } from '../../core/graphOps';
 import { detectCollections } from '../../map/collectionDetection';
 import { computeSuggestedRoute } from '../../map/route';
+
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
 
 import {
     SHOWCASE_PREVIEW,

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/smartStartShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/smartStartShowcase.test.ts
@@ -19,12 +19,9 @@ import { detectCollections } from '../../map/collectionDetection';
 import { computeSuggestedRoute } from '../../map/route';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 import {

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/smartStartShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/smartStartShowcase.test.ts
@@ -11,12 +11,21 @@
  * employer tracks.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PathwaySchema } from '../../types';
 import { validatePathway } from '../../core/graphOps';
 import { detectCollections } from '../../map/collectionDetection';
 import { computeSuggestedRoute } from '../../map/route';
+
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
 
 import {
     SMART_START_PREVIEW,

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/whatIfShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/whatIfShowcase.test.ts
@@ -19,12 +19,9 @@ import { PathwaySchema } from '../../types';
 import { generateScenarios } from '../../what-if/generators';
 
 vi.mock('learn-card-base', () => ({
-    getLogger: () => ({
-        debug: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-    }),
+    getLogger: () =>
+        (globalThis as typeof globalThis & { mockLearnCardBaseLogger: () => unknown })
+            .mockLearnCardBaseLogger(),
 }));
 
 import {

--- a/apps/learn-card-app/src/pages/pathways/import/showcase/whatIfShowcase.test.ts
+++ b/apps/learn-card-app/src/pages/pathways/import/showcase/whatIfShowcase.test.ts
@@ -11,12 +11,21 @@
  * generator's preconditions have drifted.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { validatePathway } from '../../core/graphOps';
 import { computeSuggestedRoute } from '../../map/route';
 import { PathwaySchema } from '../../types';
 import { generateScenarios } from '../../what-if/generators';
+
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    }),
+}));
 
 import {
     WHAT_IF_PREVIEW,

--- a/apps/learn-card-app/src/test-utils/mockLearnCardBaseLogger.ts
+++ b/apps/learn-card-app/src/test-utils/mockLearnCardBaseLogger.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+
+type MockLogger = {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+};
+
+export const createMockLogger = (): MockLogger => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+});

--- a/apps/learn-card-app/vitest.setup.ts
+++ b/apps/learn-card-app/vitest.setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { TextEncoder, TextDecoder as NodeTextDecoder } from 'util';
+import { createMockLogger } from './src/test-utils/mockLearnCardBaseLogger';
 
 const defineGlobalValue = <T>(key: string, value: T): void => {
     Object.defineProperty(globalThis, key, {
@@ -21,6 +22,8 @@ const defineGlobalValue = <T>(key: string, value: T): void => {
 // Polyfill for Node.js/jsdom environment.
 defineGlobalValue('TextEncoder', TextEncoder);
 defineGlobalValue('TextDecoder', NodeTextDecoder as unknown as typeof TextDecoder);
+
+defineGlobalValue('mockLearnCardBaseLogger', createMockLogger);
 
 // Define global constants that are normally set by webpack DefinePlugin
 (global as any).LCN_API_URL = 'http://localhost:4000/api';

--- a/apps/learn-card-app/vitest.setup.ts
+++ b/apps/learn-card-app/vitest.setup.ts
@@ -2,17 +2,25 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { TextEncoder, TextDecoder as NodeTextDecoder } from 'util';
 
-// Polyfill for Node.js environment
-global.TextEncoder = TextEncoder;
-global.TextDecoder = NodeTextDecoder as unknown as typeof TextDecoder;
+const defineGlobalValue = <T>(key: string, value: T): void => {
+    Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value,
+    });
 
-if (typeof globalThis.TextDecoder !== 'function') {
-    globalThis.TextDecoder = NodeTextDecoder as unknown as typeof TextDecoder;
-}
+    if (typeof window !== 'undefined') {
+        Object.defineProperty(window, key, {
+            configurable: true,
+            writable: true,
+            value,
+        });
+    }
+};
 
-if (typeof globalThis.TextEncoder !== 'function') {
-    globalThis.TextEncoder = TextEncoder;
-}
+// Polyfill for Node.js/jsdom environment.
+defineGlobalValue('TextEncoder', TextEncoder);
+defineGlobalValue('TextDecoder', NodeTextDecoder as unknown as typeof TextDecoder);
 
 // Define global constants that are normally set by webpack DefinePlugin
 (global as any).LCN_API_URL = 'http://localhost:4000/api';


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1621](https://welibrary.atlassian.net/browse/LC-1621)

#### 📚 What is the context and goal of this PR?
There was a bug with the age gate first onboarding flow. Users would enter dob/country -> see splash screen -> back to dob/country again (with a second onboarding flow modal opened too). This fixes that. Only see age gate once. No double modal. Now you don't even see the splash screen

Also fixed some tests

#### 🥴 TL; RL:
Fix bug with age gate first onboarding

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->
- Login with a new user: 18+, US
- Confirm that you only see each onboarding step once


#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1621]: https://welibrary.atlassian.net/browse/LC-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix double age gate prompt by keeping onboarding modal mounted during initialization and preventing duplicate triggers.

Main changes:
- Refactored AppRouter to conditionally render content while keeping `<Modals />` persistently mounted across `initLoading` transitions to preserve modal instance state
- Added `redirectStore.isOnboardingOpen` flag checks in `LoginPage` and `useJoinLCNetworkModal` to prevent concurrent onboarding triggers
- Enhanced test setup with centralized mock logger factory and added regression test for sparse profile handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
