### PR TITLE
fix(e2e): import getLogger from logger module, not learn-card-base barrel

### DIFF
--- a/.changeset/wise-comics-beg.md
+++ b/.changeset/wise-comics-beg.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix(e2e): import getLogger from logger module, not learn-card-base barrel

--- a/apps/learn-card-app/tests/app-store.helpers.ts
+++ b/apps/learn-card-app/tests/app-store.helpers.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test';
 import neo4j from 'neo4j-driver';
 import { randomUUID } from 'crypto';
-import { getLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base/src/logging/logger';
 const log = getLogger('app-store.helpers');
 
 const NEO4J_URI = 'bolt://localhost:7687';

--- a/apps/learn-card-app/tests/claim-link.spec.ts
+++ b/apps/learn-card-app/tests/claim-link.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
-import { getLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base/src/logging/logger';
 const log = getLogger('claim-link.spec');
 
 test.describe('Claimable Boost', () => {

--- a/apps/learn-card-app/tests/connect-apps.helpers.ts
+++ b/apps/learn-card-app/tests/connect-apps.helpers.ts
@@ -1,6 +1,6 @@
 import { getBespokeLearnCard, BespokeLearnCard } from './wallet.helpers';
 import { Page } from '@playwright/test';
-import { getLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base/src/logging/logger';
 const log = getLogger('connect-apps.helpers');
 
 export const MOCK_APP_REGISTRY = {

--- a/apps/learn-card-app/tests/share-boost.spec.ts
+++ b/apps/learn-card-app/tests/share-boost.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
-import { getLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base/src/logging/logger';
 const log = getLogger('share-boost.spec');
 
 test.describe('Share boost link', () => {

--- a/apps/learn-card-app/tests/wallet-credentials.spec.ts
+++ b/apps/learn-card-app/tests/wallet-credentials.spec.ts
@@ -9,7 +9,7 @@ import {
 import { TEST_USER_2_SEED, TEST_USER_PROFILE_ID, TEST_USER_2_PROFILE_ID } from './constants';
 import { mockDidKitWasmForContext } from './route.helpers';
 
-import { getLogger } from 'learn-card-base';
+import { getLogger } from 'learn-card-base/src/logging/logger';
 const log = getLogger('wallet-credentials.spec');
 
 test.describe('Wallet Credentials', () => {


### PR DESCRIPTION
## Problem

Playwright e2e tests fail during file collection:

```
SyntaxError: Cannot use import statement outside a module
  at ../../../packages/learn-card-base/src/components/wallet-block-list/WalletBlockList.tsx:3
> 3 | import { IonItem, IonList } from '@ionic/react';
```

`learn-card-base` has **no build step** — its package entry is `src/index.ts`, whose barrel re-exports the entire Ionic/React component tree (`WalletBlockList`, etc.).

**Regression:** #1268 (LC-1887, "Migrate All Logs to Centralized Logger", merged 2026-06-03) added `import { getLogger } from 'learn-card-base'` to several Playwright test files. Because the import targets the package root, it drags the whole component tree into the Node/Playwright require context, which can't load the raw ESM `@ionic/react` imports. e2e was green before this.

## Fix

`getLogger` lives in `packages/learn-card-base/src/logging/logger.ts`, which is **dependency-free**. Import it directly so the component barrel is never loaded in the test context.

Updated 5 test files:
- `tests/app-store.helpers.ts`
- `tests/wallet-credentials.spec.ts`
- `tests/claim-link.spec.ts`
- `tests/share-boost.spec.ts`
- `tests/connect-apps.helpers.ts`

## Verification

`pnpm exec playwright test --config playwright.config.ts --list` (loads + transforms test files, no services needed):
- **barrel import** -> fails to collect (`@ionic` ESM resolution error, "No tests found")
- **deep import** -> collects cleanly (exit 0)

No app runtime change — the Vite-bundled app handles the barrel import fine; only the Node/Playwright raw-require context was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix e2e test imports to use direct logger module path instead of learn-card-base barrel export to avoid circular dependencies.

Main changes:
- Changed `getLogger` imports from `learn-card-base` barrel to `learn-card-base/src/logging/logger` direct path across 5 test files
- Prevents potential circular dependency issues in e2e test execution pipeline

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
