### PR TITLE
[LC-1820] Make staging use seeded skill frameworks

### DIFF
--- a/.changeset/clean-cloths-shave.md
+++ b/.changeset/clean-cloths-shave.md
@@ -1,0 +1,5 @@
+---
+'learn-card-app': patch
+---
+
+Make staging use seeded frameworks

--- a/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
+++ b/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
@@ -4,6 +4,7 @@ import { useQueries } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { useWallet, useIsLoggedIn, useTenantConfig } from 'learn-card-base';
+import type { TenantConfig } from 'learn-card-base';
 
 export type GlobalSkillFrameworkConfig = {
     frameworkId: string;
@@ -79,7 +80,7 @@ const SEEDED_GLOBAL_SKILL_FRAMEWORK_DEFAULT_SKILL_IDS: Record<string, string[]> 
 const isProductionEnvironment = (): boolean =>
     typeof IS_PRODUCTION !== 'undefined' ? IS_PRODUCTION : process.env.NODE_ENV === 'production';
 
-const isStagingEnvironment = (tenantConfig?: { observability?: { sentryEnv?: string } }): boolean =>
+const isStagingEnvironment = (tenantConfig?: TenantConfig): boolean =>
     tenantConfig?.observability?.sentryEnv?.startsWith('staging') ?? false;
 
 const fetchAllAvailableFrameworks = async (

--- a/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
+++ b/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
@@ -80,7 +80,7 @@ const isProductionEnvironment = (): boolean =>
     typeof IS_PRODUCTION !== 'undefined' ? IS_PRODUCTION : process.env.NODE_ENV === 'production';
 
 const isStagingEnvironment = (tenantConfig?: { observability?: { sentryEnv?: string } }): boolean =>
-    tenantConfig?.observability?.sentryEnv === 'staging';
+    tenantConfig?.observability?.sentryEnv?.startsWith('staging') ?? false;
 
 const fetchAllAvailableFrameworks = async (
     wallet: Awaited<ReturnType<typeof useWallet>>['initWallet'] extends (

--- a/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
+++ b/apps/learn-card-app/src/helpers/globalSkillFrameworks.helpers.ts
@@ -3,7 +3,7 @@ import { useFlags } from 'launchdarkly-react-client-sdk';
 import { useQueries } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
-import { useWallet, useIsLoggedIn } from 'learn-card-base';
+import { useWallet, useIsLoggedIn, useTenantConfig } from 'learn-card-base';
 
 export type GlobalSkillFrameworkConfig = {
     frameworkId: string;
@@ -78,6 +78,9 @@ const SEEDED_GLOBAL_SKILL_FRAMEWORK_DEFAULT_SKILL_IDS: Record<string, string[]> 
 
 const isProductionEnvironment = (): boolean =>
     typeof IS_PRODUCTION !== 'undefined' ? IS_PRODUCTION : process.env.NODE_ENV === 'production';
+
+const isStagingEnvironment = (tenantConfig?: { observability?: { sentryEnv?: string } }): boolean =>
+    tenantConfig?.observability?.sentryEnv === 'staging';
 
 const fetchAllAvailableFrameworks = async (
     wallet: Awaited<ReturnType<typeof useWallet>>['initWallet'] extends (
@@ -190,7 +193,8 @@ export const useGlobalSkillFrameworks = (): GlobalSkillFrameworkConfig[] => {
     const flags = useFlags<GlobalSkillFrameworkFlags>();
     const { initWallet } = useWallet();
     const isLoggedIn = useIsLoggedIn();
-    const useSeededFrameworks = !isProductionEnvironment();
+    const tenantConfig = useTenantConfig();
+    const useSeededFrameworks = !isProductionEnvironment() || isStagingEnvironment(tenantConfig);
 
     const { data: seededFrameworks = [] } = useQuery({
         queryKey: ['seededGlobalSkillFrameworks', isLoggedIn],


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Staging was using the LaunchDarkly flag values instead of the seeded skill framework values. For some reason changing LaunchDarkly didn't seem to affect staging. So this forces staging to use the seeded framework values.

#### 🥴 TL; RL:
Make staging use seeded skill frameworks

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
Needs to deploy to staging to really test.

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable staging environments to use seeded skill frameworks alongside production by detecting staging via tenant configuration.

Main changes:
- Added `useTenantConfig` hook import and `isStagingEnvironment` utility to detect staging via Sentry environment
- Modified framework selection logic to use seeded frameworks in staging or non-production environments
- Added changeset documentation for patch version bump

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
