### PR TITLE
chore[LC-1907]:  LCA App Store category loading skeletons 

### DIFF
--- a/.changeset/fine-cobras-agree.md
+++ b/.changeset/fine-cobras-agree.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+feat(learn-card-app): App Store category loading skeletons (LC-1907)

--- a/apps/learn-card-app/src/pages/launchPad/AppStoreListItemSkeleton.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/AppStoreListItemSkeleton.tsx
@@ -51,13 +51,17 @@ export const AppStoreListItemSkeleton: React.FC = () => {
 
 /**
  * Renders a small stack of {@link AppStoreListItemSkeleton} rows in place of a
- * category list while it's loading with no data yet.
+ * category list while it's loading with no data yet. `idPrefix` keeps row keys
+ * unique when multiple stacks render as siblings (e.g. Installed + Suggested).
  */
-export const AppStoreListSkeleton: React.FC<{ count?: number }> = ({ count = 5 }) => {
+export const AppStoreListSkeleton: React.FC<{ count?: number; idPrefix?: string }> = ({
+    count = 5,
+    idPrefix = 'app-store-skeleton',
+}) => {
     return (
         <>
             {Array.from({ length: count }).map((_, index) => (
-                <AppStoreListItemSkeleton key={`app-store-skeleton-${index}`} />
+                <AppStoreListItemSkeleton key={`${idPrefix}-${index}`} />
             ))}
         </>
     );

--- a/apps/learn-card-app/src/pages/launchPad/AppStoreListItemSkeleton.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/AppStoreListItemSkeleton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import {
+    BoostSkeleton,
+    BoostTextSkeleton,
+} from 'learn-card-base/components/boost/boostSkeletonLoaders/BoostSkeletons';
+
+/**
+ * Loading placeholder for {@link AppStoreListItem}. Mirrors the real row's
+ * dimensions (icon, two text lines, pill button) so the layout doesn't shift
+ * when apps finish loading. Uses the same `IonSkeletonText`-based shimmer
+ * primitives as the other app skeletons (e.g. `NotificationSkeleton`).
+ */
+export const AppStoreListItemSkeleton: React.FC = () => {
+    return (
+        <div
+            aria-hidden="true"
+            className="w-full max-w-[600px] px-[12px] py-[12px] max-h-[76px] flex bg-white items-center justify-between overflow-visible rounded-[12px] mt-2 first:mt-4 shadow-sm"
+        >
+            <div className="flex items-center justify-start w-full">
+                <div className="rounded-lg w-[50px] h-[50px] mr-3 min-w-[50px] min-h-[50px] overflow-hidden">
+                    <BoostSkeleton
+                        containerClassName="w-full h-full"
+                        skeletonStyles={{ width: '100%', height: '100%', margin: 0 }}
+                    />
+                </div>
+
+                <div className="right-side flex items-center justify-between w-full">
+                    <div className="flex flex-col items-start justify-center text-left flex-1 min-w-0 gap-1">
+                        <BoostTextSkeleton
+                            containerClassName="w-full"
+                            skeletonStyles={{ width: '60%', height: '14px' }}
+                        />
+                        <BoostTextSkeleton
+                            containerClassName="w-full"
+                            skeletonStyles={{ width: '40%', height: '12px' }}
+                        />
+                    </div>
+
+                    <div className="flex items-center ml-2 shrink-0">
+                        <BoostSkeleton
+                            containerClassName="w-[72px] h-[34px] rounded-full overflow-hidden"
+                            skeletonStyles={{ width: '100%', height: '100%', margin: 0 }}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Renders a small stack of {@link AppStoreListItemSkeleton} rows in place of a
+ * category list while it's loading with no data yet.
+ */
+export const AppStoreListSkeleton: React.FC<{ count?: number }> = ({ count = 5 }) => {
+    return (
+        <>
+            {Array.from({ length: count }).map((_, index) => (
+                <AppStoreListItemSkeleton key={`app-store-skeleton-${index}`} />
+            ))}
+        </>
+    );
+};
+
+export default AppStoreListItemSkeleton;

--- a/apps/learn-card-app/src/pages/launchPad/LaunchPad.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/LaunchPad.tsx
@@ -30,6 +30,7 @@ import {
 
 import useAppStore, { mapTabToCategory } from './useAppStore';
 import AppStoreListItem from './AppStoreListItem';
+import { AppStoreListSkeleton } from './AppStoreListItemSkeleton';
 import FeaturedCarousel from './FeaturedCarousel';
 import { NavBarLaunchPadIcon } from '../../components/svgs/NavBarLaunchPadIcon';
 
@@ -86,7 +87,7 @@ const LaunchPad: React.FC = () => {
     const { data: featuredCarouselApps } = useFeaturedCarouselApps(appStoreCategory);
 
     // Fetch curated list apps
-    const { data: curatedListApps } = useCuratedListApps();
+    const { data: curatedListApps, isLoading: isLoadingCuratedApps } = useCuratedListApps();
 
     const installedApps = installedAppsData?.records ?? [];
     const browseApps = browseAppsData?.records ?? [];
@@ -323,7 +324,9 @@ const LaunchPad: React.FC = () => {
                                                                       ? 'Plugin'
                                                                       : 'Plugins'
                                                               }`
-                                                            : `${filteredAvailableApps.length} Search ${
+                                                            : `${
+                                                                  filteredAvailableApps.length
+                                                              } Search ${
                                                                   filteredAvailableApps.length === 1
                                                                       ? 'Result'
                                                                       : 'Results'
@@ -372,6 +375,20 @@ const LaunchPad: React.FC = () => {
                                     lines="none"
                                     className="w-full max-w-[600px] bg-grayscale-100"
                                 >
+                                    {/* My Apps tab: Installed Apps loading skeletons (cold load, no data yet) */}
+                                    {isMyApps &&
+                                        isLoadingInstalledApps &&
+                                        filteredInstalledApps.length === 0 && (
+                                            <>
+                                                <div className="px-2 pt-4 pb-2">
+                                                    <p className="text-sm font-semibold text-grayscale-600 uppercase tracking-wide">
+                                                        Installed Apps
+                                                    </p>
+                                                </div>
+                                                <AppStoreListSkeleton />
+                                            </>
+                                        )}
+
                                     {/* My Apps tab: Installed Apps (hidden if none) */}
                                     {isMyApps && filteredInstalledApps.length > 0 && (
                                         <>
@@ -388,6 +405,18 @@ const LaunchPad: React.FC = () => {
                                                     onInstallSuccess={refetchInstalledApps}
                                                 />
                                             ))}
+                                        </>
+                                    )}
+
+                                    {/* Suggested Apps loading skeletons (cold load, no data yet) */}
+                                    {isLoadingCuratedApps && filteredCuratedApps.length === 0 && (
+                                        <>
+                                            <div className="px-2 pt-4 pb-2">
+                                                <p className="text-sm font-semibold text-grayscale-600 uppercase tracking-wide">
+                                                    Suggested Apps
+                                                </p>
+                                            </div>
+                                            <AppStoreListSkeleton />
                                         </>
                                     )}
 
@@ -411,6 +440,20 @@ const LaunchPad: React.FC = () => {
                                             ))}
                                         </>
                                     )}
+
+                                    {/* Category/All tabs: browse list loading skeletons (cold load, no data yet) */}
+                                    {(isCategory || isAll) &&
+                                        isLoadingBrowseApps &&
+                                        nonPromotedAvailableApps.length === 0 && (
+                                            <>
+                                                <div className="px-2 pt-4 pb-2">
+                                                    <p className="text-sm font-semibold text-grayscale-600 uppercase tracking-wide">
+                                                        {isAll ? 'All Apps' : `All ${tab}`}
+                                                    </p>
+                                                </div>
+                                                <AppStoreListSkeleton />
+                                            </>
+                                        )}
 
                                     {/* Category/All tabs: browse list (include installed apps with Open CTA) */}
                                     {(isCategory || isAll) &&
@@ -479,14 +522,14 @@ const LaunchPad: React.FC = () => {
                                         const title = isMyApps
                                             ? 'Your apps will live here'
                                             : isAll
-                                              ? 'No apps available right now'
-                                              : `Nothing in ${tab} yet`;
+                                            ? 'No apps available right now'
+                                            : `Nothing in ${tab} yet`;
 
                                         const subtitle = isMyApps
                                             ? 'Install something from the App Store to get started.'
                                             : isAll
-                                              ? 'Check back later — new apps are added all the time.'
-                                              : 'Check back soon, or browse all apps.';
+                                            ? 'Check back later — new apps are added all the time.'
+                                            : 'Check back soon, or browse all apps.';
 
                                         const showCta = !isAll;
 
@@ -504,9 +547,7 @@ const LaunchPad: React.FC = () => {
                                                 </p>
                                                 {showCta && (
                                                     <button
-                                                        onClick={() =>
-                                                            setTab(LaunchPadTabEnum.all)
-                                                        }
+                                                        onClick={() => setTab(LaunchPadTabEnum.all)}
                                                         className="mt-5 px-5 py-2 rounded-full bg-grayscale-900 text-white text-sm font-semibold font-poppins"
                                                     >
                                                         Browse all apps

--- a/apps/learn-card-app/src/pages/launchPad/LaunchPad.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/LaunchPad.tsx
@@ -385,7 +385,7 @@ const LaunchPad: React.FC = () => {
                                                         Installed Apps
                                                     </p>
                                                 </div>
-                                                <AppStoreListSkeleton />
+                                                <AppStoreListSkeleton idPrefix="installed-skeleton" />
                                             </>
                                         )}
 
@@ -416,7 +416,7 @@ const LaunchPad: React.FC = () => {
                                                     Suggested Apps
                                                 </p>
                                             </div>
-                                            <AppStoreListSkeleton />
+                                            <AppStoreListSkeleton idPrefix="suggested-skeleton" />
                                         </>
                                     )}
 
@@ -451,7 +451,7 @@ const LaunchPad: React.FC = () => {
                                                         {isAll ? 'All Apps' : `All ${tab}`}
                                                     </p>
                                                 </div>
-                                                <AppStoreListSkeleton />
+                                                <AppStoreListSkeleton idPrefix="browse-skeleton" />
                                             </>
                                         )}
 
@@ -515,7 +515,8 @@ const LaunchPad: React.FC = () => {
                                             !hasContract &&
                                             !hasCustomApp &&
                                             !isLoadingBrowseApps &&
-                                            !isLoadingInstalledApps;
+                                            !isLoadingInstalledApps &&
+                                            !isLoadingCuratedApps;
 
                                         if (!isEmpty) return null;
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Closes: [LC-1907](https://welibrary.atlassian.net/browse/LC-1907) — _App Store: skeleton loaders while category apps load_

#### 📚 What is the context and goal of this PR?

On a cold load (no cache), the LaunchPad App Store sections ("Installed Apps", "Suggested Apps", "All {Category}") render straight from query data. The `isLoading*` flags existed but were never used to render anything, so users saw a **blank gap** until results arrived. This PR fills that gap with skeleton rows so each loading section reads as "loading" instead of "empty".

#### 🥴 TL; RL:

Cold-load App Store category → blank gap. Now shows skeleton rows that match the real list-item dimensions, so there's no layout shift when apps load in.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

https://www.loom.com/share/d3ee976680e348ecacd6f586fbfdf059


- **New:** `AppStoreListItemSkeleton.tsx` — a row placeholder mirroring `AppStoreListItem` (50×50 icon, two text lines at ~60%/40% width, pill button), plus `AppStoreListSkeleton` which renders a stack (default 5). Built on the existing `IonSkeletonText`-based `BoostSkeleton`/`BoostTextSkeleton` primitives — same shimmer convention as `NotificationSkeleton`.
- **Wired into** `LaunchPad.tsx` non-search branch — each section shows a header + skeleton stack while loading with no data yet:
  - **Installed Apps** (My Apps tab) → `isLoadingInstalledApps`
  - **Suggested Apps** (all tabs) → `isLoadingCuratedApps`
  - **All / {Category}** (Category & All tabs) → `isLoadingBrowseApps`
- Skeletons vanish the moment real rows render, and never appear alongside the empty-state (which is gated on `!isLoading`) or in **search mode** (results are client-filtered from already-loaded data).

_Loom walkthrough to be added after manual review._

#### 🛠 Important tradeoffs made:

- **Each section is gated on its own data source's loading flag** rather than tying everything to `isLoadingBrowseApps` as the ticket sketched. Since all `useAppStore` hooks are `useQuery` and already expose `isLoading`, gating Suggested on `isLoadingCuratedApps` (its actual source) avoids false skeletons when curated has loaded but browse hasn't. No query/caching behavior was changed — only already-returned flags are consumed.

#### 🔍 Types of Changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. Clear app cache / hard reload so App Store queries are uncached (cold load).
2. Open LaunchPad and switch to a **Category** tab (e.g. an "All {Category}" view) → the section should show skeleton rows in place of the blank gap, then swap to real apps with **no layout shift**.
3. **My Apps** tab on cold load → Installed / Suggested sections show skeletons until data arrives.
4. Confirm skeletons **disappear** once apps render and **never** show with the empty-state ("Nothing in X yet") or error UI.
5. Type in **search** → no skeletons appear (results are filtered client-side).

#### 📱 🖥 Which devices would you like help testing on?

Chromium / Safari / iOS Native

#### 🧪 Code Coverage

UI-only change (presentational skeleton + conditional render gating). No unit tests added — verified manually against cold-load and search states.

# Documentation

#### 📝 Documentation Checklist

(none required)

#### 💭 Documentation Notes

Internal UI polish — no API, config, or user-facing flow changes, so no `docs/` updates needed.

# ✅ PR Checklist

-   [x] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LC-1907]: https://welibrary.atlassian.net/browse/LC-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement loading skeleton UI components for App Store category lists to prevent layout shift during data fetching.

Main changes:
- Created `AppStoreListItemSkeleton` and `AppStoreListSkeleton` components mirroring actual app list item dimensions with shimmer animations
- Added skeleton loaders for Installed Apps, Suggested Apps, and browse list sections during initial load states
- Extracted `isLoadingCuratedApps` state from `useCuratedListApps` hook to conditionally render loading skeletons

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
