### PR TITLE
fix: Stale Auth Cache

### DIFF
--- a/.changeset/witty-pillows-cheer.md
+++ b/.changeset/witty-pillows-cheer.md
@@ -1,0 +1,5 @@
+---
+"learn-card-base": patch
+---
+
+fix: prevent mixed login state on app resume — a transient wallet/private-key reconstruction failure no longer caches a spurious "no profile" result, which previously surfaced "Complete Profile", the age gate, and the JoinNetworkModal for users who had already onboarded

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -52,7 +52,7 @@ const config: CapacitorConfig = {
         },
         CapacitorUpdater: {
             appId: 'com.learncard.app',
-            autoUpdate: true,
+            autoUpdate: false,
             // SINGLE SOURCE OF TRUTH for the Capgo channel.
             // - CI reads this value via `tools/capgo/getCapgoChannel.js` (regex match) to pick
             //   the channel that OTA bundles are uploaded to in the deploy workflow.

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -52,7 +52,7 @@ const config: CapacitorConfig = {
         },
         CapacitorUpdater: {
             appId: 'com.learncard.app',
-            autoUpdate: false,
+            autoUpdate: true,
             // SINGLE SOURCE OF TRUTH for the Capgo channel.
             // - CI reads this value via `tools/capgo/getCapgoChannel.js` (regex match) to pick
             //   the channel that OTA bundles are uploaded to in the deploy workflow.

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -62,7 +62,7 @@ const config: CapacitorConfig = {
             // Bump this value whenever you bump native binaries; do NOT add a parallel
             // tenant-level override — that's how channels drift and OTA updates land in
             // an empty channel (see PR #1063 incident).
-            defaultChannel: '1.0.9', // bumped here https://github.com/learningeconomy/LearnCard/pull/1313
+            defaultChannel: '1.0.8', // bumped here https://github.com/learningeconomy/LearnCard/pull/1313
         },
     },
 };

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -52,7 +52,7 @@ const config: CapacitorConfig = {
         },
         CapacitorUpdater: {
             appId: 'com.learncard.app',
-            autoUpdate: false,
+            autoUpdate: true,
             // SINGLE SOURCE OF TRUTH for the Capgo channel.
             // - CI reads this value via `tools/capgo/getCapgoChannel.js` (regex match) to pick
             //   the channel that OTA bundles are uploaded to in the deploy workflow.
@@ -62,7 +62,7 @@ const config: CapacitorConfig = {
             // Bump this value whenever you bump native binaries; do NOT add a parallel
             // tenant-level override — that's how channels drift and OTA updates land in
             // an empty channel (see PR #1063 incident).
-            defaultChannel: '1.0.9', // bumped here https://github.com/learningeconomy/LearnCard/pull/1203
+            defaultChannel: '1.0.9', // bumped here https://github.com/learningeconomy/LearnCard/pull/1313
         },
     },
 };

--- a/apps/learn-card-app/capacitor.config.ts
+++ b/apps/learn-card-app/capacitor.config.ts
@@ -52,7 +52,7 @@ const config: CapacitorConfig = {
         },
         CapacitorUpdater: {
             appId: 'com.learncard.app',
-            autoUpdate: true,
+            autoUpdate: false,
             // SINGLE SOURCE OF TRUTH for the Capgo channel.
             // - CI reads this value via `tools/capgo/getCapgoChannel.js` (regex match) to pick
             //   the channel that OTA bundles are uploaded to in the deploy workflow.
@@ -62,7 +62,7 @@ const config: CapacitorConfig = {
             // Bump this value whenever you bump native binaries; do NOT add a parallel
             // tenant-level override — that's how channels drift and OTA updates land in
             // an empty channel (see PR #1063 incident).
-            defaultChannel: '1.0.8', // bumped here https://github.com/learningeconomy/LearnCard/pull/1203
+            defaultChannel: '1.0.9', // bumped here https://github.com/learningeconomy/LearnCard/pull/1203
         },
     },
 };

--- a/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
+++ b/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
@@ -41,7 +41,7 @@
 		},
 		"CapacitorUpdater": {
 			"appId": "com.learncard.app",
-			"autoUpdate": false
+			"autoUpdate": true
 		}
 	},
 	"packageClassList": [

--- a/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
+++ b/apps/learn-card-app/environments/learncard/assets/config/capacitor.config.json
@@ -41,7 +41,7 @@
 		},
 		"CapacitorUpdater": {
 			"appId": "com.learncard.app",
-			"autoUpdate": true
+			"autoUpdate": false
 		}
 	},
 	"packageClassList": [

--- a/apps/learn-card-app/src/components/network-prompts/hooks/useEUParentalConsentModal.tsx
+++ b/apps/learn-card-app/src/components/network-prompts/hooks/useEUParentalConsentModal.tsx
@@ -7,16 +7,19 @@ import EUParentalConsentModalContent from 'apps/learn-card-app/src/components/on
 import { requiresEUParentalConsent } from 'apps/learn-card-app/src/components/onboarding/onboardingNetworkForm/helpers/gdpr';
 
 export const useEUParentalConsentModal = (onDismiss?: () => void) => {
-    const { data: cachedProfile, isLoading: cachedLoading } = useGetProfile();
+    const { data: cachedProfile, isLoading: cachedLoading, isError: cachedError } = useGetProfile();
     const profileId = cachedProfile?.profileId;
     const {
         data: freshProfile,
         isLoading: freshLoading,
+        isError: freshError,
         refetch: refetchFresh,
     } = useGetProfile(profileId, Boolean(profileId));
 
     const profile = freshProfile ?? cachedProfile;
-    const isLoading = cachedLoading || freshLoading;
+    // Treat an errored profile fetch as "still resolving" so a transient failure
+    // can't be read as a settled state and surface the consent modal prematurely.
+    const isLoading = cachedLoading || freshLoading || cachedError || freshError;
 
     const isLoggedIn = useIsLoggedIn();
 

--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.test.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.test.tsx
@@ -25,6 +25,7 @@ let mockCurrentLCNUser: {
     country?: string;
 } | null = null;
 let mockCurrentLCNUserLoading = false;
+let mockCurrentLCNUserError = false;
 
 let lastModalElement: React.ReactElement | null = null;
 
@@ -54,6 +55,7 @@ vi.mock('learn-card-base', () => ({
     useGetProfile: () => ({
         data: mockCurrentLCNUser,
         isLoading: mockCurrentLCNUserLoading,
+        isError: mockCurrentLCNUserError,
     }),
     useUpdatePreferences: () => ({
         mutateAsync: (...args: unknown[]) => mockUpdatePreferences(...args),
@@ -221,6 +223,7 @@ describe('OnboardingContainer school-code bypass', () => {
         mockAuthState = { status: 'needs_setup' };
         mockCurrentLCNUser = null;
         mockCurrentLCNUserLoading = false;
+        mockCurrentLCNUserError = false;
         setupNewKeyDeferred = createDeferred<boolean>();
 
         vi.stubGlobal('localStorage', {
@@ -294,6 +297,21 @@ describe('OnboardingContainer school-code bypass', () => {
             dob: '2000-01-01',
             country: 'US',
         };
+
+        render(<OnboardingContainer initialStep={OnboardingStepsEnum.joinNetwork} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('onboarding-network-form')).toBeInTheDocument();
+        });
+
+        expect(screen.queryByTestId('age-gate')).toBeNull();
+    });
+
+    it('does not drop an existing user onto the age gate when the profile fetch errors', async () => {
+        mockAuthState = { status: 'ready' };
+        mockCurrentLCNUser = null;
+        mockCurrentLCNUserLoading = false;
+        mockCurrentLCNUserError = true;
 
         render(<OnboardingContainer initialStep={OnboardingStepsEnum.joinNetwork} />);
 

--- a/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
+++ b/apps/learn-card-app/src/components/onboarding/OnboardingContainer.tsx
@@ -47,7 +47,11 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
     const prepareNewKeyPromiseRef = useRef<Promise<boolean> | null>(null);
 
     const currentUser = useCurrentUser();
-    const { data: currentLCNUser, isLoading: currentLCNUserLoading } = useGetProfile();
+    const {
+        data: currentLCNUser,
+        isLoading: currentLCNUserLoading,
+        isError: currentLCNUserError,
+    } = useGetProfile();
     const currentLCNUserDob =
         currentLCNUser && 'dob' in currentLCNUser ? currentLCNUser.dob ?? '' : '';
     const currentLCNUserCountry =
@@ -89,8 +93,12 @@ const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onSuccess, in
     }, [currentLCNUser, currentLCNUserCountry, currentLCNUserDob, currentUser?.profileImage]);
 
     const hasProfileAgeData = Boolean(currentLCNUserDob && currentLCNUserCountry);
+    // An errored profile fetch must count as "still resolving", not "no age data" —
+    // otherwise a transient wallet/network failure would drop an existing user onto
+    // the age gate. New users are routed via `needs_setup`, which is unaffected.
+    const profileResolving = currentLCNUserLoading || currentLCNUserError;
     const shouldStartAtAgeGate =
-        coordinatorState.status === 'needs_setup' || (!currentLCNUserLoading && !hasProfileAgeData);
+        coordinatorState.status === 'needs_setup' || (!profileResolving && !hasProfileAgeData);
 
     const [step, setStep] = useState<OnboardingStepsEnum>(
         shouldStartAtAgeGate

--- a/packages/learn-card-base/src/react-query/queries/queries.ts
+++ b/packages/learn-card-base/src/react-query/queries/queries.ts
@@ -14,6 +14,7 @@ import {
     switchedProfileStore,
 } from 'learn-card-base';
 import { networkStore } from 'learn-card-base/stores/NetworkStore';
+import { walletStore } from 'learn-card-base/stores/walletStore';
 import {
     Boost,
     BoostRecipientInfo,
@@ -765,7 +766,10 @@ export const useIsCurrentUserLCNUser = () => {
     return {
         ...result,
         data: Boolean(result.data),
-        isLoading: result.status === 'pending',
+        // `error` is treated as "still resolving", NOT "no profile": a transient
+        // wallet-init/network failure on resume must not falsely trigger the
+        // Complete Profile / age gate / JoinNetworkModal onboarding prompts.
+        isLoading: result.status === 'pending' || result.status === 'error',
     };
 };
 
@@ -775,10 +779,19 @@ export const useGetProfile = (
 ): UseQueryResult<QueriedProfile | null> => {
     const { initWallet } = useWallet();
     const isLoggedIn = useIsLoggedIn();
+    const wallet = walletStore.use.wallet();
     const switchedDid = switchedProfileStore.use.switchedDid();
 
+    // Fetching the current user's OWN profile (no explicit profileId) needs a
+    // reconstructed wallet. On resume the persisted `currentUser` rehydrates (so
+    // `isLoggedIn` flips true) before the private key is restored; gating on the
+    // wallet being present stops the query from running early and caching a bogus
+    // `null` for the whole staleTime — the root cause of the mixed-login state.
+    const requiresOwnWallet = isLoggedIn && !profileId;
+    const walletReady = !!wallet;
+
     return useQuery<QueriedProfile | null>({
-        enabled: enabled && (!!profileId || isLoggedIn),
+        enabled: enabled && (!!profileId || isLoggedIn) && (!requiresOwnWallet || walletReady),
         queryKey: ['getProfile', switchedDid ?? '', profileId],
         // The current user's profile changes rarely (avatar/displayName edits).
         // Keep cached data fresh for 5 minutes so navigations between pages don't
@@ -787,19 +800,22 @@ export const useGetProfile = (
         // (e.g., editProfile) are responsible for invalidating this query.
         staleTime: 5 * 60 * 1000,
         queryFn: async (): Promise<QueriedProfile | null> => {
-            // If user is logged in, try to use the wallet
-            if (isLoggedIn) {
-                try {
-                    const wallet = await initWallet();
-                    if (wallet) {
-                        if (profileId) {
-                            const data = await wallet.invoke.getProfile(profileId);
+            // Own profile: the wallet MUST resolve here. On failure, throw so React
+            // Query records an error (and retries) rather than caching `null` as a
+            // definitive "no profile" — which would falsely trigger onboarding.
+            if (isLoggedIn && !profileId) {
+                const ownWallet = await initWallet();
+                if (!ownWallet) throw new Error('Wallet not ready for profile fetch');
+                const data = await ownWallet.invoke.getProfile();
+                return data ?? null;
+            }
 
-                            return data ?? null;
-                        } else {
-                            const data = await wallet.invoke.getProfile();
-                            return data ?? null;
-                        }
+            if (isLoggedIn && profileId) {
+                try {
+                    const loggedInWallet = await initWallet();
+                    if (loggedInWallet) {
+                        const data = await loggedInWallet.invoke.getProfile(profileId);
+                        return data ?? null;
                     }
                 } catch (error) {
                     log.warn('Failed to initialize wallet, falling back to public API', error);

--- a/packages/learn-card-base/src/react-query/queries/queries.ts
+++ b/packages/learn-card-base/src/react-query/queries/queries.ts
@@ -801,8 +801,9 @@ export const useGetProfile = (
         staleTime: 5 * 60 * 1000,
         queryFn: async (): Promise<QueriedProfile | null> => {
             // Own profile: the wallet MUST resolve here. On failure, throw so React
-            // Query records an error (and retries) rather than caching `null` as a
-            // definitive "no profile" — which would falsely trigger onboarding.
+            // Query records an error rather than caching `null` as a definitive
+            // "no profile" (which would falsely trigger onboarding). Recovery is the
+            // `enabled` false→true transition once the wallet lands, not retries.
             if (isLoggedIn && !profileId) {
                 const ownWallet = await initWallet();
                 if (!ownWallet) throw new Error('Wallet not ready for profile fetch');


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

Users on Android (and web) kept landing in a "mixed login state": after being logged in for a while, reopening the app would show "Complete Profile", pop the age gate, and present the Join Network modal — even though they'd already onboarded and have a profile.

We thought a previous PR (LC-1738, "Stale Auth Error on Android Resume") had fixed this, but it only hardened the `AuthCoordinator`. The onboarding prompts don't read the coordinator — they read a separate react-query hook (`useGetProfile` / `useIsCurrentUserLCNUser`), which still had the race.

#### 🥴 TL; RL:

On app resume the persisted user rehydrates instantly, so `isLoggedIn` flips to true *before* the private key/wallet is rebuilt. The profile query ran too early, the wallet wasn't ready, the failure got swallowed and cached as "this user has no profile" for 5 minutes — which is what triggered all three prompts.

#### 💡 Feature Breakdown

Three coordinated changes in `packages/learn-card-base/src/react-query/queries/queries.ts`:

1. **Wait for the wallet.** The "my own profile" query now stays disabled until the wallet is actually present, so it can't run during the pre-key window and cache a bogus empty result.
2. **Don't swallow failures.** If the wallet can't resolve, the query now throws (so react-query marks it as an error and retries) instead of quietly returning "no profile".
3. **Treat errors as "still loading".** `useIsCurrentUserLCNUser` now counts an error as "still resolving", so a transient hiccup never reads as "user has no profile" and the onboarding prompts stay hidden.

A genuinely new user (wallet ready, profile really is empty) still gets the prompts as before.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Chore

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. Log in normally and confirm you reach the wallet with your profile intact.
2. Background the app for a while (or force-kill it on Android), then reopen.
3. Confirm you do **not** see "Complete Profile", the age gate, or the Join Network modal — you should land straight in your logged-in state.
4. As a brand-new user (no profile yet), confirm the "Complete Profile" / onboarding prompts still appear correctly.

#### 📱 🖥 Which devices would you like help testing on?

Android Native (primary), plus Chromium / iOS for the resume case.

#### 🧪 Code Coverage

No new tests in this PR — the change is in the gating/error handling of an existing query. Recommend running `pnpm exec nx test learn-card-base` before merge.

# Documentation

#### 💭 Documentation Notes

Internal bug fix, no API changes. Rationale is captured in inline comments on the non-obvious lines (why errors are treated as "loading" and why the query waits for the wallet).

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix stale auth cache on app resume by preventing transient wallet failures from falsely caching "no profile" and triggering premature onboarding prompts.

Main changes:
- Modified `useGetProfile` to gate queries on wallet readiness and distinguish between unresolved errors and settled "no profile" states
- Updated error handling in `useIsCurrentUserLCNUser` and onboarding components to treat fetch errors as unresolved rather than conclusive
- Added test case validating existing users aren't redirected to age gate when profile fetch fails

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
