### PR TITLE
fix(lca-api): bundle @learncard/init from its ESM build in Lambda esbuild (staging 500s)

### DIFF
--- a/.changeset/small-drinks-bet.md
+++ b/.changeset/small-drinks-bet.md
@@ -1,0 +1,6 @@
+---
+"@learncard/init": patch
+"@learncard/lca-api-service": patch
+---
+
+fix(lca-api): bundle @learncard/init from its ESM build in Lambda esbuild (staging 500s)

--- a/packages/learn-card-init/package.json
+++ b/packages/learn-card-init/package.json
@@ -26,7 +26,10 @@
                 "default": "./dist/index.cjs"
             }
         },
-        "./dist/init.esm.js": "./dist/init.esm.js"
+        "./dist/init.esm.js": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/init.esm.js"
+        }
     },
     "files": [
         "dist"

--- a/packages/learn-card-init/package.json
+++ b/packages/learn-card-init/package.json
@@ -25,7 +25,8 @@
                 "types": "./dist/index.d.cts",
                 "default": "./dist/index.cjs"
             }
-        }
+        },
+        "./dist/init.esm.js": "./dist/init.esm.js"
     },
     "files": [
         "dist"

--- a/services/learn-card-network/lca-api/serverless.yml
+++ b/services/learn-card-network/lca-api/serverless.yml
@@ -23,6 +23,13 @@ custom:
         plugins: esbuildPlugins.cjs
         bundle: true
         minify: true
+        # @learncard/init's default (node.import) entry uses createRequire('./index.cjs'),
+        # which esbuild cannot bundle — the emitted Lambda bundle is left with a runtime
+        # require('./index.cjs') that does not exist next to the output, so the function
+        # throws at init and every route 500s. Point esbuild at init's self-contained
+        # bundler ESM build instead. (See LC staging incident 2026-06-11 / PR #1297.)
+        alias:
+            '@learncard/init': '@learncard/init/dist/init.esm.js'
         external:
             [
                 'snappy',


### PR DESCRIPTION
## TL;DR
Staging `lca-api` (`https://staging.api.learncard.app/api/*`) has returned **HTTP 500 on every route since 2026-06-11 ~19:20 UTC** — ~12 days. The UptimeRobot "Staging LearnCard App API" monitor (and the `staging-health-check` workflow that gates PRs) has been red the whole time. This is a real outage, not a flaky CI job. Root cause is a Lambda bundling regression from #1297; this PR fixes it.

## Timeline
| When (UTC) | Event |
|---|---|
| 2026-06-11 18:59 | #1297 *"load init's CJS bundle via createRequire in Node ESM entry"* merged to `main` → Deploy run starts |
| ~19:1x | **"Deploy LCA API Service" job succeeds** and ships the new Lambda bundle (the run's smoketest failed, but only on an unrelated `MongoClientClosedError`, so the breakage wasn't surfaced) |
| **19:20:21** | 🔴 Staging API goes DOWN — `500 Internal Server Error` on every route |
| 2026-06-12 | `7f9967346` externalizes init in the **docker** esbuild build — right idea, wrong build (staging is Lambda), and it didn't bump `lca-api/package.json`, so it never triggered a staging redeploy. Staging stayed down. |

## Why
- `/health-check` is a no-op that returns a static string and touches nothing — yet it 500s, and so do `/did`, `/openapi.json`, `/docs`. Identical failure on every route ⇒ the **Lambda dies at module init**, before any handler runs.
- The Lambda is built by **`serverless-esbuild`** and ships **no `node_modules`** (`serverless.yml`: `'!node_modules/**'`, only the didkit native binaries re-included). So everything must be **bundled**.
- esbuild resolves `@learncard/init` via the `node.import` export condition → `dist/node-esm.mjs`, which since #1297 does:
  ```js
  const require = createRequire(import.meta.url);
  const init = require('./index.cjs');
  ```
  esbuild **cannot follow a runtime `createRequire`**, so the emitted Lambda bundle is left calling `require('./index.cjs')` for a sibling file that doesn't exist in the artifact → `init` throws at load → **every route 500s**.
- #1297 was a legitimate fix for Vite/Astro SSR consumers (static `import` of a `.cjs` breaks their transform). It just happens to be the one shape esbuild can't bundle.

## The fix
Point the Lambda's esbuild at init's **self-contained bundler ESM build** — `dist/init.esm.js` (the `module` field; verified: zero `createRequire` / `import.meta.url` / `require(`):

- `services/learn-card-network/lca-api/serverless.yml`: add esbuild `alias` `@learncard/init → @learncard/init/dist/init.esm.js`.
- `packages/learn-card-init/package.json`: expose `./dist/init.esm.js` as an explicit `exports` subpath so the alias resolves under exports encapsulation (purely additive — exposes a file that already ships; no behavior change for existing consumers).

**No runtime change for anyone else:** Vite/Astro SSR and plain Node still use the `.` export (`node-esm.mjs`) that #1297 fixed. Only `lca-api`'s Lambda bundler is redirected. `@learncard/init` is the only init-importing service (brain-service / learn-cloud-service don't import it), so blast radius is limited to `lca-api`.

## Verification — ⚠️ not yet done
Draft because this needs a **staging deploy** to confirm. After deploy:
```bash
curl -s https://staging.api.learncard.app/api/health-check
# expect: "Healthy and well! (Version ...)"
```
And ideally confirm the original error in CloudWatch logs for the `learn-card-app-api-staging` Lambda (group `/aws/lambda/learn-card-app-api-staging-*`) — expected something like `Cannot find module './index.cjs'` / `module is not defined` at init.

## Alternatives considered
- **Externalize init** (mirror the docker fix): doesn't work for the Lambda — it ships no `node_modules`, and init is `workspace:*` (unpublished), so serverless-esbuild's packager can't install it standalone.
- **Fix `node-esm.mjs` to be bundle-safe again**: would re-break the Vite/Astro case #1297 fixed. Rejected.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Lambda function 500 errors by bundling @learncard/init's self-contained ESM build instead of problematic Node import entry.

Main changes:
- Export @learncard/init ESM build as direct import path in package.json exports
- Configure esbuild alias to use @learncard/init/dist/init.esm.js, bypassing createRequire bundling issue

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
