### PR TITLE
test(e2e): fix wallet-credentials failures from skipped "Publish & Issue" step

### DIFF
--- a/apps/learn-card-app/tests/test.helpers.ts
+++ b/apps/learn-card-app/tests/test.helpers.ts
@@ -77,8 +77,12 @@ export const issueCredentialToSelf = async (page: Page, timeout = 60_000) => {
     // Click Next to proceed to publish
     await page.getByRole('button', { name: 'Next' }).click({ timeout: 30_000 });
 
-    // Click Publish & Issue
-    await page.getByRole('button', { name: /publish & issue/i }).click({ timeout: 30_000 });
+    // Click Publish & Issue (skipped when the skipPublishStep flag is enabled,
+    // which routes "Next" straight to the Issue To screen — see BoostCMS.tsx)
+    const publishButton = page.getByRole('button', { name: /publish & issue/i });
+    if (await locatorExists(publishButton, 5_000)) {
+        await publishButton.click({ timeout: 30_000 });
+    }
 
     // Click Plus to open recipient selection
     await page.getByRole('button', { name: 'Plus' }).click({ timeout: 30_000 });

--- a/apps/learn-card-app/tests/test.helpers.ts
+++ b/apps/learn-card-app/tests/test.helpers.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import { TEST_USER_SEED } from './constants';
 
 // This is basically expect(locator).toBeVisible() except it'll actually wait for the timeout if the element isn't visible yet
@@ -31,7 +31,9 @@ export const joinNetworkIfNeeded = async (page: Page, profileId: string) => {
         await userIdInput.fill(profileId);
         await page.getByRole('button', { name: "Let's Go!" }).click({ timeout: 30_000 });
         // Wait for "Joining Network..." to finish and modal to close
-        await page.getByRole('button', { name: "Let's Go!" }).waitFor({ state: 'hidden', timeout: 60_000 });
+        await page
+            .getByRole('button', { name: "Let's Go!" })
+            .waitFor({ state: 'hidden', timeout: 60_000 });
     }
 };
 
@@ -56,6 +58,28 @@ export const openAddToLearnCardMenu = async (page: Page) => {
 };
 
 /**
+ * After clicking "Next" in the boost flow, clicks "Publish & Issue" when it is
+ * shown.
+ *
+ * When the `skipPublishStep` flag is enabled (current E2E config), "Next" lands
+ * directly on the "Issue To" screen and the publish step is absent — see
+ * BoostCMS.tsx. We wait for whichever screen renders first (the publish button
+ * or the "Issue To" Plus button) and only click publish when it is present.
+ * Racing the two screens avoids a fixed dead-wait when the step is skipped and
+ * avoids silently skipping a required click if the button renders slowly.
+ */
+export const clickPublishAndIssueIfPresent = async (page: Page) => {
+    const publishButton = page.getByRole('button', { name: /publish & issue/i });
+    const issueToPlusButton = page.getByRole('button', { name: 'Plus' });
+
+    await expect(publishButton.or(issueToPlusButton).first()).toBeVisible({ timeout: 30_000 });
+
+    if (await publishButton.isVisible()) {
+        await publishButton.click({ timeout: 30_000 });
+    }
+};
+
+/**
  * Issues a credential to the current user via the UI.
  *
  * Flow: Add to LearnCard → Boost Someone → pick template → fill form →
@@ -72,23 +96,24 @@ export const issueCredentialToSelf = async (page: Page, timeout = 60_000) => {
 
     // Fill in credential title and description
     await page.getByRole('textbox', { name: /0\// }).fill(TEST_CREDENTIAL_TITLE);
-    await page.locator('textarea[placeholder="What is this boost for?"]').fill('Test credential description');
+    await page
+        .locator('textarea[placeholder="What is this boost for?"]')
+        .fill('Test credential description');
 
     // Click Next to proceed to publish
     await page.getByRole('button', { name: 'Next' }).click({ timeout: 30_000 });
 
-    // Click Publish & Issue (skipped when the skipPublishStep flag is enabled,
-    // which routes "Next" straight to the Issue To screen — see BoostCMS.tsx)
-    const publishButton = page.getByRole('button', { name: /publish & issue/i });
-    if (await locatorExists(publishButton, 5_000)) {
-        await publishButton.click({ timeout: 30_000 });
-    }
+    // Click Publish & Issue (skipped when the skipPublishStep flag is enabled)
+    await clickPublishAndIssueIfPresent(page);
 
     // Click Plus to open recipient selection
     await page.getByRole('button', { name: 'Plus' }).click({ timeout: 30_000 });
 
     // Click Boost Myself
-    await page.getByRole('button', { name: /boost myself/i }).first().click({ timeout });
+    await page
+        .getByRole('button', { name: /boost myself/i })
+        .first()
+        .click({ timeout });
 
     // Click Save to issue the boost
     await page.getByRole('button', { name: 'Save' }).click({ timeout: 30_000 });
@@ -117,18 +142,25 @@ export const waitForAuthenticatedState = async (
     timeout = 30000
 ) => {
     // Parse options
-    const options = typeof pathOrOptions === 'string'
-        ? { path: pathOrOptions, seed: TEST_USER_SEED, profileId: undefined as string | undefined }
-        : { path: pathOrOptions.path ?? '/', seed: pathOrOptions.seed ?? TEST_USER_SEED, profileId: pathOrOptions.profileId };
+    const options =
+        typeof pathOrOptions === 'string'
+            ? {
+                  path: pathOrOptions,
+                  seed: TEST_USER_SEED,
+                  profileId: undefined as string | undefined,
+              }
+            : {
+                  path: pathOrOptions.path ?? '/',
+                  seed: pathOrOptions.seed ?? TEST_USER_SEED,
+                  profileId: pathOrOptions.profileId,
+              };
 
     // Wait for the LCN gate's underlying profile lookup so `Add to LearnCard`
     // opens the menu rather than the OnboardingContainer. Tolerate timeout
     // for cache-hit paths where no fresh request fires.
     const profileFetchPromise = page
         .waitForResponse(
-            response =>
-                /profile\.getProfile/.test(response.url()) &&
-                response.status() < 500,
+            response => /profile\.getProfile/.test(response.url()) && response.status() < 500,
             { timeout }
         )
         .catch(() => undefined);

--- a/apps/learn-card-app/tests/wallet-credentials.spec.ts
+++ b/apps/learn-card-app/tests/wallet-credentials.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
 import {
     issueCredentialToSelf,
+    locatorExists,
     openAddToLearnCardMenu,
     TEST_CREDENTIAL_TITLE,
     waitForAuthenticatedState,
@@ -85,8 +86,12 @@ test.describe('Wallet Credentials', () => {
         // Click Next to proceed to publish
         await page.getByRole('button', { name: 'Next' }).click({ timeout: 30_000 });
 
-        // Click Publish & Issue
-        await page.getByRole('button', { name: /publish & issue/i }).click({ timeout: 30_000 });
+        // Click Publish & Issue (skipped when the skipPublishStep flag is enabled,
+        // which routes "Next" straight to the Issue To screen — see BoostCMS.tsx)
+        const publishButton = page.getByRole('button', { name: /publish & issue/i });
+        if (await locatorExists(publishButton, 5_000)) {
+            await publishButton.click({ timeout: 30_000 });
+        }
 
         // Click Plus to open recipient selection
         await page.getByRole('button', { name: 'Plus' }).click({ timeout: 30_000 });

--- a/apps/learn-card-app/tests/wallet-credentials.spec.ts
+++ b/apps/learn-card-app/tests/wallet-credentials.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
 import {
+    clickPublishAndIssueIfPresent,
     issueCredentialToSelf,
-    locatorExists,
     openAddToLearnCardMenu,
     TEST_CREDENTIAL_TITLE,
     waitForAuthenticatedState,
@@ -86,12 +86,8 @@ test.describe('Wallet Credentials', () => {
         // Click Next to proceed to publish
         await page.getByRole('button', { name: 'Next' }).click({ timeout: 30_000 });
 
-        // Click Publish & Issue (skipped when the skipPublishStep flag is enabled,
-        // which routes "Next" straight to the Issue To screen — see BoostCMS.tsx)
-        const publishButton = page.getByRole('button', { name: /publish & issue/i });
-        if (await locatorExists(publishButton, 5_000)) {
-            await publishButton.click({ timeout: 30_000 });
-        }
+        // Click Publish & Issue (skipped when the skipPublishStep flag is enabled)
+        await clickPublishAndIssueIfPresent(page);
 
         // Click Plus to open recipient selection
         await page.getByRole('button', { name: 'Plus' }).click({ timeout: 30_000 });


### PR DESCRIPTION
## What

Makes the `Publish & Issue` click conditional in the wallet-credentials E2E tests so they pass whether or not the boost publish step is shown.

## Why

The `skipPublishStep` feature flag (LC-1285, #1169) is enabled in the E2E environment. With it on, clicking **Next** in the boost creation flow routes straight to the **Issue To** recipient screen — the intermediate **Publish & Issue** screen never renders.

Both tests still hard-waited for that button and timed out after 30s:

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  - waiting for getByRole('button', { name: /publish & issue/i })
  at test.helpers.ts:81
```

This was confirmed from the Playwright `error-context.md` accessibility snapshot at the failure point, which shows the page already on the **Issue To** screen (heading `Issue To`, `Plus` button, disabled `Save`) — i.e. past the publish step.

`Issue credential to yourself` and `Issue credential to someone else` have failed **every** e2e run on `changeset-release/main` since the flag flipped on. This is a stale-test issue, not a product regression.

## Fix

Guard the `Publish & Issue` click with the existing `locatorExists` helper (5s probe) in both:
- `apps/learn-card-app/tests/test.helpers.ts` (`issueCredentialToSelf`)
- `apps/learn-card-app/tests/wallet-credentials.spec.ts` (someone-else path)

Resilient to the flag flipping in either direction.

## Verification

Typechecks clean (`tsc --noEmit`). Full E2E runs on the EC2 runner — trigger the **Test Runner** workflow via `workflow_dispatch` with `branch=fix/e2e-wallet-credentials-skip-publish` to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix E2E wallet-credentials test failures caused by skipped "Publish & Issue" step in BoostCMS flow when skipPublishStep flag is enabled.

Main changes:
- Add `expect` import and extract `joinNetworkIfNeeded` button wait logic for improved reliability with multi-line formatting
- Introduce `clickPublishAndIssueIfPresent()` helper that races publish button against "Issue To" Plus button visibility
- Replace hardcoded publish button click with conditional helper in `issueCredentialToSelf()` and wallet-credentials test; add credential description fill and robust "Boost Myself" selector

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
