### PR TITLE
fix: [LC-1935] Fix Smoketest GH Actions

### DIFF
--- a/.changeset/tall-otters-happen.md
+++ b/.changeset/tall-otters-happen.md
@@ -1,0 +1,5 @@
+---
+'@learncard/types': patch
+---
+
+Fix smoketest GH actions

--- a/packages/learn-card-types/src/queries.ts
+++ b/packages/learn-card-types/src/queries.ts
@@ -7,6 +7,18 @@ const parseRegexString = (regexStr: string) => {
     return { pattern: match[1], flags: match[2] };
 };
 
+const withStringOverride = <T extends z.ZodTypeAny>(schema: T): T => {
+    const metaSchema = schema as T & {
+        meta?: (metadata: { override: { type: 'string' } }) => T;
+    };
+
+    if (typeof metaSchema.meta === 'function') {
+        return metaSchema.meta({ override: { type: 'string' } });
+    }
+
+    return schema;
+};
+
 // TRPC validator that converts Regex strings into RegExps
 const RegExpStringValidator = z
     .string()
@@ -31,19 +43,14 @@ const RegExpStringValidator = z
         } catch (error) {
             throw new Error(`Invalid RegExp: ${(error as Error).message}`);
         }
-    })
-    .meta({ override: { type: 'string' } });
+    });
 
-export const RegExpValidator = z
-    .instanceof(RegExp)
-    .meta({ override: { type: 'string' } })
-    .or(RegExpStringValidator)
-    .meta({ override: { type: 'string' } });
+export const RegExpValidator = withStringOverride(z.instanceof(RegExp).or(RegExpStringValidator));
 
 const BaseStringQuery = z
     .string()
     .or(z.object({ $in: z.string().array() }))
-    .or(z.object({ $regex: RegExpValidator.meta({ override: { type: 'string' } }) }));
+    .or(z.object({ $regex: RegExpValidator }));
 
 export const StringQuery = z.union([
     BaseStringQuery,


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues
<!--- Example: Fixes: WE-53, Related to: WE-308 -->
[LC-1935](https://welibrary.atlassian.net/browse/LC-1935)

#### 📚 What is the context and goal of this PR?
Smoketest GH Actions were failing due to a zod issue. Fixed by using a small helper to use `.meta(...)` only when it's actually available

#### 🥴 TL; RL:
Fix smoketests

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
- Approve this and then watch the smoketest actions

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->
GH action change

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   ]x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1935]: https://welibrary.atlassian.net/browse/LC-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor Zod schema metadata handling to centralize string override logic and fix smoketest GH Actions workflow.

Main changes:
- Introduced `withStringOverride` helper function to consolidate repeated `.meta()` calls across schema definitions
- Refactored `RegExpValidator` to use the new helper, eliminating redundant metadata overrides throughout the schema chain
- Simplified `BaseStringQuery` schema by removing inline metadata and applying override through centralized utility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
