### PR TITLE
fix(types): declare zod as an explicit dependency of @learncard/types [LC-1935]

### DIFF
--- a/.changeset/zod-types-dependency.md
+++ b/.changeset/zod-types-dependency.md
@@ -1,0 +1,7 @@
+---
+'@learncard/types': patch
+---
+
+Declare `zod` (and the `zod-openapi` type augmentation) as explicit dependencies of `@learncard/types`.
+
+`@learncard/types` uses zod's v4-only `.meta({ override })` API at module load but previously declared no zod dependency, relying on hoisting. Inside the monorepo this works because a `pnpm.overrides` entry pins zod to `4.1.13`, but in a fresh registry install (the npm-packages smoketest) those overrides don't apply, so zod could resolve to a v3 where `.meta()` doesn't exist — crashing on import. Declaring the dependency ensures a v4 zod with `.meta()` is always resolved, fixing LC-1935 at its root without the `.meta`-existence guard (whose previous form, #1321, broke OpenAPI document generation in the brain-service).

--- a/packages/learn-card-types/package.json
+++ b/packages/learn-card-types/package.json
@@ -34,6 +34,10 @@
     "bugs": {
         "url": "https://github.com/learningeconomy/LearnCard/issues"
     },
+    "dependencies": {
+        "zod": "^4.1.13",
+        "zod-openapi": "^5.4.5"
+    },
     "devDependencies": {
         "@esbuild-plugins/node-resolve": "^0.2.2",
         "@size-limit/preset-small-lib": "^7.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2296,6 +2296,13 @@ importers:
         version: 5.6.2
 
   packages/learn-card-types:
+    dependencies:
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+      zod-openapi:
+        specifier: 5.4.5
+        version: 5.4.5(zod@4.1.13)
     devDependencies:
       '@esbuild-plugins/node-resolve':
         specifier: ^0.2.2


### PR DESCRIPTION
## What

Adds an explicit `dependencies` block to `@learncard/types`:

```jsonc
"dependencies": {
  "zod": "^4.1.13",
  "zod-openapi": "^5.4.5"
}
```

## Why — the root cause behind the smoketest failure *and* the recent prod outage

`@learncard/types` uses zod's **v4-only `.meta({ override })`** API at module load (`src/queries.ts`) but declared **no zod dependency**, relying on hoisting.

- **Inside the monorepo** it works only because a `pnpm.overrides` entry in the root `package.json` pins `zod` to `4.1.13`.
- **In a fresh registry install** (e.g. the `smoketest-npm-packages.yml` job, which installs the published packages outside the monorepo) those overrides **don't apply**, so `zod` can resolve to a **v3** (pulled transitively by sibling `@learncard/*` packages that still declare `^3.23.x`), where `.meta()` doesn't exist → **crash on import**. That's [LC-1935].

[#1321](https://github.com/learningeconomy/LearnCard/pull/1321) worked around this by guarding the `.meta()` call (`typeof schema.meta === 'function'`). But that change also moved the `{ type: 'string' }` override **off the inner `z.instanceof(RegExp)` node** onto the outer union. `zod-openapi` recurses into union members and needs the override on the `instanceof` node itself, so `generateOpenApiDocument(appRouter)` threw at module-init in the brain-service:

```
Zod schema of type `custom` at … > $regex > anyOf > 0 cannot be represented
in OpenAPI. Please assign it metadata with `.meta()`
```

That crashed the entire `lambda.ts` bundle (every `/trpc`, `/api`, `/docs`, `/skills`, `/status-lists` handler 500'd; only the separate `didWeb` lambda survived), taking down all logins. [#1321](https://github.com/learningeconomy/LearnCard/pull/1321) was reverted in [#1323](https://github.com/learningeconomy/LearnCard/pull/1323), which fixed prod but **reintroduces the original LC-1935 smoketest crash** (unconditional `.meta()` again).

## How this fixes it properly

Declaring the dependency means `@learncard/types` always resolves a **v4 zod with `.meta()`** — in the monorepo and in fresh installs alike. So:

- ✅ The npm-packages smoketest no longer crashes on import (LC-1935 fixed at the source).
- ✅ The brain-service keeps the reverted, working `queries.ts` (override on the inner node) — OpenAPI generation succeeds.
- ✅ No `.meta`-existence guard needed.

`zod-openapi` is added too because `@learncard/types` imports it for the `import type {} from 'zod-openapi'` augmentation that provides the `override` meta typing.

## Verification

- `pnpm --filter @learncard/types build` ✅
- `pnpm install --frozen-lockfile` ✅ (lockfile change is only the additive `@learncard/types` deps)
- Reproduced the prod CloudWatch error locally against the failing route shape (`POST /boost/skills/search` with nested `$or`/`$regex`), and confirmed generation **succeeds** with the reverted `queries.ts` + this change ✅
- Real fix validated by the `smoketest-npm-packages` CI job on this PR.

## Follow-up (not in this PR)

Sibling packages (`learn-card-base`, `learn-card-helpers`, `credential-library`) still declare `zod: ^3.23.x` while the ecosystem runs zod 4 via the override — worth aligning to remove the remaining dual-major footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LC-1935]: https://welibrary.atlassian.net/browse/LC-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Declare zod and zod-openapi as explicit dependencies in @learncard/types to ensure v4 compatibility and fix import failures in fresh registry installations.

Main changes:
- Added zod ^4.1.13 and zod-openapi ^5.4.5 to dependencies section in package.json
- Created changeset documenting dependency fix for @learncard/types patch release

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

