### PR TITLE
feat: DM Review Checklist

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -17,6 +17,7 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GH_REPO: ${{ github.repository }}
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
               run: |
                   set -euo pipefail
 
@@ -48,6 +49,9 @@ jobs:
                   changes_requested_items='[]'
                   stale_items='[]'
                   draft_count=0
+
+                  # Per-assignee accumulator for personal DM checklists: { "<github_login>": [ item, ... ] }
+                  assignee_items='{}'
 
                   pr_count=$(echo "$prs_json" | jq 'length')
 
@@ -104,6 +108,18 @@ jobs:
                       end
                     ')
 
+                    if [ "$has_changes_requested" = "true" ]; then
+                      category="changes"; priority=1
+                    elif [ "$has_approval" != "true" ]; then
+                      if [ "$age_days" -ge 7 ]; then
+                        category="stale"; priority=0
+                      else
+                        category="review"; priority=2
+                      fi
+                    else
+                      continue
+                    fi
+
                     # Build a JSON item for this PR
                     item=$(jq -n \
                       --arg number "$number" \
@@ -114,17 +130,21 @@ jobs:
                       --argjson age_days "$age_days" \
                       --argjson sprint "$is_sprint" \
                       --arg assignees "$assignees" \
-                      '{number: $number, title: $title, author: $author, url: $url, age: $age, age_days: $age_days, sprint: $sprint, assignees: $assignees}')
+                      --arg category "$category" \
+                      --argjson priority "$priority" \
+                      '{number: $number, title: $title, author: $author, url: $url, age: $age, age_days: $age_days, sprint: $sprint, assignees: $assignees, category: $category, priority: $priority}')
 
-                    if [ "$has_changes_requested" = "true" ]; then
-                      changes_requested_items=$(echo "$changes_requested_items" | jq --argjson item "$item" '. + [$item]')
-                    elif [ "$has_approval" != "true" ]; then
-                      if [ "$age_days" -ge 7 ]; then
-                        stale_items=$(echo "$stale_items" | jq --argjson item "$item" '. + [$item]')
-                      else
-                        needs_review_items=$(echo "$needs_review_items" | jq --argjson item "$item" '. + [$item]')
-                      fi
-                    fi
+                    case "$category" in
+                      changes) changes_requested_items=$(echo "$changes_requested_items" | jq --argjson item "$item" '. + [$item]') ;;
+                      stale)   stale_items=$(echo "$stale_items" | jq --argjson item "$item" '. + [$item]') ;;
+                      review)  needs_review_items=$(echo "$needs_review_items" | jq --argjson item "$item" '. + [$item]') ;;
+                    esac
+
+                    for login in $(echo "$pr" | jq -r '.assignees[]?.login'); do
+                      assignee_items=$(echo "$assignee_items" | jq \
+                        --arg login "$login" --argjson item "$item" \
+                        '.[$login] = ((.[$login] // []) + [$item])')
+                    done
                   done
 
                   # --- Build Slack Block Kit payload ---
@@ -220,6 +240,48 @@ jobs:
                   echo "$payload" > /tmp/slack-payload.json
 
                   echo "total=$total" >> "$GITHUB_OUTPUT"
+
+                  # --- Personal DM checklists ---
+                  # Requires a Slack bot token (SLACK_BOT_TOKEN) with chat:write + im:write scopes.
+                  # Incoming webhooks cannot DM users, so this is skipped if the token is absent.
+                  if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
+                    echo "SLACK_BOT_TOKEN not set — skipping personal DM checklists."
+                  else
+                    for gh_login in $(echo "$SLACK_USER_MAP" | jq -r 'keys[]'); do
+                      user_items=$(echo "$assignee_items" | jq --arg l "$gh_login" '.[$l] // []')
+                      count=$(echo "$user_items" | jq 'length')
+                      if [ "$count" -eq 0 ]; then
+                        continue
+                      fi
+
+                      slack_id=$(echo "$SLACK_USER_MAP" | jq -r --arg l "$gh_login" '.[$l] | gsub("[<@>]"; "")')
+
+                      # Highest priority first (stale=0, changes=1, review=2), then oldest first
+                      checklist=$(echo "$user_items" | jq -r '
+                        sort_by(.priority, -.age_days) | .[] |
+                        ({"0": "🔴", "1": "🟡", "2": "🔵"}[.priority | tostring]) as $dot |
+                        "☐ " + $dot + "  <" + .url + "|#" + .number + "> *" + .title + "*  ·  " + .age +
+                        (if .sprint then "  ·  ⚡" else "" end)
+                      ')
+
+                      dm_blocks=$(jq -n --arg count "$count" --arg items "$checklist" '[
+                        {"type": "header", "text": {"type": "plain_text", "text": "Your PR Review Checklist", "emoji": true}},
+                        {"type": "context", "elements": [{"type": "mrkdwn", "text": ($count + " PR(s) assigned to you · 🔴 stale · 🟡 changes requested · 🔵 needs review")}]},
+                        {"type": "section", "text": {"type": "mrkdwn", "text": $items}}
+                      ]')
+
+                      dm_payload=$(jq -n --arg channel "$slack_id" --argjson blocks "$dm_blocks" '{channel: $channel, blocks: $blocks}')
+
+                      response=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+                        -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                        -H 'Content-Type: application/json; charset=utf-8' \
+                        -d "$dm_payload")
+
+                      if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
+                        echo "Failed to DM $gh_login: $(echo "$response" | jq -r '.error // "unknown"')"
+                      fi
+                    done
+                  fi
 
             - name: Send Slack notification
               if: always()

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -140,11 +140,12 @@ jobs:
                       review)  needs_review_items=$(echo "$needs_review_items" | jq --argjson item "$item" '. + [$item]') ;;
                     esac
 
-                    for login in $(echo "$pr" | jq -r '.assignees[]?.login'); do
+                    while IFS= read -r login; do
+                      [ -n "$login" ] || continue
                       assignee_items=$(echo "$assignee_items" | jq \
                         --arg login "$login" --argjson item "$item" \
                         '.[$login] = ((.[$login] // []) + [$item])')
-                    done
+                    done < <(echo "$pr" | jq -r '.assignees[]?.login')
                   done
 
                   # --- Build Slack Block Kit payload ---
@@ -247,7 +248,8 @@ jobs:
                   if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
                     echo "SLACK_BOT_TOKEN not set — skipping personal DM checklists."
                   else
-                    for gh_login in $(echo "$SLACK_USER_MAP" | jq -r 'keys[]'); do
+                    while IFS= read -r gh_login; do
+                      [ -n "$gh_login" ] || continue
                       user_items=$(echo "$assignee_items" | jq --arg l "$gh_login" '.[$l] // []')
                       count=$(echo "$user_items" | jq 'length')
                       if [ "$count" -eq 0 ]; then
@@ -285,7 +287,7 @@ jobs:
                       if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
                         echo "Failed to DM $gh_login: $(echo "$response" | jq -r '.error // "unknown"')"
                       fi
-                    done
+                    done < <(echo "$SLACK_USER_MAP" | jq -r 'keys[]')
                   fi
 
             - name: Send Slack notification

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -261,18 +261,21 @@ jobs:
                       # Link to this user's open assigned PRs in the repo (GitHub search query)
                       assigned_url="https://github.com/${GH_REPO}/pulls?q=is%3Aopen+is%3Apr+assignee%3A${gh_login}"
 
-                      # Highest priority first (stale=0, changes=1, review=2), then oldest first
-                      checklist=$(echo "$user_items" | jq -r '
-                        sort_by(.priority, -.age_days) | .[] |
-                        ({"0": "🔴", "1": "🟡", "2": "🔵"}[.priority | tostring]) as $dot |
-                        "☐ " + $dot + "  <" + .url + "|#" + .number + "> *" + .title + "*  ·  " + .age +
-                        (if .sprint then "  ·  ⚡" else "" end)
-                      ')
-
-                      dm_blocks=$(jq -n --arg count "$count" --arg items "$checklist" --arg assigned_url "$assigned_url" '[
-                        {"type": "header", "text": {"type": "plain_text", "text": "Your PR Review Checklist", "emoji": true}},
-                        {"type": "context", "elements": [{"type": "mrkdwn", "text": ($count + " PR(s) assigned to you · 🔴 stale · 🟡 changes requested · 🔵 needs review")}]},
-                        {"type": "section", "text": {"type": "mrkdwn", "text": $items}},
+                      # One section per PR (sorted: priority asc, then oldest first) to stay under Slack's 3000-char section limit.
+                      dm_blocks=$(echo "$user_items" | jq \
+                        --arg count "$count" --arg assigned_url "$assigned_url" '
+                        ({"0": "🔴", "1": "🟡", "2": "🔵"}) as $dots |
+                        [
+                          {"type": "header", "text": {"type": "plain_text", "text": "Your PR Review Checklist", "emoji": true}},
+                          {"type": "context", "elements": [{"type": "mrkdwn", "text": ($count + " PR(s) assigned to you · 🔴 stale · 🟡 changes requested · 🔵 needs review")}]}
+                        ]
+                        + ( sort_by(.priority, -.age_days) | map(
+                            {"type": "section", "text": {"type": "mrkdwn", "text": (
+                              "☐ " + $dots[.priority | tostring] + "  <" + .url + "|#" + .number + "> *" + .title + "*  ·  " + .age +
+                              (if .sprint then "  ·  ⚡" else "" end)
+                            )}}
+                          ) )
+                        + [
                         {"type": "divider"},
                         {"type": "context", "elements": [{"type": "mrkdwn", "text": ("📎 <" + $assigned_url + "|View all your assigned PRs on GitHub>")}]}
                       ]')

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -256,6 +256,9 @@ jobs:
 
                       slack_id=$(echo "$SLACK_USER_MAP" | jq -r --arg l "$gh_login" '.[$l] | gsub("[<@>]"; "")')
 
+                      # Link to this user's open assigned PRs in the repo (GitHub search query)
+                      assigned_url="https://github.com/${GH_REPO}/pulls?q=is%3Aopen+is%3Apr+assignee%3A${gh_login}"
+
                       # Highest priority first (stale=0, changes=1, review=2), then oldest first
                       checklist=$(echo "$user_items" | jq -r '
                         sort_by(.priority, -.age_days) | .[] |
@@ -264,10 +267,12 @@ jobs:
                         (if .sprint then "  ·  ⚡" else "" end)
                       ')
 
-                      dm_blocks=$(jq -n --arg count "$count" --arg items "$checklist" '[
+                      dm_blocks=$(jq -n --arg count "$count" --arg items "$checklist" --arg assigned_url "$assigned_url" '[
                         {"type": "header", "text": {"type": "plain_text", "text": "Your PR Review Checklist", "emoji": true}},
                         {"type": "context", "elements": [{"type": "mrkdwn", "text": ($count + " PR(s) assigned to you · 🔴 stale · 🟡 changes requested · 🔵 needs review")}]},
-                        {"type": "section", "text": {"type": "mrkdwn", "text": $items}}
+                        {"type": "section", "text": {"type": "mrkdwn", "text": $items}},
+                        {"type": "divider"},
+                        {"type": "context", "elements": [{"type": "mrkdwn", "text": ("📎 <" + $assigned_url + "|View all your assigned PRs on GitHub>")}]}
                       ]')
 
                       dm_payload=$(jq -n --arg channel "$slack_id" --argjson blocks "$dm_blocks" '{channel: $channel, blocks: $blocks}')

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -275,7 +275,7 @@ jobs:
                       response=$(curl -s -X POST https://slack.com/api/chat.postMessage \
                         -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
                         -H 'Content-Type: application/json; charset=utf-8' \
-                        -d "$dm_payload")
+                        -d "$dm_payload" || echo '{"ok":false,"error":"curl_failed"}')
 
                       if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
                         echo "Failed to DM $gh_login: $(echo "$response" | jq -r '.error // "unknown"')"


### PR DESCRIPTION
# Overview

The scheduled PR review digest posts one big list to a shared Slack channel. It's easy to scan past your own PRs in that wall of text. This adds a second output: a private DM to each person with just the PRs assigned to them, ordered as a checklist so they know what to review first.

The channel digest is unchanged. This only adds the per-person DMs alongside it.

#### What it does

- After building the channel digest, the workflow groups every PR-needing-attention by its assignees.
- For each mapped Slack user who has at least one assigned PR, it sends them a DM titled "Your PR Review Checklist".
- Each PR is a `☐` checklist line, sorted by urgency: 🔴 stale (7+ days, no approval) → 🟡 changes requested → 🔵 needs review, oldest first within each group. Sprint PRs get a ⚡.
- People with no assigned PRs get no DM.

#### Why

The shared digest is good for team-wide visibility but bad as a personal to-do. A DM that says "here are your 3 reviews, in priority order" is far more actionable and keeps the noise out of the channel.

# Testing

#### How to QA

This needs a new repo secret before it'll do anything:

1. Create/reuse a Slack app with bot scopes `chat:write` and `im:write`, install it to the workspace.
2. Add the bot token as the `SLACK_BOT_TOKEN` repo secret.
3. Trigger the workflow manually (Actions → "PR Review Reminder" → Run workflow).

What to check:
- Each person in the `SLACK_USER_MAP` who is assigned to an open, non-draft PR gets a DM.
- The checklist order matches the urgency rule above.
- The shared-channel digest still posts exactly as before.
- Without `SLACK_BOT_TOKEN` set, the run logs "skipping personal DM checklists" and the channel digest still works (no failures).

All changes are in `.github/workflows/pr-review-reminder.yml`.

#### Types of Changes

- [x] New feature (non-breaking change which adds functionality)

#### Does this create new technical debt?

- [x] No

# Documentation

Internal CI workflow change, no user-facing docs needed. The one operational gotcha (the `SLACK_BOT_TOKEN` secret + required scopes) is documented in a comment at the top of the DM block.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement personal Slack DM review checklists for PR assignees with priority-based categorization and GitHub-Slack user mapping integration.

Main changes:
- Add SLACK_BOT_TOKEN environment variable and per-assignee PR item accumulator with priority/category classification logic
- Build personalized Slack DM blocks sorted by priority and age, sent via chat.postMessage API with GitHub search links
- Refactor PR categorization into explicit category/priority fields enabling both webhook notifications and targeted DM delivery

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
