### PR TITLE
fix(ci): repair OpenAPI SDK PR creation (duplicate Authorization header)

### DIFF
--- a/.github/workflows/open-api-generator.yml
+++ b/.github/workflows/open-api-generator.yml
@@ -23,7 +23,6 @@ jobs:
               uses: actions/checkout@v7
               with:
                   fetch-depth: 0
-                  token: '${{ secrets.GITHUB_TOKEN }}'
                   # create-pull-request manages its own git auth; persisting the
                   # checkout extraheader causes a "Duplicate header: Authorization"
                   # 400 with newer git (2.54+). See peter-evans/create-pull-request.

--- a/.github/workflows/open-api-generator.yml
+++ b/.github/workflows/open-api-generator.yml
@@ -24,6 +24,10 @@ jobs:
               with:
                   fetch-depth: 0
                   token: '${{ secrets.GITHUB_TOKEN }}'
+                  # create-pull-request manages its own git auth; persisting the
+                  # checkout extraheader causes a "Duplicate header: Authorization"
+                  # 400 with newer git (2.54+). See peter-evans/create-pull-request.
+                  persist-credentials: false
 
             - name: Git config
               run: |
@@ -48,7 +52,7 @@ jobs:
                   echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Create or update PR
-              uses: peter-evans/create-pull-request@v6
+              uses: peter-evans/create-pull-request@v7
               with:
                   commit-message: Update ${{ matrix.generator-name }}-client SDK to version ${{ steps.package-version.outputs.version }}
                   title: Update Open API Client SDKs to version ${{ steps.package-version.outputs.version }}


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!-- No Jira issue — CI infra fix surfaced from a failing Deploy run. -->
N/A — CI infrastructure fix.

#### 📚 What is the context and goal of this PR?

The **Generate SDK Clients → Generate Client SDKs for LearnCard Network API (python)** job in the Deploy workflow was failing at the **"Create or update PR"** step:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/learningeconomy/LearnCard/': The requested URL returned error: 400
The process '/usr/bin/git' failed with exit code 128
```

The OpenAPI generation itself succeeded — every client template file was written. The failure is purely in the PR-creation step.

**Root cause:** `actions/checkout` persists a credential `extraheader` (`AUTHORIZATION: basic ***`) into the local git config. `peter-evans/create-pull-request` then runs its own authenticated git operations (e.g. `git remote prune origin`) and injects a *second* Authorization header. The runner's git (2.54.0) sends both, and GitHub rejects the request with HTTP 400.

This is unrelated to the Zod 4.4 / OpenAPI change that triggered the run.

#### 🥴 TL; RL:

Stop `actions/checkout` from persisting git credentials so `create-pull-request` (which manages its own auth via the `token` input) doesn't end up sending a duplicate `Authorization` header.

#### 💡 Feature Breakdown

`.github/workflows/open-api-generator.yml`:
- Added `persist-credentials: false` to the checkout step — **the actual fix**.
- Bumped `peter-evans/create-pull-request@v6` → `@v7` to clear the deprecated Node 20 shim warning.

#### 🛠 Important tradeoffs made:

None. `create-pull-request` already authenticates via its `token` input, so dropping the persisted checkout credential has no functional impact on the workflow.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
-   [ ] Yes

> Note: `.github/workflows/maids.yml` has the same latent pattern (`create-pull-request@v5` + persisted checkout creds). Not touched here to keep this PR scoped; can be fixed in a follow-up if/when that workflow pushes.

# Testing

#### 🔬 How Can Someone QA This?

Re-run the **Deploy** workflow (or wait for the next run that affects the brain-service OpenAPI spec) and confirm the **Generate Client SDKs for LearnCard Network API (python)** job completes the "Create or update PR" step without the `Duplicate header: "Authorization"` / HTTP 400 error, and that the `open-api-generator` PR is created/updated.

#### 📱 🖥 Which devices would you like help testing on?

N/A — CI only.

#### 🧪 Code Coverage

N/A — GitHub Actions workflow change; not unit-testable. Verification is via the live workflow run.

# Documentation

#### 📝 Documentation Checklist

No docs needed.

#### 💭 Documentation Notes

Internal CI fix, no API or user-facing changes.

# ✅ PR Checklist

-   [ ] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix duplicate Authorization header error in OpenAPI SDK PR creation workflow by removing conflicting git credentials configuration and updating action version.

Main changes:
- Removed `token: GITHUB_TOKEN` from checkout step; set `persist-credentials: false` to prevent auth header conflicts
- Upgraded `peter-evans/create-pull-request` action from v6 to v7 for improved git authentication handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

