### PR TITLE
fix: AI Passport Contract, Local Dev

### DIFF
--- a/.changeset/proud-comics-warn.md
+++ b/.changeset/proud-comics-warn.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: AI Passport Contract, Local Dev

--- a/apps/learn-card-app/src/hooks/useAutoConsentLearnCardAi.ts
+++ b/apps/learn-card-app/src/hooks/useAutoConsentLearnCardAi.ts
@@ -6,6 +6,7 @@ const log = getLogger('use-auto-consent-learn-card-ai');
 import { CurrentUser, useWallet, useCurrentUser, useWithdrawConsent } from 'learn-card-base';
 import { getOrFetchConsentedContracts } from 'learn-card-base';
 import { getTermsWithSharedUrisForWallet } from 'learn-card-base';
+import { isProductionNetwork } from 'learn-card-base/helpers/networkHelpers';
 
 import {
     AiPassportAppsEnum,
@@ -37,6 +38,8 @@ export const useAutoConsentLearnCardAi = () => {
     const autoConsentLearnCardAi = useCallback(
         async ({ enabled, userOverrides }: AutoConsentOptions) => {
             if (!enabled) return false;
+            // Prod-only contract (does not exist off-prod); mirrors useNetworkConsentMutation gate.
+            if (!isProductionNetwork()) return false;
             if (autoConsentInFlight) return autoConsentInFlight;
 
             const run = (async () => {

--- a/apps/learn-card-app/src/hooks/useAutoConsentLearnCardAi.ts
+++ b/apps/learn-card-app/src/hooks/useAutoConsentLearnCardAi.ts
@@ -6,7 +6,7 @@ const log = getLogger('use-auto-consent-learn-card-ai');
 import { CurrentUser, useWallet, useCurrentUser, useWithdrawConsent } from 'learn-card-base';
 import { getOrFetchConsentedContracts } from 'learn-card-base';
 import { getTermsWithSharedUrisForWallet } from 'learn-card-base';
-import { isProductionNetwork } from 'learn-card-base/helpers/networkHelpers';
+import { isProductionNetwork } from 'learn-card-base';
 
 import {
     AiPassportAppsEnum,

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -198,6 +198,7 @@ export * from './components/openid4vc/ExchangeErrorDisplay';
 export * from './components/openid4vc/IssuerHeader';
 export * from './components/openid4vc/VerifierHeader';
 export * from './helpers/web3AuthHelpers';
+export * from './helpers/networkHelpers';
 export * from './helpers/statusBarHelpers';
 export * from './helpers/platformHelpers';
 export * from './helpers/navBarHelpers';


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Signing up or logging in on a local (non-production) environment would hang and spam the console with `Failed to auto-consent to LearnCard AI contract`. The LearnCard AI Passport contract is a production-only record that lives on `network.learncard.com`. It does not exist on local or staging networks, so the auto-consent flow kept trying to fetch a contract that isn't there, failing and retrying in a loop that stalled the login flow.

#### 🥴 TL; RL:

Don't run LearnCard AI auto-consent off-production. The contract only exists in prod, so skip it everywhere else.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

Added a single early return in `autoConsentLearnCardAi` (in `apps/learn-card-app/src/hooks/useAutoConsentLearnCardAi.ts`):

- If the active network isn't production (`isProductionNetwork()` is false), return immediately before any network calls.
- This mirrors the existing guard already used by the sibling network-consent flow (`useNetworkConsentMutation`), so it follows an established pattern rather than introducing a new one.

#### 🛠 Important tradeoffs made:

- AI auto-consent is intentionally a no-op on local/staging. Because the contract is prod-only, this can't be exercised off-prod anyway. Testing the real flow locally would require seeding the contract on the local network — out of scope here.
- The guard sits in the hook itself, which is the single chokepoint for all three callers (`AppRouter`, `OnboardingNetworkForm`, `useAiConsentToggle`), so one change covers every entry path.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Run the app against a local backend (non-production network).
2. Sign up a new user, or log in with an existing one.
3. Confirm login completes normally and does not stall.
4. Confirm the console no longer logs `Failed to auto-consent to LearnCard AI contract`.
5. Sanity check production behavior is unchanged: with AI enabled, auto-consent still runs as before.

#### 📱 🖥 Which devices would you like help testing on?

Chromium / Firefox

#### 🧪 Code Coverage

No new tests. The change is a one-line environment guard that reuses the existing `isProductionNetwork()` helper.

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [x] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

Bug fix with no API or user-flow changes. Added a one-line inline comment explaining why the prod-only guard exists, so it isn't mistaken for an arbitrary flag later.

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add production network validation to prevent AI Passport contract operations in local development environments.

Main changes:
- Import `isProductionNetwork` helper and add conditional check to block auto-consent on non-production networks
- Add changeset documenting patch version bump for learn-card-app

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
