### PR TITLE
fix: Chromatic diffThreshold

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -99,5 +99,9 @@ jobs:
                   workingDir: apps/learn-card-app
                   # The app has no prebuilt Storybook output, so let Chromatic run the build script.
                   buildScriptName: build-storybook
+                  # TurboSnap: only snapshot stories whose files (or their dependencies) changed
+                  # since the baseline. Storybook 8 + Vite generates the dependency stats natively,
+                  # so no extra --stats-json flag is needed when Chromatic builds Storybook itself.
+                  onlyChanged: true
                   # Don't fail the build on visual changes — they're reviewed in Chromatic's UI.
                   exitZeroOnChanges: true

--- a/apps/learn-card-app/.storybook/preview.tsx
+++ b/apps/learn-card-app/.storybook/preview.tsx
@@ -31,7 +31,7 @@ const preview: Preview = {
         controls: { matchers: { color: /(background|color)$/i, date: /Date$/ } },
         layout: 'fullscreen',
         chromatic: {
-            diffThreshold: 0.2,
+            diffThreshold: 0.1,
             diffIncludeAntiAliasing: false,
         },
         backgrounds: {

--- a/apps/learn-card-app/.storybook/preview.tsx
+++ b/apps/learn-card-app/.storybook/preview.tsx
@@ -30,6 +30,10 @@ const preview: Preview = {
         actions: { argTypesRegex: '^on[A-Z].*' },
         controls: { matchers: { color: /(background|color)$/i, date: /Date$/ } },
         layout: 'fullscreen',
+        chromatic: {
+            diffThreshold: 0.2,
+            diffIncludeAntiAliasing: false,
+        },
         backgrounds: {
             default: 'app',
             values: [


### PR DESCRIPTION
# Overview

Two small tweaks to the LearnCard App's Chromatic setup to cut down noise and speed up visual regression runs.

#### What & why

We were getting a lot of false positives in Chromatic — stories flagged as "changed" when nothing about them actually changed. On top of that, every PR re-snapshotted the whole Storybook even when only a handful of components were touched. This PR addresses both.

**1. Fewer false positives** (`apps/learn-card-app/.storybook/preview.tsx`)
Added a global `chromatic` parameter to the Storybook preview:
- `diffThreshold: 0.2` — raised from Chromatic's default (0.063) so tiny sub-pixel differences no longer trip a diff.
- `diffIncludeAntiAliasing: false` — ignores anti-aliasing jitter (font/edge rendering), one of the most common sources of phantom diffs.

These apply to every story but can still be overridden per-story if a specific one needs stricter matching.

**2. TurboSnap** (`.github/workflows/chromatic.yml`)
Added `onlyChanged: true` to the app's Chromatic action. TurboSnap traces Vite's dependency graph and only snapshots stories whose files (or their imports) changed since the baseline; the rest are copied from the baseline at a fraction of the snapshot cost. No `--stats-json` flag is needed — Storybook 8 + Vite generates the stats natively since Chromatic builds Storybook itself.

#### Note / tradeoff

The workflow still runs on the `pull_request` trigger. Chromatic technically recommends `push` for TurboSnap, but this repo's Chromatic job is built around comparing against `origin/main` (nx affected, checkout ref, concurrency), and switching to `push` would need branch-aware baseline handling to avoid breaking baselines on `main`. The `chromaui/action` already handles `pull_request` by pinning `pull_request.head.sha`, so TurboSnap works today. If we later notice TurboSnap skipping stories it shouldn't, that's the signal to do a proper `push` migration.

#### 🔍 Types of Changes

-   [x] Chore (CI / Storybook config tweak)

# Testing

#### 🔬 How Can Someone QA This?

1. Open the Chromatic build linked on this PR.
2. Confirm the build runs and that TurboSnap is active — the build page shows a TurboSnap indicator and the CLI log reports "Found N story files affected by recent changes" (rather than re-snapshotting everything).
3. Confirm stories that weren't touched are marked as TurboSnapped / unchanged instead of flagged as diffs.

Config-only change — no app runtime behavior is affected.

#### 🧪 Code Coverage

No tests added; this is CI and Storybook configuration.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Configure Chromatic visual testing thresholds and enable TurboSnap optimization for efficient story diffing in Storybook CI.

Main changes:
- Added diffThreshold (0.2) and diffIncludeAntiAliasing settings to Chromatic preview configuration
- Enabled TurboSnap's onlyChanged flag to snapshot only stories with changed dependencies

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

