### PR TITLE
🐛 hotfix: Bundle DIDKit WASM into Lambda artifacts (fix staging 500s)

### DIFF
--- a/.changeset/quiet-webs-happen.md
+++ b/.changeset/quiet-webs-happen.md
@@ -1,0 +1,8 @@
+---
+"@learncard/network-brain-service": patch
+"@learncard/lca-api-service": patch
+"@learncard/learn-cloud-service": patch
+"@learncard/simple-signing-service": patch
+---
+
+🐛 Bundle DIDKit WASM into Lambda artifacts (fix staging 500s)

--- a/services/learn-card-network/brain-service/esbuildPlugins.cjs
+++ b/services/learn-card-network/brain-service/esbuildPlugins.cjs
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const forceCjsSodiumWrapperPlugin = {
@@ -9,8 +12,34 @@ const forceCjsSodiumWrapperPlugin = {
     },
 };
 
+// The DIDKit WASM binary is marked `external`, so esbuild never bundles it. It used
+// to reach the Lambda via serverless `package.patterns` copying it out of
+// `node_modules`, but those globs are service-relative and match nothing under Bun
+// workspaces (the package is a hoisted symlink at the repo root), so the file never
+// entered the artifact and every DIDKit path 500'd with MODULE_NOT_FOUND.
+//
+// Copy the WASM into esbuild's output dir at build time (when `node_modules` still
+// resolves). serverless-esbuild packages every non-`node_modules` file from the build
+// dir into each function zip, so it ships next to the handler and is loaded relative
+// to `__dirname` at runtime (see src/helpers/learnCard.helpers.ts).
+const copyDidkitWasmPlugin = {
+    name: 'copy-didkit-wasm',
+    setup(build) {
+        build.onEnd(() => {
+            const { outdir, outfile } = build.initialOptions;
+            const outDir = outdir || (outfile && path.dirname(outfile));
+            if (!outDir) return;
+
+            const src = require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.copyFileSync(src, path.join(outDir, 'didkit_wasm_bg.wasm'));
+        });
+    },
+};
+
 module.exports = [
     forceCjsSodiumWrapperPlugin,
+    copyDidkitWasmPlugin,
     sentryEsbuildPlugin({
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: process.env.SENTRY_ORG,

--- a/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { generateLearnCard } from '@learncard/core';
 import type { LearnCard } from '@learncard/core';
@@ -20,6 +22,19 @@ import type { LearnCardPlugin } from '@learncard/learn-card-plugin';
 import { getDidWebPlugin } from '@learncard/did-web-plugin';
 import type { DidWebPlugin } from '@learncard/did-web-plugin';
 import { DynamicLoaderPlugin } from '@learncard/dynamic-loader-plugin';
+
+// The DIDKit WASM is copied next to the compiled handler at build time (see
+// esbuildPlugins.cjs). The Lambda bundle's node_modules layout doesn't match what
+// require.resolve expects (the package is a hoisted workspace symlink), so prefer the
+// co-located copy and fall back to package resolution for local dev / Docker.
+const DIDKIT_WASM_SPECIFIER = '@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm';
+
+const resolveDidkitWasmPath = (): string => {
+    const colocated = join(__dirname, 'didkit_wasm_bg.wasm');
+    if (existsSync(colocated)) return colocated;
+
+    return require.resolve(DIDKIT_WASM_SPECIFIER);
+};
 
 // Try native plugin first, fall back to WASM
 const didKitPluginPromises = new Map<boolean, Promise<DIDKitPlugin>>();
@@ -47,9 +62,7 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
         if (process.env.SKIP_DIDKIT_NAPI) {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
         }
 
@@ -60,9 +73,7 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
         } catch {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
         }
     })();

--- a/services/learn-card-network/lca-api/esbuildPlugins.cjs
+++ b/services/learn-card-network/lca-api/esbuildPlugins.cjs
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const forceCjsSodiumWrapperPlugin = {
@@ -9,8 +12,34 @@ const forceCjsSodiumWrapperPlugin = {
     },
 };
 
+// The DIDKit WASM binary is marked `external`, so esbuild never bundles it. It used
+// to reach the Lambda via serverless `package.patterns` copying it out of
+// `node_modules`, but those globs are service-relative and match nothing under Bun
+// workspaces (the package is a hoisted symlink at the repo root), so the file never
+// entered the artifact and every DIDKit path 500'd with MODULE_NOT_FOUND.
+//
+// Copy the WASM into esbuild's output dir at build time (when `node_modules` still
+// resolves). serverless-esbuild packages every non-`node_modules` file from the build
+// dir into each function zip, so it ships next to the handler and is loaded relative
+// to `__dirname` at runtime (see src/helpers/learnCard.helpers.ts).
+const copyDidkitWasmPlugin = {
+    name: 'copy-didkit-wasm',
+    setup(build) {
+        build.onEnd(() => {
+            const { outdir, outfile } = build.initialOptions;
+            const outDir = outdir || (outfile && path.dirname(outfile));
+            if (!outDir) return;
+
+            const src = require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.copyFileSync(src, path.join(outDir, 'didkit_wasm_bg.wasm'));
+        });
+    },
+};
+
 module.exports = [
     forceCjsSodiumWrapperPlugin,
+    copyDidkitWasmPlugin,
     sentryEsbuildPlugin({
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: process.env.SENTRY_ORG,

--- a/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { initLearnCard } from '@learncard/init';
 import type { EmptyLearnCard, LearnCardFromSeed, DidWebLearnCardFromSeed } from '@learncard/init';
@@ -18,6 +20,19 @@ const saCardsCache = getLRUCache<
 >();
 const didWebCardsCache = getLRUCache<DidWebLearnCardFromSeed['returnValue']>();
 const ephemeralCardsCache = getLRUCache<LearnCardFromSeed['returnValue']>();
+
+// The DIDKit WASM is copied next to the compiled handler at build time (see
+// esbuildPlugins.cjs). The Lambda bundle's node_modules layout doesn't match what
+// require.resolve expects (the package is a hoisted workspace symlink), so prefer the
+// co-located copy and fall back to package resolution for local dev / Docker.
+const DIDKIT_WASM_SPECIFIER = '@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm';
+
+const resolveDidkitWasmPath = (): string => {
+    const colocated = join(__dirname, 'didkit_wasm_bg.wasm');
+    if (existsSync(colocated)) return colocated;
+
+    return require.resolve(DIDKIT_WASM_SPECIFIER);
+};
 
 // Try native plugin first, fall back to WASM
 let didKitInitPromise: Promise<'node' | Buffer> | null = null;
@@ -39,9 +54,7 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
 
     didKitInitPromise = (async () => {
         if (process.env.SKIP_DIDKIT_NAPI) {
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return wasmBuffer;
         }
 
@@ -51,9 +64,7 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
             await getNativePlugin();
             return 'node' as const;
         } catch {
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return wasmBuffer;
         }
     })();

--- a/services/learn-card-network/learn-cloud-service/esbuildPlugins.cjs
+++ b/services/learn-card-network/learn-cloud-service/esbuildPlugins.cjs
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const forceCjsSodiumWrapperPlugin = {
@@ -9,8 +12,34 @@ const forceCjsSodiumWrapperPlugin = {
     },
 };
 
+// The DIDKit WASM binary is marked `external`, so esbuild never bundles it. It used
+// to reach the Lambda via serverless `package.patterns` copying it out of
+// `node_modules`, but those globs are service-relative and match nothing under Bun
+// workspaces (the package is a hoisted symlink at the repo root), so the file never
+// entered the artifact and every DIDKit path 500'd with MODULE_NOT_FOUND.
+//
+// Copy the WASM into esbuild's output dir at build time (when `node_modules` still
+// resolves). serverless-esbuild packages every non-`node_modules` file from the build
+// dir into each function zip, so it ships next to the handler and is loaded relative
+// to `__dirname` at runtime (see src/helpers/learnCard.helpers.ts).
+const copyDidkitWasmPlugin = {
+    name: 'copy-didkit-wasm',
+    setup(build) {
+        build.onEnd(() => {
+            const { outdir, outfile } = build.initialOptions;
+            const outDir = outdir || (outfile && path.dirname(outfile));
+            if (!outDir) return;
+
+            const src = require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.copyFileSync(src, path.join(outDir, 'didkit_wasm_bg.wasm'));
+        });
+    },
+};
+
 module.exports = [
     forceCjsSodiumWrapperPlugin,
+    copyDidkitWasmPlugin,
     sentryEsbuildPlugin({
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: process.env.SENTRY_ORG,

--- a/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { generateLearnCard } from '@learncard/core';
 import type { LearnCard } from '@learncard/core';
@@ -18,6 +20,19 @@ import type { ExpirationPlugin } from '@learncard/expiration-plugin';
 import { getLearnCardPlugin } from '@learncard/learn-card-plugin';
 import type { LearnCardPlugin } from '@learncard/learn-card-plugin';
 import { isTest } from './test.helpers';
+
+// The DIDKit WASM is copied next to the compiled handler at build time (see
+// esbuildPlugins.cjs). The Lambda bundle's node_modules layout doesn't match what
+// require.resolve expects (the package is a hoisted workspace symlink), so prefer the
+// co-located copy and fall back to package resolution for local dev / Docker.
+const DIDKIT_WASM_SPECIFIER = '@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm';
+
+const resolveDidkitWasmPath = (): string => {
+    const colocated = join(__dirname, 'didkit_wasm_bg.wasm');
+    if (existsSync(colocated)) return colocated;
+
+    return require.resolve(DIDKIT_WASM_SPECIFIER);
+};
 
 // Try native plugin first, fall back to WASM
 let didKitPluginPromise: Promise<DIDKitPlugin> | null = null;
@@ -43,9 +58,7 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
         if (process.env.SKIP_DIDKIT_NAPI) {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return await getWasmPlugin(wasmBuffer);
         }
 
@@ -56,9 +69,7 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
         } catch {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
-            const wasmBuffer = await readFile(
-                require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm')
-            );
+            const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return await getWasmPlugin(wasmBuffer);
         }
     })();

--- a/services/learn-card-network/simple-signing-service/esbuildPlugins.cjs
+++ b/services/learn-card-network/simple-signing-service/esbuildPlugins.cjs
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const forceCjsSodiumWrapperPlugin = {
@@ -9,8 +12,34 @@ const forceCjsSodiumWrapperPlugin = {
     },
 };
 
+// The DIDKit WASM binary is marked `external`, so esbuild never bundles it. It used
+// to reach the Lambda via serverless `package.patterns` copying it out of
+// `node_modules`, but those globs are service-relative and match nothing under Bun
+// workspaces (the package is a hoisted symlink at the repo root), so the file never
+// entered the artifact and every DIDKit path 500'd with MODULE_NOT_FOUND.
+//
+// Copy the WASM into esbuild's output dir at build time (when `node_modules` still
+// resolves). serverless-esbuild packages every non-`node_modules` file from the build
+// dir into each function zip, so it ships next to the handler and is loaded relative
+// to `__dirname` at runtime (see src/helpers/learnCard.helpers.ts).
+const copyDidkitWasmPlugin = {
+    name: 'copy-didkit-wasm',
+    setup(build) {
+        build.onEnd(() => {
+            const { outdir, outfile } = build.initialOptions;
+            const outDir = outdir || (outfile && path.dirname(outfile));
+            if (!outDir) return;
+
+            const src = require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.copyFileSync(src, path.join(outDir, 'didkit_wasm_bg.wasm'));
+        });
+    },
+};
+
 module.exports = [
     forceCjsSodiumWrapperPlugin,
+    copyDidkitWasmPlugin,
     sentryEsbuildPlugin({
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: process.env.SENTRY_ORG,

--- a/services/learn-card-network/simple-signing-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/simple-signing-service/src/helpers/learnCard.helpers.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { generateLearnCard, LearnCard } from '@learncard/core';
 import { DIDKitPlugin, DidMethod, getDidKitPlugin } from '@learncard/didkit-plugin';
@@ -11,7 +13,20 @@ import { DynamicLoaderPlugin } from '@learncard/dynamic-loader-plugin';
 import { getLRUCache } from '@cache/in-memory-lru';
 import { getSigningAuthorityForDid } from '@accesslayer/signing-authority/read';
 
-const didkit = readFile(require.resolve('@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm'));
+// The DIDKit WASM is copied next to the compiled handler at build time (see
+// esbuildPlugins.cjs). The Lambda bundle's node_modules layout doesn't match what
+// require.resolve expects (the package is a hoisted workspace symlink), so prefer the
+// co-located copy and fall back to package resolution for local dev / Docker.
+const DIDKIT_WASM_SPECIFIER = '@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm';
+
+const resolveDidkitWasmPath = (): string => {
+    const colocated = join(__dirname, 'didkit_wasm_bg.wasm');
+    if (existsSync(colocated)) return colocated;
+
+    return require.resolve(DIDKIT_WASM_SPECIFIER);
+};
+
+const didkit = readFile(resolveDidkitWasmPath());
 
 export type EmptyLearnCard = LearnCard<[DIDKitPlugin, ExpirationPlugin, LearnCardPlugin]>;
 
@@ -64,20 +79,20 @@ export const getLearnCard = async (
     const emptyLc = await generateLearnCard();
 
     const baseLc = allowRemoteContexts
-        ? await (await emptyLc.addPlugin(DynamicLoaderPlugin)).addPlugin(
-              await getDidKitPlugin(await didkit, allowRemoteContexts)
-          )
+        ? await (
+              await emptyLc.addPlugin(DynamicLoaderPlugin)
+          ).addPlugin(await getDidKitPlugin(await didkit, allowRemoteContexts))
         : await emptyLc.addPlugin(await getDidKitPlugin(await didkit));
 
-    const didkeyLc = await baseLc.addPlugin(
-        await getDidKeyPlugin<DidMethod>(baseLc, seed, 'key')
-    );
+    const didkeyLc = await baseLc.addPlugin(await getDidKeyPlugin<DidMethod>(baseLc, seed, 'key'));
 
     const didkeyAndVCLc = await didkeyLc.addPlugin(getVCPlugin(didkeyLc));
 
     const expirationLc = await didkeyAndVCLc.addPlugin(expirationPlugin(didkeyAndVCLc));
 
-    const learnCard = await expirationLc.addPlugin(getLearnCardPlugin(expirationLc)) as SeedLearnCard;
+    const learnCard = (await expirationLc.addPlugin(
+        getLearnCardPlugin(expirationLc)
+    )) as SeedLearnCard;
 
     learnCardsCache.add(cacheKey, learnCard);
 


### PR DESCRIPTION
## TL;DR

The staging smoketest went red because the **DIDKit WASM was missing from the deployed Lambda artifacts**. The Bun-workspaces migration (#1303) broke the service-relative serverless `package.patterns` that used to copy `didkit_wasm_bg.wasm` out of `node_modules` — the package is now a hoisted symlink at the repo root, so the glob matched nothing and the file never entered the zip. Every DIDKit code path then 500'd at runtime with `Cannot find module '…/didkit_wasm_bg.wasm'`:

- **brain-service** — partial outage (only `/.well-known/did.json`; DIDKit is lazy-loaded)
- **lca-api** — total outage (loads DIDKit un-awaited during request setup → crashes every invocation, even `/health-check`) — confirmed on staging via CloudWatch
- **learn-cloud-service / simple-signing-service** — same latent bug, not yet smoketested

This PR bundles the WASM into each function **at build time** and loads it via `__dirname`, fixing all four network services. **WASM-only** — native packaging is a tracked follow-up.

📄 **Full investigation, root-cause walkthrough, native-packaging options & CloudWatch runbook:** [Confluence — Staging Smoketest Failure (2026-07-02)](https://welibrary.atlassian.net/wiki/spaces/LC/pages/993820674)

## Root cause

After #1303, the serverless `package.patterns` copying the WASM are **service-directory-relative** globs into `node_modules/@learncard/didkit-plugin/...`, but under Bun workspaces there is no service-level `node_modules` — the package is a hoisted symlink at the repo root — so the glob matched nothing. At runtime `require.resolve(...)` threw.

## Fix

Copy the WASM into esbuild's output dir at build time (when `node_modules` still resolves) via a `copy-didkit-wasm` esbuild plugin. serverless-esbuild packages every non-`node_modules` build-dir file into each function zip, so it ships next to the handler at `/var/task/didkit_wasm_bg.wasm`. The runtime loader now prefers that co-located copy (via `__dirname`) and falls back to `require.resolve` for local dev / Docker.

Applied to **all four** network services (brain-service, lca-api, learn-cloud-service, simple-signing-service).

**WASM-only:** the native `didkit-plugin-node` path is untouched — it already fails over to WASM in Lambda for the same packaging reason. Packaging native correctly (via a Lambda Layer) is a separate follow-up (options documented in the Confluence page).

## Verification

- ✅ esbuild build copies `didkit_wasm_bg.wasm` (8.9 MB) into the output dir
- ✅ `tsc --noEmit` clean across all four services
- ✅ Confirmed in serverless-esbuild `pack.js` that non-`node_modules` build-dir files are included in every function zip (`.wasm` is not in the default exclusion list)
- ⏳ **Final packaging + runtime can only be verified by a staging deploy** — please deploy this branch to staging and confirm the smoketest goes green

## Follow-ups

- Native DIDKit via a Lambda Layer if a measured perf delta warrants it
- Add `simple-signing-service` + a signing/did path to the smoketest (currently unmonitored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Lambda deployment failures by bundling DIDKit WASM binary into function artifacts instead of relying on broken node_modules resolution in Bun workspaces.

Main changes:
- Added esbuild plugin to copy didkit_wasm_bg.wasm into build output during compilation
- Implemented resolveDidkitWasmPath() helper checking co-located WASM file before falling back to require.resolve()
- Applied fix across four services: brain-service, lca-api, learn-cloud-service, simple-signing-service

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
