### PR TITLE
💚 Put bun on PATH for the EC2 e2e runner (fix exit 127)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,11 @@ jobs:
                   script_stop: true
                   command_timeout: 50m
                   script: |
+                      # appleboy/ssh-action runs a non-interactive shell that does not source
+                      # ~/.bashrc, so bun/bunx are not on PATH and run-tests.sh dies with
+                      # `bunx: command not found` (exit 127). Add bun's default install dir.
+                      export BUN_INSTALL="$HOME/.bun"
+                      export PATH="$BUN_INSTALL/bin:$PATH"
                       cd ~/learncard-e2e-runner
                       git pull origin main
                       ./scripts/sync-repo.sh ${{ github.head_ref || github.event.inputs.branch }}


### PR DESCRIPTION
## TL;DR

The **e2e-tests** job (self-hosted EC2 runner) has been failing with `bunx: command not found` (exit 127). `appleboy/ssh-action` runs a **non-interactive shell** that doesn't source `~/.bashrc`, so `bun`/`bunx` aren't on PATH — `./scripts/run-tests.sh` dies the moment it tries to launch Playwright, *after* the whole docker-compose stack has already built and come up. Surfaced after the Bun-workspaces migration moved the runner onto bun.

**Fix:** export bun's default install dir on PATH in the SSH script before calling the runner scripts.

## Evidence

From the last release run's `e2e-tests` job:

```
err:  Container lcn-app  Started        ← full docker stack came up fine
./scripts/run-tests.sh: line 94: bunx: command not found
Process exited with status 127
```

## Notes

- **This job only runs on `changeset-release/main` and manual `workflow_dispatch`** (see its `if:`) — that's why feature-branch Test Runner runs go green: `e2e-tests` is skipped there.
- **Zero-regression:** prepending a non-existent dir to PATH is a no-op, so this can't make things worse.
- Assumes bun is at the canonical `$HOME/.bun/bin` on the EC2 box (bun's default install location). If it's installed elsewhere, adjust the path.
- The more "correct" home for this one-liner is `run-tests.sh` itself (in the external `learncard-e2e-runner` repo). This fixes it from the LearnCard side without needing access to that repo.
- **Verify** by triggering the e2e job via `workflow_dispatch` (spins up the EC2 instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix exit 127 error in EC2 e2e runner by ensuring bun/bunx CLI tools are available on PATH in SSH sessions.

Main changes:
- Added BUN_INSTALL and PATH environment variables to non-interactive SSH shell before test execution script

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

