### PR TITLE
[LC-1940] ✨ Ship native DIDKit to Lambda via a Layer (follow-up to #1341)

### DIFF
--- a/.changeset/shy-spies-strive.md
+++ b/.changeset/shy-spies-strive.md
@@ -1,0 +1,7 @@
+---
+"@learncard/network-brain-service": patch
+"@learncard/lca-api-service": patch
+"@learncard/learn-cloud-service": patch
+---
+
+✨ Ship native DIDKit to Lambda via a Layer (follow-up to #1341)

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ internal-docs/*
 .worktrees/
 CLAUDE.local.md
 
+# Assembled at deploy time by scripts/prepare-didkit-native-layer.cjs
+services/learn-card-network/*/didkit-native-layer/
+
 # Local Netlify folder
 .netlify
 # Local environment configuration

--- a/scripts/prepare-didkit-native-layer.cjs
+++ b/scripts/prepare-didkit-native-layer.cjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Assembles a Lambda Layer directory containing @learncard/didkit-plugin-node so the
+ * native DIDKit addon is resolvable in Lambda.
+ *
+ * Why a layer: the native wrapper locates its binary via
+ * `require.resolve('@learncard/didkit-plugin-node/package.json')` + readdir, so the
+ * package must exist as a real, resolvable package on the module path — it cannot be
+ * bundled by esbuild or dropped next to the handler (unlike the WASM). Lambda mounts
+ * layers at /opt and puts /opt/nodejs/node_modules on NODE_PATH, which satisfies that.
+ *
+ * Run from a service directory before `serverless deploy` (see the service's
+ * `serverless-deploy` npm script). Output: <service>/didkit-native-layer/nodejs/
+ * node_modules/@learncard/didkit-plugin-node/ — referenced by the `layers:` block in
+ * the service's serverless.yml.
+ *
+ * The compiled dist/ only requires its own relative files + node builtins (the
+ * @learncard/* imports are type-only), so the layer needs just this one package.
+ * In CI, the "Build Native DIDKit Plugin" job's artifact (dist/ + index.linux-x64-gnu.node)
+ * is downloaded into the package root before deploy. Locally the .node binary is
+ * usually absent — the layer then ships without it and the runtime falls back to WASM,
+ * same as before this change.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const serviceDir = process.cwd();
+const layerRoot = path.join(serviceDir, 'didkit-native-layer');
+const layerPkgDir = path.join(layerRoot, 'nodejs', 'node_modules', '@learncard', 'didkit-plugin-node');
+
+const packageRoot = path.dirname(
+    require.resolve('@learncard/didkit-plugin-node/package.json', { paths: [serviceDir] })
+);
+
+fs.rmSync(layerRoot, { recursive: true, force: true });
+fs.mkdirSync(layerPkgDir, { recursive: true });
+
+fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(layerPkgDir, 'package.json'));
+
+const distDir = path.join(packageRoot, 'dist');
+if (!fs.existsSync(distDir)) {
+    console.error(
+        `[didkit-layer] ERROR: ${distDir} does not exist — build @learncard/didkit-plugin-node first (nx ^build should have done this).`
+    );
+    process.exit(1);
+}
+fs.cpSync(distDir, path.join(layerPkgDir, 'dist'), { recursive: true });
+
+// napi-rs binaries look like index.linux-x64-gnu.node; the wrapper discovers them by
+// readdir of the package root.
+const nodeBinaries = fs
+    .readdirSync(packageRoot)
+    .filter(f => f.startsWith('index.') && f.endsWith('.node'));
+
+for (const binary of nodeBinaries) {
+    fs.copyFileSync(path.join(packageRoot, binary), path.join(layerPkgDir, binary));
+}
+
+if (nodeBinaries.length === 0) {
+    console.warn(
+        '[didkit-layer] WARNING: no index.*.node binary in package root — layer will ship without the native addon and the runtime will fall back to WASM. (Expected locally; in CI the didkit-native-linux-x64 artifact provides it.)'
+    );
+} else {
+    console.log(`[didkit-layer] packaged native binaries: ${nodeBinaries.join(', ')}`);
+}
+console.log(`[didkit-layer] layer assembled at ${layerRoot}`);

--- a/services/learn-card-network/brain-service/package.json
+++ b/services/learn-card-network/brain-service/package.json
@@ -15,7 +15,7 @@
         "start-p-4000": "PORT=4000 serverless offline --httpPort 4000 --websocketPort 4001 --lambdaPort 4002 --albPort 4003 --host 127.0.0.1 --config serverless-local.yml",
         "dev": "bun --conditions=development --watch src/docker-entry.ts",
         "start:docker": "bun --conditions=development src/docker-entry.ts",
-        "serverless-deploy": "serverless deploy --verbose"
+        "serverless-deploy": "node ../../../scripts/prepare-didkit-native-layer.cjs && serverless deploy --verbose"
     },
     "keywords": [],
     "author": "Learning Economy Foundation (www.learningeconomy.io)",

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -34,6 +34,12 @@ custom:
         bundle: true
         minify: true
         external: ['@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm', '*.node', 'p-limit']
+        # didkit-plugin-node ships via the didkitNative Lambda Layer. `exclude` both
+        # marks it esbuild-external AND stops the packager from installing a
+        # binary-less registry copy into the artifact (which would shadow the layer,
+        # since /var/task/node_modules wins over NODE_PATH). 'aws-sdk' is the
+        # serverless-esbuild default and must be preserved when overriding.
+        exclude: ['aws-sdk', '@learncard/didkit-plugin-node']
         sourcemap: external
         target: 'node20'
         watch:
@@ -92,9 +98,26 @@ package:
         - 'node_modules/@learncard/didkit-plugin-node/package.json'
         - 'node_modules/@learncard/didkit-plugin-node/dist/**'
 
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
+# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
+# resolves in Lambda instead of silently falling back to WASM. Assembled by
+# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+layers:
+    didkitNative:
+        path: didkit-native-layer
+        name: ${self:service}-${opt:stage, 'dev'}-didkit-native
+        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        compatibleRuntimes:
+            - nodejs20.x
+        compatibleArchitectures:
+            - x86_64
+
 provider:
     name: aws
     runtime: nodejs20.x
+    # Attach the native DIDKit layer to every function in this service.
+    layers:
+        - { Ref: DidkitNativeLambdaLayer }
     memorySize: 2048
     timeout: 29
     stage: ${opt:stage, "dev"}

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -91,12 +91,14 @@ custom:
 
 package:
     individually: true
+    # DIDKit assets no longer ship via node_modules copy-patterns: those globs were
+    # service-relative and match nothing under Bun workspaces (root cause of the
+    # 2026-07-02 staging incident, PR #1341) — and if a service-level node_modules
+    # ever reappeared, force-including didkit-plugin-node here would shadow the
+    # didkitNative Lambda Layer (/var/task/node_modules wins over NODE_PATH). The
+    # WASM ships inside the bundle (esbuildPlugins.cjs); native ships via the Layer.
     patterns:
         - '!node_modules/**'
-        - 'node_modules/@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm'
-        - 'node_modules/@learncard/didkit-plugin-node/*.node'
-        - 'node_modules/@learncard/didkit-plugin-node/package.json'
-        - 'node_modules/@learncard/didkit-plugin-node/dist/**'
 
 # Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
 # /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts

--- a/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
@@ -70,7 +70,10 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
             return await getNativePlugin(undefined, allowRemoteContexts);
-        } catch {
+        } catch (error) {
+            // Surface the fallback — a silent catch here hid a months-long "native never
+            // actually loads in Lambda" gap (see PR #1341 investigation).
+            console.warn('[didkit] native plugin unavailable, falling back to WASM:', error);
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());

--- a/services/learn-card-network/lca-api/package.json
+++ b/services/learn-card-network/lca-api/package.json
@@ -13,7 +13,7 @@
         "start-p-5000": "PORT=5000 serverless offline --httpPort 5000 --websocketPort 5001 --lambdaPort 5002 --albPort 5003 --config serverless-local.yml",
         "dev": "bun --conditions=development --watch src/docker-entry.ts",
         "start:docker": "bun --conditions=development src/docker-entry.ts",
-        "serverless-deploy": "serverless deploy",
+        "serverless-deploy": "node ../../../scripts/prepare-didkit-native-layer.cjs && serverless deploy",
         "serverless-deploy-scouts": "serverless deploy --config serverless-scouts.yml"
     },
     "keywords": [],

--- a/services/learn-card-network/lca-api/serverless.yml
+++ b/services/learn-card-network/lca-api/serverless.yml
@@ -38,6 +38,12 @@ custom:
                 '@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm',
                 '@learncard/didkit-plugin-node/*.node',
             ]
+        # didkit-plugin-node ships via the didkitNative Lambda Layer. `exclude` both
+        # marks it esbuild-external AND stops the packager from installing a
+        # binary-less registry copy into the artifact (which would shadow the layer,
+        # since /var/task/node_modules wins over NODE_PATH). 'aws-sdk' is the
+        # serverless-esbuild default and must be preserved when overriding.
+        exclude: ['aws-sdk', '@learncard/didkit-plugin-node']
         sourcemap: external
         target: 'node20'
         watch:
@@ -97,9 +103,26 @@ package:
         - 'node_modules/@learncard/didkit-plugin-node/dist/**'
         - 'src/swagger-ui'
 
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
+# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
+# resolves in Lambda instead of silently falling back to WASM. Assembled by
+# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+layers:
+    didkitNative:
+        path: didkit-native-layer
+        name: ${self:service}-${opt:stage, 'dev'}-didkit-native
+        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        compatibleRuntimes:
+            - nodejs20.x
+        compatibleArchitectures:
+            - x86_64
+
 provider:
     name: aws
     runtime: nodejs20.x
+    # Attach the native DIDKit layer to every function in this service.
+    layers:
+        - { Ref: DidkitNativeLambdaLayer }
     memorySize: 2048
     timeout: 29
     stage: ${opt:stage, "dev"}

--- a/services/learn-card-network/lca-api/serverless.yml
+++ b/services/learn-card-network/lca-api/serverless.yml
@@ -95,12 +95,14 @@ custom:
 
 package:
     individually: true
+    # DIDKit assets no longer ship via node_modules copy-patterns: those globs were
+    # service-relative and match nothing under Bun workspaces (root cause of the
+    # 2026-07-02 staging incident, PR #1341) — and if a service-level node_modules
+    # ever reappeared, force-including didkit-plugin-node here would shadow the
+    # didkitNative Lambda Layer (/var/task/node_modules wins over NODE_PATH). The
+    # WASM ships inside the bundle (esbuildPlugins.cjs); native ships via the Layer.
     patterns:
         - '!node_modules/**'
-        - 'node_modules/@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm'
-        - 'node_modules/@learncard/didkit-plugin-node/*.node'
-        - 'node_modules/@learncard/didkit-plugin-node/package.json'
-        - 'node_modules/@learncard/didkit-plugin-node/dist/**'
         - 'src/swagger-ui'
 
 # Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at

--- a/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
@@ -63,7 +63,10 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
             await getNativePlugin();
             return 'node' as const;
-        } catch {
+        } catch (error) {
+            // Surface the fallback — a silent catch here hid a months-long "native never
+            // actually loads in Lambda" gap (see PR #1341 investigation).
+            console.warn('[didkit] native plugin unavailable, falling back to WASM:', error);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
             return wasmBuffer;
         }

--- a/services/learn-card-network/learn-cloud-service/package.json
+++ b/services/learn-card-network/learn-cloud-service/package.json
@@ -13,7 +13,7 @@
         "start-p-5000": "PORT=5000 serverless offline --httpPort 5000 --websocketPort 5001 --lambdaPort 5002 --albPort 5003 --config serverless-local.yml",
         "dev": "bun --conditions=development --watch src/docker-entry.ts",
         "start:docker": "bun --conditions=development src/docker-entry.ts",
-        "serverless-deploy": "serverless deploy"
+        "serverless-deploy": "node ../../../scripts/prepare-didkit-native-layer.cjs && serverless deploy"
     },
     "keywords": [],
     "author": "Learning Economy Foundation (www.learningeconomy.io)",

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -26,6 +26,12 @@ custom:
         bundle: true
         # minify: true
         external: ['@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm', '*.node']
+        # didkit-plugin-node ships via the didkitNative Lambda Layer. `exclude` both
+        # marks it esbuild-external AND stops the packager from installing a
+        # binary-less registry copy into the artifact (which would shadow the layer,
+        # since /var/task/node_modules wins over NODE_PATH). 'aws-sdk' is the
+        # serverless-esbuild default and must be preserved when overriding.
+        exclude: ['aws-sdk', '@learncard/didkit-plugin-node']
         sourcemap: external
         target: 'node16'
         watch:
@@ -85,9 +91,26 @@ package:
         - 'node_modules/@learncard/didkit-plugin-node/package.json'
         - 'node_modules/@learncard/didkit-plugin-node/dist/**'
 
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
+# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
+# resolves in Lambda instead of silently falling back to WASM. Assembled by
+# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+layers:
+    didkitNative:
+        path: didkit-native-layer
+        name: ${self:service}-${opt:stage, 'dev'}-didkit-native
+        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        compatibleRuntimes:
+            - nodejs20.x
+        compatibleArchitectures:
+            - x86_64
+
 provider:
     name: aws
     runtime: nodejs20.x
+    # Attach the native DIDKit layer to every function in this service.
+    layers:
+        - { Ref: DidkitNativeLambdaLayer }
     memorySize: 4096
     timeout: 29
     stage: ${opt:stage, "dev"}

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -84,12 +84,14 @@ custom:
 
 package:
     individually: true
+    # DIDKit assets no longer ship via node_modules copy-patterns: those globs were
+    # service-relative and match nothing under Bun workspaces (root cause of the
+    # 2026-07-02 staging incident, PR #1341) — and if a service-level node_modules
+    # ever reappeared, force-including didkit-plugin-node here would shadow the
+    # didkitNative Lambda Layer (/var/task/node_modules wins over NODE_PATH). The
+    # WASM ships inside the bundle (esbuildPlugins.cjs); native ships via the Layer.
     patterns:
         - '!node_modules/**'
-        - 'node_modules/@learncard/didkit-plugin/dist/didkit_wasm_bg.wasm'
-        - 'node_modules/@learncard/didkit-plugin-node/*.node'
-        - 'node_modules/@learncard/didkit-plugin-node/package.json'
-        - 'node_modules/@learncard/didkit-plugin-node/dist/**'
 
 # Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
 # /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts

--- a/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
@@ -66,7 +66,10 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
             return await getNativePlugin();
-        } catch {
+        } catch (error) {
+            // Surface the fallback — a silent catch here hid a months-long "native never
+            // actually loads in Lambda" gap (see PR #1341 investigation).
+            console.warn('[didkit] native plugin unavailable, falling back to WASM:', error);
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());


### PR DESCRIPTION
## TL;DR

**Follow-up to #1341** (stacked on that branch — merge #1341 first; GitHub will retarget this to `main` automatically). #1341 made the WASM fallback resolvable; this PR makes the **native-first path actually succeed in Lambda**, restoring the pre-Bun-migration behavior where the fast napi addon serves DIDKit ops instead of silently falling back to WASM on every cold start.

📄 Context: [Confluence — Staging Smoketest Failure investigation](https://welibrary.atlassian.net/wiki/spaces/LC/pages/993820674) (see "packaging native DIDKit correctly").

## Why a Layer

The native wrapper locates its binary at runtime via:

```js
const packageJson = require.resolve('@learncard/didkit-plugin-node/package.json');
const nodeFile = fs.readdirSync(path.dirname(packageJson)).find(f => f.startsWith('index.') && f.endsWith('.node'));
```

So the package must exist as a **real, resolvable package on the module path** — it can't be bundled by esbuild or dropped next to the handler (unlike the WASM). Lambda mounts layers at `/opt` and puts `/opt/nodejs/node_modules` on `NODE_PATH`, which satisfies this exactly. And the layer is small in scope: the compiled `dist/` has **zero runtime deps beyond node builtins** (`@learncard/*` imports are type-only), so the layer contains just this one package (~19.6 MB unzipped, ~7.7 MB zipped, well under limits).

## What's in the PR

| Piece | What it does |
|---|---|
| `scripts/prepare-didkit-native-layer.cjs` | Assembles `<service>/didkit-native-layer/nodejs/node_modules/@learncard/didkit-plugin-node/` (package.json + dist + `index.*.node`) from the package root. In CI the existing **didkit-native-linux-x64 artifact** already provides dist + binary there — zero new CI plumbing. Locally the binary is absent → warns → runtime falls back to WASM as today. |
| `serverless.yml` ×3 (brain, lca, learn-cloud) | Defines the `didkitNative` layer, attaches via `provider.layers` (all functions), and adds the package to `custom.esbuild.exclude` — which in serverless-esbuild both marks it esbuild-external **and** stops the packager from installing a binary-less registry copy that would shadow the layer (`/var/task/node_modules` wins over `NODE_PATH`). `aws-sdk` kept in exclude (it's the default being overridden). |
| `serverless-deploy` npm scripts ×3 | Run the prep script before `serverless deploy` (nx-appended `--stage/--region` args still land on the deploy command). |
| `learnCard.helpers.ts` ×3 | `console.warn` when falling back to WASM — the **silent catch** is what hid "native never loads in Lambda" for months. Post-deploy, absence of this warning in CloudWatch = native confirmed live. |

**Untouched on purpose:** simple-signing-service (never uses the native plugin — it's WASM-only by design) and the scouts lca config (`serverless-scouts.yml`, keeps today's WASM-fallback behavior).

## Verification done locally

- ✅ Layer assembly tested **both ways**: without a binary (warn + WASM-fallback path) and with the real CI artifact binary dropped in
- ✅ Full resolution chain simulated from a neutral cwd with `NODE_PATH=<layer>` (mimics `/var/task` + `/opt`): `require.resolve` of package.json → readdir finds `index.linux-x64-gnu.node` → main entry resolves to `dist/index.js`
- ✅ YAML parses ×3, `tsc --noEmit` clean ×3
- ⏳ The final step — dlopen of the linux binary — is **deploy-only**. Verify on staging via CloudWatch: DIDKit-touching requests should show **no** `[didkit] native plugin unavailable` warning.

## Notes / risks for review

1. **Safe-by-construction fallback:** if the layer fails to attach or the binary won't load, the existing try/catch falls back to WASM (which #1341 fixed) — worst case is today's behavior, now with a log line.
2. **`provider.layers` + serverless-lift:** brain's notifications-queue worker is created by lift; if it doesn't inherit provider layers, that one function just stays on WASM fallback. Graceful.
3. **Behavior note:** the native wrapper *ignores* `allowRemoteContexts` (`_allowRemoteContexts` param unused) — this matches pre-migration prod behavior (native was live then), but flagging for awareness on remote-context verification flows.
4. **Perf claim to verify post-deploy:** compare CloudWatch Duration on signing/did routes before/after — this PR is only worth its infra if that delta is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Deploy native DIDKit binary to Lambda via layers instead of bundling, fixing silent fallback to WASM and Bun workspace module resolution issues.

Main changes:
- Added error logging to DIDKit initialization in three services, exposing fallback behavior that was previously silent
- Created `prepare-didkit-native-layer.cjs` script to assemble Lambda Layer with native plugin binaries and dist files
- Updated serverless configs to exclude didkit-plugin-node from bundles, attach native layer to all functions, and removed broken node_modules copy patterns

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
