### PR TITLE
🚑 [LC-1940] Layer must also ship @learncard/didkit-plugin (fix staging auth 500s)

### DIFF
--- a/.changeset/tall-peas-prove.md
+++ b/.changeset/tall-peas-prove.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+🚑 [LC-1940] Layer must also ship @learncard/didkit-plugin (fix staging auth 500s)

--- a/scripts/prepare-didkit-native-layer.cjs
+++ b/scripts/prepare-didkit-native-layer.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Assembles a Lambda Layer directory containing @learncard/didkit-plugin-node so the
- * native DIDKit addon is resolvable in Lambda.
+ * Assembles a Lambda Layer directory containing the DIDKit packages so the native
+ * addon path works in Lambda.
  *
  * Why a layer: the native wrapper locates its binary via
  * `require.resolve('@learncard/didkit-plugin-node/package.json')` + readdir, so the
@@ -9,58 +9,95 @@
  * bundled by esbuild or dropped next to the handler (unlike the WASM). Lambda mounts
  * layers at /opt and puts /opt/nodejs/node_modules on NODE_PATH, which satisfies that.
  *
+ * Why BOTH packages: didkit-plugin-node's dist lazily requires
+ * `@learncard/didkit-plugin` at runtime (issuePresentation/verifyPresentation delegate
+ * getDocumentMap to it — see dist/plugin.js). With only the native package in the
+ * layer, that require fails and every VP-verifying route (auth context creation!)
+ * 500s: "Cannot find module '@learncard/didkit-plugin'" (staging incident follow-up,
+ * 2026-07-02). Node's parent-dir walk from the layer package reaches
+ * /opt/nodejs/node_modules, so a sibling copy resolves it. Both packages' dist
+ * bundles are self-contained (relative requires + node builtins only — verified
+ * against single- AND double-quoted requires across .js and .cjs).
+ *
  * Run from a service directory before `serverless deploy` (see the service's
  * `serverless-deploy` npm script). Output: <service>/didkit-native-layer/nodejs/
- * node_modules/@learncard/didkit-plugin-node/ — referenced by the `layers:` block in
- * the service's serverless.yml.
+ * node_modules/@learncard/… — referenced by the `layers:` block in the service's
+ * serverless.yml.
  *
- * The compiled dist/ only requires its own relative files + node builtins (the
- * @learncard/* imports are type-only), so the layer needs just this one package.
- * In CI, the "Build Native DIDKit Plugin" job's artifact (dist/ + index.linux-x64-gnu.node)
- * is downloaded into the package root before deploy. Locally the .node binary is
- * usually absent — the layer then ships without it and the runtime falls back to WASM,
- * same as before this change.
+ * In CI, the "Build Native DIDKit Plugin" job's artifact (dist/ +
+ * index.linux-x64-gnu.node) is downloaded into the didkit-plugin-node package root
+ * before deploy. Locally the .node binary is usually absent — the layer then ships
+ * without it and the runtime falls back to WASM, same as before this change.
  */
 const fs = require('node:fs');
 const path = require('node:path');
 
 const serviceDir = process.cwd();
 const layerRoot = path.join(serviceDir, 'didkit-native-layer');
-const layerPkgDir = path.join(layerRoot, 'nodejs', 'node_modules', '@learncard', 'didkit-plugin-node');
+const layerModules = path.join(layerRoot, 'nodejs', 'node_modules');
 
-const packageRoot = path.dirname(
-    require.resolve('@learncard/didkit-plugin-node/package.json', { paths: [serviceDir] })
-);
+// Locate a package's on-disk root. `require.resolve('<name>/package.json')` is the
+// obvious way, but a package whose `exports` map doesn't expose "./package.json"
+// (e.g. @learncard/didkit-plugin) throws ERR_PACKAGE_PATH_NOT_EXPORTED — so fall back
+// to resolving the entry point and walking up to the nearest package.json.
+const resolvePackageRoot = name => {
+    try {
+        return path.dirname(require.resolve(`${name}/package.json`, { paths: [serviceDir] }));
+    } catch {
+        let dir = path.dirname(require.resolve(name, { paths: [serviceDir] }));
+        while (!fs.existsSync(path.join(dir, 'package.json'))) {
+            const parent = path.dirname(dir);
+            if (parent === dir) throw new Error(`Cannot locate package root for ${name}`);
+            dir = parent;
+        }
+        return dir;
+    }
+};
+
+// name → whether to also copy napi binaries (index.*.node) from the package root
+const LAYER_PACKAGES = [
+    { name: '@learncard/didkit-plugin-node', nodeBinaries: true },
+    { name: '@learncard/didkit-plugin', nodeBinaries: false },
+];
 
 fs.rmSync(layerRoot, { recursive: true, force: true });
-fs.mkdirSync(layerPkgDir, { recursive: true });
 
-fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(layerPkgDir, 'package.json'));
+for (const { name, nodeBinaries } of LAYER_PACKAGES) {
+    const packageRoot = resolvePackageRoot(name);
+    const dest = path.join(layerModules, ...name.split('/'));
+    fs.mkdirSync(dest, { recursive: true });
 
-const distDir = path.join(packageRoot, 'dist');
-if (!fs.existsSync(distDir)) {
-    console.error(
-        `[didkit-layer] ERROR: ${distDir} does not exist — build @learncard/didkit-plugin-node first (nx ^build should have done this).`
-    );
-    process.exit(1);
+    fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(dest, 'package.json'));
+
+    const distDir = path.join(packageRoot, 'dist');
+    if (!fs.existsSync(distDir)) {
+        console.error(
+            `[didkit-layer] ERROR: ${distDir} does not exist — build ${name} first (nx ^build should have done this).`
+        );
+        process.exit(1);
+    }
+    fs.cpSync(distDir, path.join(dest, 'dist'), { recursive: true });
+
+    if (nodeBinaries) {
+        // napi-rs binaries look like index.linux-x64-gnu.node; the wrapper discovers
+        // them by readdir of the package root.
+        const binaries = fs
+            .readdirSync(packageRoot)
+            .filter(f => f.startsWith('index.') && f.endsWith('.node'));
+
+        for (const binary of binaries) {
+            fs.copyFileSync(path.join(packageRoot, binary), path.join(dest, binary));
+        }
+
+        if (binaries.length === 0) {
+            console.warn(
+                `[didkit-layer] WARNING: no index.*.node binary in ${name} — layer will ship without the native addon and the runtime will fall back to WASM. (Expected locally; in CI the didkit-native-linux-x64 artifact provides it.)`
+            );
+        } else {
+            console.log(`[didkit-layer] ${name}: packaged native binaries: ${binaries.join(', ')}`);
+        }
+    }
+    console.log(`[didkit-layer] ${name}: packaged (dist + package.json)`);
 }
-fs.cpSync(distDir, path.join(layerPkgDir, 'dist'), { recursive: true });
 
-// napi-rs binaries look like index.linux-x64-gnu.node; the wrapper discovers them by
-// readdir of the package root.
-const nodeBinaries = fs
-    .readdirSync(packageRoot)
-    .filter(f => f.startsWith('index.') && f.endsWith('.node'));
-
-for (const binary of nodeBinaries) {
-    fs.copyFileSync(path.join(packageRoot, binary), path.join(layerPkgDir, binary));
-}
-
-if (nodeBinaries.length === 0) {
-    console.warn(
-        '[didkit-layer] WARNING: no index.*.node binary in package root — layer will ship without the native addon and the runtime will fall back to WASM. (Expected locally; in CI the didkit-native-linux-x64 artifact provides it.)'
-    );
-} else {
-    console.log(`[didkit-layer] packaged native binaries: ${nodeBinaries.join(', ')}`);
-}
 console.log(`[didkit-layer] layer assembled at ${layerRoot}`);


### PR DESCRIPTION
## 🚨 Urgent — staging authenticated routes are 500ing

Follow-up to #1343. The native `didkit-plugin-node` dist **lazily requires `@learncard/didkit-plugin` at runtime** — `issuePresentation`/`verifyPresentation` delegate `getDocumentMap` to it (`dist/plugin.js:154`). With only the native package in the layer, that require fails and **every VP-verifying route 500s — including tRPC context creation, i.e. all authenticated traffic**:

```
Cannot find module '@learncard/didkit-plugin'
Require stack: /opt/nodejs/node_modules/@learncard/didkit-plugin-node/dist/plugin.js
    at async Object.verifyPresentation (.../plugin.js:154)
    path: "utilities.getChallenges"
```

## Why my audit missed it (mea culpa)

The "dist has zero runtime deps" check greped **double-quoted requires only**; `plugin.js` uses single quotes. Re-audited both packages across `.js`/`.cjs` with both quote styles: `@learncard/didkit-plugin`'s dist is fully **self-contained** (relative requires only), so the layer needs exactly **one more package** (~19MB unzipped, total ~40MB — fine).

## Why the smoketest stayed green

It only probes unauthenticated routes (health / docs / did.json / unknown-procedure 404) — VP-verifying context creation never runs. **Follow-up: add an authenticated probe (challenges round-trip) to the smoketest** so auth-path regressions can't hide again.

## Fix

- `prepare-didkit-native-layer.cjs` now ships **both** packages into the layer (`didkit-plugin-node` + `didkit-plugin`). Node's parent-dir walk from the layer package reaches `/opt/nodejs/node_modules`, so the sibling resolves.
- Also fixes package-root resolution: didkit-plugin's `exports` map doesn't expose `./package.json` → `require.resolve('<name>/package.json')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`; fall back to resolving the entry and walking up.
- No serverless.yml changes — same layer, fatter zip.

## Verification

- ✅ Replicated the **exact** failing require with `module.createRequire` from the layer's `plugin.js` path: resolves inside the layer, `getDocumentMap` loads (`NODE_ENV=production`).
- ⏳ Post-merge: deploy → hit an authenticated route → confirm no `Cannot find module` + no `[didkit]` fallback warns in CloudWatch.

**Fallback safety note:** if anything else surfaces, detaching `provider.layers` from the three serverless.ymls reverts to the known-good wasm-only state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix staging authentication 500s by including both DIDKit packages in Lambda Layer to resolve lazy runtime dependencies.

Main changes:
- Refactored script to package both @learncard/didkit-plugin-node and @learncard/didkit-plugin with loop-based iteration
- Added resolvePackageRoot utility handling packages with restricted exports maps via fallback entry point resolution
- Enhanced documentation explaining runtime module resolution and WASM fallback behavior for missing native binaries

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

