### PR TITLE
Fix DIDKit Lambda layer dependency and health checks

### DIFF
--- a/.changeset/deep-health-didkit.md
+++ b/.changeset/deep-health-didkit.md
@@ -1,0 +1,7 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/lca-api-service': patch
+'@learncard/learn-cloud-service': patch
+---
+
+Add /health-check/deep: issues and verifies a test credential + presentation in-process, proving the full DIDKit crypto path (plugin load, signing, and the native plugin runtime delegation) works, and reports which DIDKit engine (native/wasm) loaded. Shallow health checks stayed green through two DIDKit outages on 2026-07-02; this endpoint makes those failure modes observable from a plain HTTP probe.

--- a/.changeset/shy-spies-strive.md
+++ b/.changeset/shy-spies-strive.md
@@ -4,4 +4,4 @@
 "@learncard/learn-cloud-service": patch
 ---
 
-✨ Ship native DIDKit to Lambda via a Layer (follow-up to #1341)
+✨ Ship native DIDKit to Lambda via a Layer, include its runtime DIDKit dependency, and surface DID auth VPs in service health checks.

--- a/scripts/prepare-didkit-native-layer.cjs
+++ b/scripts/prepare-didkit-native-layer.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Assembles a Lambda Layer directory containing @learncard/didkit-plugin-node so the
- * native DIDKit addon is resolvable in Lambda.
+ * Assembles a Lambda Layer directory containing the native DIDKit addon and the
+ * runtime package it requires.
  *
  * Why a layer: the native wrapper locates its binary via
  * `require.resolve('@learncard/didkit-plugin-node/package.json')` + readdir, so the
@@ -9,15 +9,18 @@
  * bundled by esbuild or dropped next to the handler (unlike the WASM). Lambda mounts
  * layers at /opt and puts /opt/nodejs/node_modules on NODE_PATH, which satisfies that.
  *
- * Run from a service directory before `serverless deploy` (see the service's
- * `serverless-deploy` npm script). Output: <service>/didkit-native-layer/nodejs/
- * node_modules/@learncard/didkit-plugin-node/ — referenced by the `layers:` block in
- * the service's serverless.yml.
+ * The native wrapper also imports `@learncard/didkit-plugin` at runtime for
+ * `getDocumentMap()` when issuing/verifying credentials and presentations, so that
+ * package must live beside it in the same layer. A package bundled into /var/task does
+ * not satisfy a require() originating from /opt.
  *
- * The compiled dist/ only requires its own relative files + node builtins (the
- * @learncard/* imports are type-only), so the layer needs just this one package.
+ * Run from a service directory before `serverless deploy` (see the service's
+ * `serverless-deploy` npm script). Output:
+ * <service>/didkit-native-layer/nodejs/node_modules/@learncard/{didkit-plugin-node,didkit-plugin}/
+ * — referenced by the `layers:` block in the service's serverless.yml.
+ *
  * In CI, the "Build Native DIDKit Plugin" job's artifact (dist/ + index.linux-x64-gnu.node)
- * is downloaded into the package root before deploy. Locally the .node binary is
+ * is downloaded into the native package root before deploy. Locally the .node binary is
  * usually absent — the layer then ships without it and the runtime falls back to WASM,
  * same as before this change.
  */
@@ -26,34 +29,60 @@ const path = require('node:path');
 
 const serviceDir = process.cwd();
 const layerRoot = path.join(serviceDir, 'didkit-native-layer');
-const layerPkgDir = path.join(layerRoot, 'nodejs', 'node_modules', '@learncard', 'didkit-plugin-node');
+const layerNodeModulesDir = path.join(layerRoot, 'nodejs', 'node_modules');
 
-const packageRoot = path.dirname(
-    require.resolve('@learncard/didkit-plugin-node/package.json', { paths: [serviceDir] })
-);
+const resolvePackageRoot = packageName => {
+    let dir = path.dirname(require.resolve(packageName, { paths: [serviceDir] }));
+
+    while (dir !== path.dirname(dir)) {
+        const packageJsonPath = path.join(dir, 'package.json');
+
+        if (fs.existsSync(packageJsonPath)) {
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+            if (packageJson.name === packageName) return dir;
+        }
+
+        dir = path.dirname(dir);
+    }
+
+    throw new Error(`[didkit-layer] Could not locate package root for ${packageName}`);
+};
+
+const copyPackageDist = packageName => {
+    const packageRoot = resolvePackageRoot(packageName);
+    const layerPkgDir = path.join(layerNodeModulesDir, ...packageName.split('/'));
+
+    fs.mkdirSync(layerPkgDir, { recursive: true });
+    fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(layerPkgDir, 'package.json'));
+
+    const distDir = path.join(packageRoot, 'dist');
+    if (!fs.existsSync(distDir)) {
+        console.error(
+            `[didkit-layer] ERROR: ${distDir} does not exist — build ${packageName} first (nx ^build should have done this).`
+        );
+        process.exit(1);
+    }
+
+    fs.cpSync(distDir, path.join(layerPkgDir, 'dist'), { recursive: true });
+
+    return { packageRoot, layerPkgDir };
+};
 
 fs.rmSync(layerRoot, { recursive: true, force: true });
-fs.mkdirSync(layerPkgDir, { recursive: true });
 
-fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(layerPkgDir, 'package.json'));
-
-const distDir = path.join(packageRoot, 'dist');
-if (!fs.existsSync(distDir)) {
-    console.error(
-        `[didkit-layer] ERROR: ${distDir} does not exist — build @learncard/didkit-plugin-node first (nx ^build should have done this).`
-    );
-    process.exit(1);
-}
-fs.cpSync(distDir, path.join(layerPkgDir, 'dist'), { recursive: true });
+const { packageRoot: nativePackageRoot, layerPkgDir: nativeLayerPkgDir } = copyPackageDist(
+    '@learncard/didkit-plugin-node'
+);
+copyPackageDist('@learncard/didkit-plugin');
 
 // napi-rs binaries look like index.linux-x64-gnu.node; the wrapper discovers them by
 // readdir of the package root.
 const nodeBinaries = fs
-    .readdirSync(packageRoot)
+    .readdirSync(nativePackageRoot)
     .filter(f => f.startsWith('index.') && f.endsWith('.node'));
 
 for (const binary of nodeBinaries) {
-    fs.copyFileSync(path.join(packageRoot, binary), path.join(layerPkgDir, binary));
+    fs.copyFileSync(path.join(nativePackageRoot, binary), path.join(nativeLayerPkgDir, binary));
 }
 
 if (nodeBinaries.length === 0) {
@@ -63,4 +92,6 @@ if (nodeBinaries.length === 0) {
 } else {
     console.log(`[didkit-layer] packaged native binaries: ${nodeBinaries.join(', ')}`);
 }
+
+console.log('[didkit-layer] packaged runtime dependency: @learncard/didkit-plugin');
 console.log(`[didkit-layer] layer assembled at ${layerRoot}`);

--- a/services/learn-card-network/brain-service/serverless.yml
+++ b/services/learn-card-network/brain-service/serverless.yml
@@ -100,15 +100,15 @@ package:
     patterns:
         - '!node_modules/**'
 
-# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
-# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
-# resolves in Lambda instead of silently falling back to WASM. Assembled by
-# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) and
+# its runtime @learncard/didkit-plugin dependency at /opt/nodejs/node_modules so
+# the native-first DIDKit path in learnCard.helpers.ts resolves in Lambda instead
+# of silently falling back to WASM. Assembled by scripts/prepare-didkit-native-layer.cjs.
 layers:
     didkitNative:
         path: didkit-native-layer
         name: ${self:service}-${opt:stage, 'dev'}-didkit-native
-        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        description: Native DIDKit napi addon and runtime DIDKit dependency
         compatibleRuntimes:
             - nodejs20.x
         compatibleArchitectures:

--- a/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
@@ -36,6 +36,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 const didKitPluginPromises = new Map<boolean, Promise<DIDKitPlugin>>();
 
@@ -63,13 +68,17 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            const plugin = await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            didKitEngine = 'wasm';
+            return plugin;
         }
 
         try {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
-            return await getNativePlugin(undefined, allowRemoteContexts);
+            const plugin = await getNativePlugin(undefined, allowRemoteContexts);
+            didKitEngine = 'native';
+            return plugin;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
@@ -77,7 +86,9 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            const plugin = await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            didKitEngine = 'wasm';
+            return plugin;
         }
     })();
 

--- a/services/learn-card-network/brain-service/src/routes/utilities.ts
+++ b/services/learn-card-network/brain-service/src/routes/utilities.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 
 import { getChallenges } from '@helpers/challenges.helpers';
 import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
@@ -22,7 +23,29 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            // Exercise DIDKit on every health probe: issue a DID auth VP with the
+            // service keypair and verify it in-process. The signed VP is intentionally
+            // NOT returned — an unbound (no challenge/domain) auth VP handed to
+            // anonymous callers would be a free impersonation artifact for any
+            // verifier that skips challenge binding. See /health-check/deep for full
+            // diagnostics.
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const errors = result.errors ?? [];
+
+            if (errors.length > 0) {
+                throw new TRPCError({
+                    code: 'INTERNAL_SERVER_ERROR',
+                    message: `DIDKit health check failed verification: ${errors.join('; ')}`,
+                });
+            }
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            }) — DIDKit ok (${getDidKitEngine()} engine, DID auth VP issued + verified)`;
         }),
 
     deepHealthCheck: openRoute

--- a/services/learn-card-network/brain-service/src/routes/utilities.ts
+++ b/services/learn-card-network/brain-service/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -21,7 +22,13 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/brain-service/src/routes/utilities.ts
+++ b/services/learn-card-network/brain-service/src/routes/utilities.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
-import { getLearnCard } from '@helpers/learnCard.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -22,13 +22,55 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
+            return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
             const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
 
-            const vp = await learnCard.invoke.getDidAuthVp();
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
 
-            return `Healthy and well! (Version ${
-                packageJson.version
-            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/lca-api/serverless.yml
+++ b/services/learn-card-network/lca-api/serverless.yml
@@ -105,15 +105,15 @@ package:
         - '!node_modules/**'
         - 'src/swagger-ui'
 
-# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
-# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
-# resolves in Lambda instead of silently falling back to WASM. Assembled by
-# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) and
+# its runtime @learncard/didkit-plugin dependency at /opt/nodejs/node_modules so
+# the native-first DIDKit path in learnCard.helpers.ts resolves in Lambda instead
+# of silently falling back to WASM. Assembled by scripts/prepare-didkit-native-layer.cjs.
 layers:
     didkitNative:
         path: didkit-native-layer
         name: ${self:service}-${opt:stage, 'dev'}-didkit-native
-        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        description: Native DIDKit napi addon and runtime DIDKit dependency
         compatibleRuntimes:
             - nodejs20.x
         compatibleArchitectures:

--- a/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
@@ -34,6 +34,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 let didKitInitPromise: Promise<'node' | Buffer> | null = null;
 
@@ -55,6 +60,7 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
     didKitInitPromise = (async () => {
         if (process.env.SKIP_DIDKIT_NAPI) {
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
+            didKitEngine = 'wasm';
             return wasmBuffer;
         }
 
@@ -62,12 +68,14 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
             await getNativePlugin();
+            didKitEngine = 'native';
             return 'node' as const;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
             console.warn('[didkit] native plugin unavailable, falling back to WASM:', error);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
+            didKitEngine = 'wasm';
             return wasmBuffer;
         }
     })();

--- a/services/learn-card-network/lca-api/src/routes/utilities.ts
+++ b/services/learn-card-network/lca-api/src/routes/utilities.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 
 import { getChallenges } from '@helpers/challenges.helpers';
 import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
@@ -23,7 +24,29 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            // Exercise DIDKit on every health probe: issue a DID auth VP with the
+            // service keypair and verify it in-process. The signed VP is intentionally
+            // NOT returned — an unbound (no challenge/domain) auth VP handed to
+            // anonymous callers would be a free impersonation artifact for any
+            // verifier that skips challenge binding. See /health-check/deep for full
+            // diagnostics.
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const errors = result.errors ?? [];
+
+            if (errors.length > 0) {
+                throw new TRPCError({
+                    code: 'INTERNAL_SERVER_ERROR',
+                    message: `DIDKit health check failed verification: ${errors.join('; ')}`,
+                });
+            }
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            }) — DIDKit ok (${getDidKitEngine()} engine, DID auth VP issued + verified)`;
         }),
 
     deepHealthCheck: openRoute

--- a/services/learn-card-network/lca-api/src/routes/utilities.ts
+++ b/services/learn-card-network/lca-api/src/routes/utilities.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
-import { getLearnCard } from '@helpers/learnCard.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute, didAndChallengeRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -23,13 +23,55 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
+            return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
             const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
 
-            const vp = await learnCard.invoke.getDidAuthVp();
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
 
-            return `Healthy and well! (Version ${
-                packageJson.version
-            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/lca-api/src/routes/utilities.ts
+++ b/services/learn-card-network/lca-api/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute, didAndChallengeRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -22,7 +23,13 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/learn-cloud-service/serverless.yml
+++ b/services/learn-card-network/learn-cloud-service/serverless.yml
@@ -93,15 +93,15 @@ package:
     patterns:
         - '!node_modules/**'
 
-# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) at
-# /opt/nodejs/node_modules so the native-first DIDKit path in learnCard.helpers.ts
-# resolves in Lambda instead of silently falling back to WASM. Assembled by
-# scripts/prepare-didkit-native-layer.cjs (see the serverless-deploy npm script).
+# Ships @learncard/didkit-plugin-node (JS wrapper + linux-x64 napi binary) and
+# its runtime @learncard/didkit-plugin dependency at /opt/nodejs/node_modules so
+# the native-first DIDKit path in learnCard.helpers.ts resolves in Lambda instead
+# of silently falling back to WASM. Assembled by scripts/prepare-didkit-native-layer.cjs.
 layers:
     didkitNative:
         path: didkit-native-layer
         name: ${self:service}-${opt:stage, 'dev'}-didkit-native
-        description: Native DIDKit napi addon (@learncard/didkit-plugin-node)
+        description: Native DIDKit napi addon and runtime DIDKit dependency
         compatibleRuntimes:
             - nodejs20.x
         compatibleArchitectures:

--- a/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
@@ -34,6 +34,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 let didKitPluginPromise: Promise<DIDKitPlugin> | null = null;
 
@@ -59,13 +64,17 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer);
+            const plugin = await getWasmPlugin(wasmBuffer);
+            didKitEngine = 'wasm';
+            return plugin;
         }
 
         try {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
-            return await getNativePlugin();
+            const plugin = await getNativePlugin();
+            didKitEngine = 'native';
+            return plugin;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
@@ -73,7 +82,9 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer);
+            const plugin = await getWasmPlugin(wasmBuffer);
+            didKitEngine = 'wasm';
+            return plugin;
         }
     })();
 

--- a/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
+++ b/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 
 import { getChallenges } from '@helpers/challenges.helpers';
 import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
@@ -22,7 +23,29 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            // Exercise DIDKit on every health probe: issue a DID auth VP with the
+            // service keypair and verify it in-process. The signed VP is intentionally
+            // NOT returned — an unbound (no challenge/domain) auth VP handed to
+            // anonymous callers would be a free impersonation artifact for any
+            // verifier that skips challenge binding. See /health-check/deep for full
+            // diagnostics.
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const errors = result.errors ?? [];
+
+            if (errors.length > 0) {
+                throw new TRPCError({
+                    code: 'INTERNAL_SERVER_ERROR',
+                    message: `DIDKit health check failed verification: ${errors.join('; ')}`,
+                });
+            }
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            }) — DIDKit ok (${getDidKitEngine()} engine, DID auth VP issued + verified)`;
         }),
 
     deepHealthCheck: openRoute

--- a/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
+++ b/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -21,7 +22,13 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
-            return `Healthy and well! (Version ${packageJson.version})`;
+            const learnCard = await getLearnCard();
+
+            const vp = await learnCard.invoke.getDidAuthVp();
+
+            return `Healthy and well! (Version ${
+                packageJson.version
+            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
+++ b/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
-import { getLearnCard } from '@helpers/learnCard.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -22,13 +22,55 @@ export const utilitiesRouter = t.router({
         .input(z.void())
         .output(z.string())
         .query(async () => {
+            return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
             const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
 
-            const vp = await learnCard.invoke.getDidAuthVp();
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
 
-            return `Healthy and well! (Version ${
-                packageJson.version
-            })\n\nHere's a VP!\n\n${JSON.stringify(vp, null, 2)}`;
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/tests/smoketests/tests/api-health.spec.ts
+++ b/tests/smoketests/tests/api-health.spec.ts
@@ -56,6 +56,19 @@ test.describe('Tier 1: API Health Checks', () => {
             expect(response.status()).toBe(200);
         });
 
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${API_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] brain: engine=${body.didkitEngine} (${body.ms}ms)`);
+        });
+
         test('tRPC router is mounted and serving', async ({ request }) => {
             await expectTrpcReachable(request, BRAIN_ROOT);
         });
@@ -79,6 +92,19 @@ test.describe('Tier 1: API Health Checks', () => {
             expect(response.status()).toBe(200);
         });
 
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${CLOUD_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] learn-cloud: engine=${body.didkitEngine} (${body.ms}ms)`);
+        });
+
         test('tRPC router is mounted and serving', async ({ request }) => {
             await expectTrpcReachable(request, CLOUD_ROOT);
         });
@@ -88,6 +114,19 @@ test.describe('Tier 1: API Health Checks', () => {
         test('health endpoint returns 200', async ({ request }) => {
             const response = await request.get(`${LCA_API_URL}/health-check`);
             expect(response.status()).toBe(200);
+        });
+
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${LCA_API_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] lca-api: engine=${body.didkitEngine} (${body.ms}ms)`);
         });
 
         test('tRPC router is mounted and serving', async ({ request }) => {


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Related to staging smoketest failures for Lambda DIDKit packaging.

#### 📚 What is the context and goal of this PR?

Staging Lambdas were failing in DIDKit paths after the Bun workspace migration because the native DIDKit Lambda Layer shipped `@learncard/didkit-plugin-node`, but not its runtime dependency `@learncard/didkit-plugin`. The native wrapper loads that package from `/opt/nodejs/node_modules` when VC/presentation methods need document maps, so bundling it elsewhere does not satisfy the Layer-originating `require()`.

This PR packages the runtime DIDKit dependency into the same Lambda Layer for Brain Service, LCA API, and LearnCloud, then makes each service health check exercise `getLearnCard()` by returning a DID auth VP. That makes health checks fail if DIDKit runtime packaging is broken.

#### 🥴 TL; RL:

- Packages `@learncard/didkit-plugin` alongside `@learncard/didkit-plugin-node` in the native DIDKit Lambda Layer.
- Keeps the existing WASM resolver behavior from the earlier Lambda artifact fix.
- Updates Brain Service, LCA API, and LearnCloud health checks to include a service DID auth VP while keeping the route response as a string.
- Updates the existing service changeset to cover the Layer dependency and health-check smoke coverage.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

No UI changes.

Backend changes:

- `scripts/prepare-didkit-native-layer.cjs`
    - Resolves package roots without relying on `package.json` subpath exports.
    - Copies `package.json` and `dist/` for both DIDKit packages into the Layer.
    - Copies native `.node` binaries for `@learncard/didkit-plugin-node` as before.
- `services/learn-card-network/*/serverless.yml`
    - Documents that the Layer ships both the native wrapper and its runtime DIDKit dependency.
- `services/learn-card-network/*/src/routes/utilities.ts`
    - Imports `getLearnCard()`.
    - Calls `learnCard.invoke.getDidAuthVp()` inside `/health-check`.
    - Returns the DID auth VP in the existing string health-check response.

#### 🛠 Important tradeoffs made:

- The health-check response remains a string for compatibility with existing callers.
- The health-check VP generation is intentionally lightweight and service-local; it adds runtime DIDKit coverage without requiring database or network writes.
- The Layer includes the published `dist/` output for `@learncard/didkit-plugin` rather than a hand-pruned subset, avoiding fragile package-layout assumptions.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Deploy the branch to staging.
2. Hit each service health check:
    - Brain Service `/health-check`
    - LCA API `/health-check`
    - LearnCloud `/health-check`
3. Confirm each returns HTTP 200 and a string containing:
    - `Healthy and well!`
    - the service version
    - a DID auth VP
4. Confirm the staging smoketest no longer reports `Cannot find module '@learncard/didkit-plugin'` from `/opt/nodejs/node_modules/@learncard/didkit-plugin-node/dist/plugin.js`.

#### 📱 🖥 Which devices would you like help testing on?

Backend staging Lambdas only.

#### 🧪 Code Coverage

Local verification performed:

- `bun run build` passed in `services/learn-card-network/brain-service`.
- `bun run build` passed in `services/learn-card-network/lca-api`.
- `bun run build` passed in `services/learn-card-network/learn-cloud-service`.
- Assembled the DIDKit native Layer from all three service directories.
- Simulated Lambda module resolution with `NODE_PATH=<service>/didkit-native-layer/nodejs/node_modules` from a neutral cwd and confirmed the native DIDKit path resolves `@learncard/didkit-plugin`.
- Inspected the generated Layer zip and confirmed it contains both `@learncard/didkit-plugin-node` and `@learncard/didkit-plugin`.

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [x] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

No user-facing documentation needed. This is an internal Lambda packaging and service health-check reliability fix.

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix DIDKit Lambda layer dependency and enhance health checks with deep VP verification and engine state tracking.

Main changes:
- Track DIDKit engine state (native/wasm/unloaded) via getDidKitEngine() and expose in health check responses
- Enhanced shallow health checks to exercise DIDKit with DID auth VP issuance+verification; added /health-check/deep endpoint for comprehensive round-trip testing
- Updated layer assembly script to include @learncard/didkit-plugin runtime dependency alongside native plugin-node for Lambda resolution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
