### PR TITLE
✨ Deep health check: prove DIDKit works end to end (/health-check/deep)

### DIFF
--- a/.changeset/deep-health-didkit.md
+++ b/.changeset/deep-health-didkit.md
@@ -1,0 +1,7 @@
+---
+'@learncard/network-brain-service': patch
+'@learncard/lca-api-service': patch
+'@learncard/learn-cloud-service': patch
+---
+
+Add /health-check/deep: issues and verifies a test credential + presentation in-process, proving the full DIDKit crypto path (plugin load, signing, and the native plugin runtime delegation) works, and reports which DIDKit engine (native/wasm) loaded. Shallow health checks stayed green through two DIDKit outages on 2026-07-02; this endpoint makes those failure modes observable from a plain HTTP probe.

--- a/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/learnCard.helpers.ts
@@ -36,6 +36,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 const didKitPluginPromises = new Map<boolean, Promise<DIDKitPlugin>>();
 
@@ -63,13 +68,17 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            const plugin = await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            didKitEngine = 'wasm';
+            return plugin;
         }
 
         try {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
-            return await getNativePlugin(undefined, allowRemoteContexts);
+            const plugin = await getNativePlugin(undefined, allowRemoteContexts);
+            didKitEngine = 'native';
+            return plugin;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
@@ -77,7 +86,9 @@ const getDidKitPlugin = async (allowRemoteContexts = false): Promise<DIDKitPlugi
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            const plugin = await getWasmPlugin(wasmBuffer, allowRemoteContexts);
+            didKitEngine = 'wasm';
+            return plugin;
         }
     })();
 

--- a/services/learn-card-network/brain-service/src/routes/utilities.ts
+++ b/services/learn-card-network/brain-service/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -22,6 +23,54 @@ export const utilitiesRouter = t.router({
         .output(z.string())
         .query(async () => {
             return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
+            const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
+
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/lca-api/src/helpers/learnCard.helpers.ts
@@ -34,6 +34,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 let didKitInitPromise: Promise<'node' | Buffer> | null = null;
 
@@ -55,6 +60,7 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
     didKitInitPromise = (async () => {
         if (process.env.SKIP_DIDKIT_NAPI) {
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
+            didKitEngine = 'wasm';
             return wasmBuffer;
         }
 
@@ -62,12 +68,14 @@ const getDidKitInit = async (): Promise<'node' | Buffer> => {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
             await getNativePlugin();
+            didKitEngine = 'native';
             return 'node' as const;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
             console.warn('[didkit] native plugin unavailable, falling back to WASM:', error);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
+            didKitEngine = 'wasm';
             return wasmBuffer;
         }
     })();

--- a/services/learn-card-network/lca-api/src/routes/utilities.ts
+++ b/services/learn-card-network/lca-api/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute, didAndChallengeRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -23,6 +24,54 @@ export const utilitiesRouter = t.router({
         .output(z.string())
         .query(async () => {
             return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
+            const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
+
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
+++ b/services/learn-card-network/learn-cloud-service/src/helpers/learnCard.helpers.ts
@@ -34,6 +34,11 @@ const resolveDidkitWasmPath = (): string => {
     return require.resolve(DIDKIT_WASM_SPECIFIER);
 };
 
+// Which DIDKit engine actually loaded — exposed via the deep health check so
+// native-vs-wasm is observable from an HTTP probe instead of CloudWatch spelunking.
+let didKitEngine: 'native' | 'wasm' | 'unloaded' = 'unloaded';
+export const getDidKitEngine = (): 'native' | 'wasm' | 'unloaded' => didKitEngine;
+
 // Try native plugin first, fall back to WASM
 let didKitPluginPromise: Promise<DIDKitPlugin> | null = null;
 
@@ -59,13 +64,17 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer);
+            const plugin = await getWasmPlugin(wasmBuffer);
+            didKitEngine = 'wasm';
+            return plugin;
         }
 
         try {
             const didkitModule = await import('@learncard/didkit-plugin-node');
             const getNativePlugin = resolveDidKitPluginFactory(didkitModule);
-            return await getNativePlugin();
+            const plugin = await getNativePlugin();
+            didKitEngine = 'native';
+            return plugin;
         } catch (error) {
             // Surface the fallback — a silent catch here hid a months-long "native never
             // actually loads in Lambda" gap (see PR #1341 investigation).
@@ -73,7 +82,9 @@ const getDidKitPlugin = async (): Promise<DIDKitPlugin> => {
             const didkitModule = await import('@learncard/didkit-plugin');
             const getWasmPlugin = resolveDidKitPluginFactory(didkitModule);
             const wasmBuffer = await readFile(resolveDidkitWasmPath());
-            return await getWasmPlugin(wasmBuffer);
+            const plugin = await getWasmPlugin(wasmBuffer);
+            didKitEngine = 'wasm';
+            return plugin;
         }
     })();
 

--- a/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
+++ b/services/learn-card-network/learn-cloud-service/src/routes/utilities.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getChallenges } from '@helpers/challenges.helpers';
+import { getLearnCard, getDidKitEngine } from '@helpers/learnCard.helpers';
 
 import { t, openRoute, didRoute } from '@routes';
 import { setValidChallengesForDid } from '@cache/challenges';
@@ -22,6 +23,54 @@ export const utilitiesRouter = t.router({
         .output(z.string())
         .query(async () => {
             return `Healthy and well! (Version ${packageJson.version})`;
+        }),
+
+    deepHealthCheck: openRoute
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/health-check/deep',
+                tags: ['Utilities'],
+                summary: 'Deep health check (exercises DIDKit end to end)',
+                description:
+                    'Issues and verifies a test credential + presentation with the service keypair, proving the full DIDKit crypto path (plugin load, signing, and the runtime delegation inside the native plugin) works. Reports which DIDKit engine loaded. Added after the 2026-07-02 incidents, where shallow health checks stayed green while DIDKit paths were broken.',
+            },
+        })
+        .input(z.void())
+        .output(
+            z.object({
+                healthy: z.boolean(),
+                version: z.string(),
+                didkitEngine: z.enum(['native', 'wasm', 'unloaded']),
+                did: z.string(),
+                vpVerified: z.boolean(),
+                verificationErrors: z.string().array(),
+                ms: z.number(),
+            })
+        )
+        .query(async () => {
+            const start = Date.now();
+
+            const learnCard = await getLearnCard();
+            // getTestVp issues a test VC internally, so this round-trip exercises
+            // issueCredential, issuePresentation, AND verifyPresentation — including
+            // both lazy delegation call sites in the native plugin.
+            const unsignedVp = await learnCard.invoke.getTestVp();
+            const vp = await learnCard.invoke.issuePresentation(unsignedVp);
+            const result = await learnCard.invoke.verifyPresentation(vp);
+
+            const verificationErrors = result.errors ?? [];
+            const vpVerified = verificationErrors.length === 0;
+
+            return {
+                healthy: vpVerified,
+                version: packageJson.version,
+                didkitEngine: getDidKitEngine(),
+                did: learnCard.id.did(),
+                vpVerified,
+                verificationErrors,
+                ms: Date.now() - start,
+            };
         }),
 
     getChallenges: didRoute

--- a/tests/smoketests/tests/api-health.spec.ts
+++ b/tests/smoketests/tests/api-health.spec.ts
@@ -56,6 +56,19 @@ test.describe('Tier 1: API Health Checks', () => {
             expect(response.status()).toBe(200);
         });
 
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${API_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] brain: engine=${body.didkitEngine} (${body.ms}ms)`);
+        });
+
         test('tRPC router is mounted and serving', async ({ request }) => {
             await expectTrpcReachable(request, BRAIN_ROOT);
         });
@@ -79,6 +92,19 @@ test.describe('Tier 1: API Health Checks', () => {
             expect(response.status()).toBe(200);
         });
 
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${CLOUD_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] learn-cloud: engine=${body.didkitEngine} (${body.ms}ms)`);
+        });
+
         test('tRPC router is mounted and serving', async ({ request }) => {
             await expectTrpcReachable(request, CLOUD_ROOT);
         });
@@ -88,6 +114,19 @@ test.describe('Tier 1: API Health Checks', () => {
         test('health endpoint returns 200', async ({ request }) => {
             const response = await request.get(`${LCA_API_URL}/health-check`);
             expect(response.status()).toBe(200);
+        });
+
+        test('deep health check exercises DIDKit (VP round-trip)', async ({ request }) => {
+            const response = await request.get(`${LCA_API_URL}/health-check/deep`);
+            // Roll-out tolerance: environments deployed before this endpoint existed 404.
+            test.skip(response.status() === 404, 'deep health check not deployed here yet');
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(
+                body.vpVerified,
+                `verification errors: ${JSON.stringify(body.verificationErrors)}`
+            ).toBe(true);
+            console.log(`[deep-health] lca-api: engine=${body.didkitEngine} (${body.ms}ms)`);
         });
 
         test('tRPC router is mounted and serving', async ({ request }) => {


### PR DESCRIPTION
## TL;DR

Implements the team suggestion from today's incidents: **health checks that actually exercise DIDKit**, so a green check means the crypto path *works*, not just that the HTTP handler runs. Shallow health checks stayed green through **both** of today's DIDKit outages (missing WASM → #1341; missing layer sibling → #1346).

## What it does

New `GET /health-check/deep` on **brain, lca-api, and learn-cloud**:

1. Issues a test VC → wraps in a VP → signs with the service keypair → **verifies** — exercising `issueCredential`, `issuePresentation`, **and** `verifyPresentation`, i.e. the plugin-load path *and both lazy delegation call sites in the native plugin* (the exact two things that broke today).
2. **Reports which DIDKit engine loaded** (`native` / `wasm` / `unloaded`) — this morning's CloudWatch Logs Insights spelunking becomes a `curl`:

```json
{ "healthy": true, "version": "…", "didkitEngine": "native", "did": "did:key:…", "vpVerified": true, "verificationErrors": [], "ms": 42 }
```

3. Smoketests probe it for all three services, asserting `vpVerified` and logging the engine per environment. A **404 soft-skip** keeps prod/scouts smoketests green until the endpoint is deployed there (skip note shows in the report; tighten once rolled out).

## Design choices

- **New endpoint, not a change to `/health-check`** — existing monitors keep cheap liveness semantics; deep is opt-in. Happy to fold it in instead if the team prefers.
- No credentials in the smoketest env — the service signs with its own seed, server-side.
- Failure surfaces the *actual* error (e.g. today's `Cannot find module` would appear verbatim in the 500 / `verificationErrors`).

## Verification

- ✅ `tsc --noEmit` clean ×3 services + smoketests
- ✅ Ran the exact round-trip through brain's helpers locally under bun: native correctly fails over to wasm on macOS (no darwin binary), warn fires, `engine: "wasm"` reported, **`vpVerified: true`** with zero errors
- ⏳ Post-merge on staging: `curl https://staging.network.learncard.com/api/health-check/deep` should show `"didkitEngine": "native"` (once #1346 is deployed) — and the smoketest gains the auth-path coverage that would have caught today's second incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add comprehensive DIDKit end-to-end health check endpoints across three services to detect plugin loading and cryptographic operation failures missed by shallow health checks.

Main changes:
- Track DIDKit engine state (native/wasm/unloaded) via module-level variable and exported getter in learnCard helpers across all services
- Implement `/health-check/deep` endpoints exercising full VP issuance/verification round-trip with engine and error reporting
- Add integration tests validating deep health checks across Brain Service, LearnCloud, and LCA API with 404 rollout tolerance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
