### PR TITLE
chore: Remove accidentally committed .claude symlink

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,1 +1,0 @@
-/Users/donny/Work/LearnCard/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ node_modules
 .aider*
 
 # Personal AI tooling (not shared — teammates may use different setups)
-.claude/
+# No trailing slash: also matches a stray .claude symlink, not just a directory
+.claude
 .codex/
 .vexp/
 .superpowers/


### PR DESCRIPTION
## Summary

The repo root contains a committed symlink `.claude` (git mode `120000`) whose target is the **absolute path** `/Users/donny/Work/LearnCard/.claude` — i.e., a self-referential symlink loop pointing at one specific machine. It was accidentally committed in #1151.

This breaks for every developer:
- The absolute target doesn't exist on other machines (dangling symlink), and on the original machine it resolves to itself (infinite loop).
- It blocks tooling that needs a real `.claude` directory at the repo root (e.g., Claude Code worktrees).

## Changes

- Remove the tracked `.claude` symlink.
- Broaden the existing `.gitignore` rule from `.claude/` to `.claude` — the trailing-slash form only matches directories, so it didn't cover the symlink (git treats symlinks as files), which is how it slipped in despite the ignore rule.

After pulling this change, anyone with a local `.claude` directory or symlink keeps it untouched and ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove accidentally committed .claude symlink that exposed local development path information.

Main changes:
- Deleted .claude symlink pointing to local machine development directory path

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
