### PR TITLE
feat: [LC-1943] ScoutPass lc CLI — tenant/stage environment support

### DIFF
--- a/.changeset/brave-scouts-navigate.md
+++ b/.changeset/brave-scouts-navigate.md
@@ -1,0 +1,10 @@
+---
+'scoutpass-app': patch
+---
+
+Add tenant/stage environment support to the ScoutPass lc CLI (LC-1943)
+
+- New `environments/scoutpass/` config with a base (production) config and a `local` stage overlay, mirroring learn-card-app's environments schema
+- `bun run lc dev|start|docker-start` accept an optional stage arg and inject the resolved env (LCN_URL, LCN_API_URL, CLOUD_URL, LEARN_CLOUD_XAPI_URL, API_URL, SENTRY_ENV); dev commands default to the `local` stage
+- New `bun run lc resolve [stage]` prints the merged config and the env vars that would be injected
+- compose.yaml / compose-local.yaml env now uses `${VAR:-default}` substitution so lc-injected env flows through while bare `docker compose up` keeps today's defaults

--- a/apps/scouts/compose-local.yaml
+++ b/apps/scouts/compose-local.yaml
@@ -23,11 +23,11 @@ services:
             - path: ./.env
               required: false
         environment:
-            LCN_URL: http://localhost:4000/trpc
-            LCN_API_URL: http://localhost:4000/api
-            CLOUD_URL: http://localhost:4100/trpc
-            LEARN_CLOUD_XAPI_URL: http://localhost:4100/xapi
-            API_URL: http://localhost:5100/trpc
+            LCN_URL: ${LCN_URL:-http://localhost:4000/trpc}
+            LCN_API_URL: ${LCN_API_URL:-http://localhost:4000/api}
+            CLOUD_URL: ${CLOUD_URL:-http://localhost:4100/trpc}
+            LEARN_CLOUD_XAPI_URL: ${LEARN_CLOUD_XAPI_URL:-http://localhost:4100/xapi}
+            API_URL: ${API_URL:-http://localhost:5100/trpc}
             SKIP_DIDKIT_NAPI: '1'
             VITE_DOCKER_SOURCE: 'true'
             CHOKIDAR_USEPOLLING: 'true'

--- a/apps/scouts/compose.yaml
+++ b/apps/scouts/compose.yaml
@@ -18,10 +18,10 @@ services:
         extra_hosts:
             - 'localhost:host-gateway'
         environment:
-            LCN_URL: http://localhost:4000/trpc
-            LCN_API_URL: http://localhost:4000/api
-            CLOUD_URL: http://localhost:4100/trpc
-            API_URL: http://localhost:5100/trpc
+            LCN_URL: ${LCN_URL:-http://localhost:4000/trpc}
+            LCN_API_URL: ${LCN_API_URL:-http://localhost:4000/api}
+            CLOUD_URL: ${CLOUD_URL:-http://localhost:4100/trpc}
+            API_URL: ${API_URL:-http://localhost:5100/trpc}
 
     delete-service:
         build: ../../services/playwright-delete-service

--- a/apps/scouts/environments/scoutpass/config.json
+++ b/apps/scouts/environments/scoutpass/config.json
@@ -1,0 +1,13 @@
+{
+    "_comment": "Base (production) environment for ScoutPass. Stage overlays (config.<stage>.json) are merged on top via deepMerge — see scripts/lc.ts. ScoutPass has no staging environment, so the only stages are 'local' and 'production'.",
+    "branding": {
+        "name": "ScoutPass"
+    },
+    "apis": {
+        "brainService": "https://scoutnetwork.org/trpc",
+        "brainServiceApi": "https://scoutnetwork.org/api",
+        "cloudService": "https://cloud.scoutnetwork.org/trpc",
+        "lcaApi": "https://api.scoutnetwork.org/trpc",
+        "xapi": "https://cloud.scoutnetwork.org/xapi"
+    }
+}

--- a/apps/scouts/environments/scoutpass/config.local.json
+++ b/apps/scouts/environments/scoutpass/config.local.json
@@ -1,0 +1,13 @@
+{
+    "_comment": "Local dev overrides for ScoutPass. Merged on top of config.json via deepMerge. These values match the local docker stack (compose-local.yaml).",
+    "apis": {
+        "brainService": "http://localhost:4000/trpc",
+        "brainServiceApi": "http://localhost:4000/api",
+        "cloudService": "http://localhost:4100/trpc",
+        "lcaApi": "http://localhost:5100/trpc",
+        "xapi": "http://localhost:4100/xapi"
+    },
+    "observability": {
+        "sentryEnv": "scouts-development"
+    }
+}

--- a/apps/scouts/scripts/lc.ts
+++ b/apps/scouts/scripts/lc.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
 import { spawn } from 'child_process';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { createInterface } from 'readline';
-import { dirname, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { getLogger } from '../../../packages/learn-card-base/src/logging/logger';
@@ -12,6 +13,16 @@ const log = getLogger('lc');
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const APP_ROOT = resolve(__dirname, '..');
+const ENVIRONMENTS_DIR = resolve(APP_ROOT, 'environments');
+
+/**
+ * ScoutPass is single-tenant, so unlike learn-card-app's lc there is no tenant
+ * picker — just stages. Stages are discovered from environments/scoutpass:
+ * every config.<stage>.json overlay is a stage, plus the implicit 'production'
+ * stage which is the base config.json with no overlay. ScoutPass has no staging
+ * environment, so this normally yields ['local', 'production'].
+ */
+const PROJECT_ID = 'scoutpass';
 
 const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -31,7 +42,8 @@ const runCommand = (
     cmd: string,
     label: string,
     shortcut?: string,
-    cwd: string = APP_ROOT
+    cwd: string = APP_ROOT,
+    extraEnv?: Record<string, string>
 ): void => {
     log.info('');
     log.info(green(`▶ ${label}`));
@@ -48,10 +60,130 @@ const runCommand = (
     const child = spawn('sh', ['-c', cmd], {
         cwd,
         stdio: 'inherit',
-        env: { ...process.env },
+        env: { ...process.env, ...extraEnv },
     });
 
     child.on('exit', code => process.exit(code ?? 0));
+};
+
+// ---------------------------------------------------------------------------
+// Stage / environment resolution
+// ---------------------------------------------------------------------------
+
+const discoverStages = (): string[] => {
+    const projectDir = join(ENVIRONMENTS_DIR, PROJECT_ID);
+
+    if (!existsSync(projectDir)) return ['production'];
+
+    const overlays = readdirSync(projectDir)
+        .filter(f => /^config\..+\.json$/.test(f))
+        .map(f => f.replace(/^config\./, '').replace(/\.json$/, ''));
+
+    // 'production' is the base config.json with no overlay applied
+    return [...overlays, 'production'];
+};
+
+const asStage = (value?: string): string | undefined => {
+    if (!value) return undefined;
+
+    return discoverStages().includes(value) ? value : undefined;
+};
+
+const deepMerge = (
+    base: Record<string, unknown>,
+    overlay: Record<string, unknown>
+): Record<string, unknown> => {
+    const result: Record<string, unknown> = { ...base };
+
+    for (const [key, value] of Object.entries(overlay)) {
+        const baseValue = result[key];
+
+        if (
+            value &&
+            baseValue &&
+            typeof value === 'object' &&
+            typeof baseValue === 'object' &&
+            !Array.isArray(value) &&
+            !Array.isArray(baseValue)
+        ) {
+            result[key] = deepMerge(
+                baseValue as Record<string, unknown>,
+                value as Record<string, unknown>
+            );
+        } else {
+            result[key] = value;
+        }
+    }
+
+    return result;
+};
+
+const resolveStageConfig = (stage: string): Record<string, any> => {
+    const projectDir = join(ENVIRONMENTS_DIR, PROJECT_ID);
+    const basePath = join(projectDir, 'config.json');
+
+    if (!existsSync(basePath)) {
+        log.error(`Missing base config: ${basePath}`);
+        process.exit(1);
+    }
+
+    const base = JSON.parse(readFileSync(basePath, 'utf-8'));
+
+    if (stage === 'production') return base;
+
+    const overlayPath = join(projectDir, `config.${stage}.json`);
+
+    if (!existsSync(overlayPath)) return base;
+
+    return deepMerge(base, JSON.parse(readFileSync(overlayPath, 'utf-8')));
+};
+
+/**
+ * Maps a resolved stage config to the env vars the scouts app consumes.
+ * These become vite build defines (see vite.config.ts) and are forwarded
+ * into docker compose via ${VAR:-default} substitution in the compose files.
+ */
+const configToEnv = (config: Record<string, any>): Record<string, string> => {
+    const env: Record<string, string> = {};
+    const apis = config.apis ?? {};
+
+    if (apis.brainService) env.LCN_URL = apis.brainService;
+    if (apis.brainServiceApi) env.LCN_API_URL = apis.brainServiceApi;
+    if (apis.cloudService) env.CLOUD_URL = apis.cloudService;
+    if (apis.xapi) env.LEARN_CLOUD_XAPI_URL = apis.xapi;
+    if (apis.lcaApi) env.API_URL = apis.lcaApi;
+    if (config.observability?.sentryEnv) env.SENTRY_ENV = config.observability.sentryEnv;
+
+    return env;
+};
+
+const resolveStageEnv = (stage: string): Record<string, string> =>
+    configToEnv(resolveStageConfig(stage));
+
+const printResolvedStage = (stage?: string): void => {
+    const stages = discoverStages();
+    const selected = stage ?? 'local';
+
+    if (!stages.includes(selected)) {
+        log.info(yellow(`Unknown stage: ${selected}. Available: ${stages.join(', ')}`));
+        rl.close();
+        return;
+    }
+
+    log.info('');
+    log.info(bold(`Resolved environment for ${PROJECT_ID} (stage: ${selected})`));
+    log.info('');
+    log.info(JSON.stringify(resolveStageConfig(selected), null, 4));
+    log.info('');
+    log.info(bold('Injected env vars:'));
+    log.info('');
+
+    for (const [key, value] of Object.entries(resolveStageEnv(selected))) {
+        log.info(`  ${cyan(key)}=${value}`);
+    }
+
+    log.info('');
+    rl.close();
 };
 
 const asPlatform = (value?: string): Platform | undefined => {
@@ -110,11 +242,19 @@ const pickPlatform = async (): Promise<Platform> => {
     return choice === '2' ? 'android' : 'ios';
 };
 
-const startAppOnly = (): void => {
-    runCommand('bun run docker-start', 'Starting Scouts app only', 'bun run lc start');
+const startAppOnly = (stage?: string): void => {
+    const stageId = stage ?? 'local';
+
+    runCommand(
+        'bun run docker-start',
+        `Starting Scouts app only (env: ${stageId})`,
+        'bun run lc start',
+        APP_ROOT,
+        resolveStageEnv(stageId)
+    );
 };
 
-const startDev = async (devMode?: DevMode, noBuild?: boolean): Promise<void> => {
+const startDev = async (devMode?: DevMode, noBuild?: boolean, stage?: string): Promise<void> => {
     if (!devMode) {
         log.info('');
         log.info(bold('How do you want to run Scouts?'));
@@ -149,8 +289,19 @@ const startDev = async (devMode?: DevMode, noBuild?: boolean): Promise<void> => 
         noBuild = buildAnswer.trim().toLowerCase() === 'n';
     }
 
+    // Dev flows default to the local stage — its env matches the docker stack.
+    // Pass a stage arg (e.g. `bun run lc dev app production`) to point elsewhere.
+    const stageId = stage ?? 'local';
+    const stageEnv = resolveStageEnv(stageId);
+
     if (devMode === 'app') {
-        runCommand('bun run docker-start', 'Starting Scouts app only', 'bun run lc dev app');
+        runCommand(
+            'bun run docker-start',
+            `Starting Scouts app only (env: ${stageId})`,
+            'bun run lc dev app',
+            APP_ROOT,
+            stageEnv
+        );
         return;
     }
 
@@ -159,7 +310,9 @@ const startDev = async (devMode?: DevMode, noBuild?: boolean): Promise<void> => 
             runCommand(
                 'docker compose -f compose-local.yaml up --scale app=0',
                 'Starting Scouts Docker services only — skipping rebuild',
-                'bun run lc dev services fast'
+                'bun run lc dev services fast',
+                APP_ROOT,
+                stageEnv
             );
             return;
         }
@@ -167,7 +320,9 @@ const startDev = async (devMode?: DevMode, noBuild?: boolean): Promise<void> => 
         runCommand(
             'bun run dev:services',
             'Starting Scouts Docker services only',
-            'bun run lc dev services'
+            'bun run lc dev services',
+            APP_ROOT,
+            stageEnv
         );
         return;
     }
@@ -175,13 +330,21 @@ const startDev = async (devMode?: DevMode, noBuild?: boolean): Promise<void> => 
     if (noBuild) {
         runCommand(
             'bun run dev-no-build',
-            'Starting Scouts full stack — skipping rebuild',
-            'bun run lc dev fast'
+            `Starting Scouts full stack (env: ${stageId}) — skipping rebuild`,
+            'bun run lc dev fast',
+            APP_ROOT,
+            stageEnv
         );
         return;
     }
 
-    runCommand('bun run dev', 'Starting Scouts full stack', 'bun run lc dev');
+    runCommand(
+        'bun run dev',
+        `Starting Scouts full stack (env: ${stageId})`,
+        'bun run lc dev',
+        APP_ROOT,
+        stageEnv
+    );
 };
 
 const nativeSync = (): void => {
@@ -275,16 +438,36 @@ const printHelp = (): void => {
     log.info(bold('  ⚡ Start'));
     log.info('');
     log.info(
-        `  ${cyan('bun run lc dev [full|app|services] [fast|no-build]')} ${dim(
+        `  ${cyan('bun run lc dev [full|app|services] [fast|no-build] [stage]')} ${dim(
             'Interactive dev launcher'
         )}`
     );
-    log.info(`  ${cyan('bun run lc start')}                        ${dim('Vite dev server only')}`);
+    log.info(`  ${cyan('bun run lc start [stage]')}                ${dim('Vite dev server only')}`);
     log.info(`  ${cyan('bun run lc services')}                     ${dim('Docker services only')}`);
     log.info(
-        `  ${cyan('bun run lc docker-start')}                ${dim(
+        `  ${cyan('bun run lc docker-start [stage]')}         ${dim(
             'Vite dev server with app-specific runtime env'
         )}`
+    );
+    log.info('');
+    log.info(bold('  🌐 Environments'));
+    log.info('');
+    log.info(
+        `  ${cyan('bun run lc resolve [stage]')}              ${dim(
+            'Print resolved config + injected env vars'
+        )}`
+    );
+    log.info(
+        dim(
+            `  Stages are discovered from environments/${PROJECT_ID} (config.<stage>.json + implicit 'production').`
+        )
+    );
+    log.info(
+        dim(
+            `  Currently available: ${discoverStages().join(
+                ', '
+            )} — dev commands default to 'local'.`
+        )
     );
     log.info('');
     log.info(bold('  📱 Native'));
@@ -354,9 +537,18 @@ const handleShortcuts = async (): Promise<boolean> => {
             printHelp();
             return true;
 
-        case 'start':
-            runCommand('bun run start', 'Starting Scouts app only', 'bun run lc start');
+        case 'start': {
+            const stageId = asStage(args[1]) ?? 'local';
+
+            runCommand(
+                'bun run start',
+                `Starting Scouts app only (env: ${stageId})`,
+                'bun run lc start',
+                APP_ROOT,
+                resolveStageEnv(stageId)
+            );
             return true;
+        }
 
         case 'services':
             runCommand(
@@ -366,12 +558,21 @@ const handleShortcuts = async (): Promise<boolean> => {
             );
             return true;
 
-        case 'docker-start':
+        case 'docker-start': {
+            const stageId = asStage(args[1]) ?? 'local';
+
             runCommand(
                 'bun run docker-start',
-                'Starting Scouts Docker-start app',
-                'bun run lc docker-start'
+                `Starting Scouts Docker-start app (env: ${stageId})`,
+                'bun run lc docker-start',
+                APP_ROOT,
+                resolveStageEnv(stageId)
             );
+            return true;
+        }
+
+        case 'resolve':
+            printResolvedStage(asStage(args[1]) ?? args[1]);
             return true;
 
         case 'build':
@@ -415,7 +616,15 @@ const handleShortcuts = async (): Promise<boolean> => {
                 return asNoBuild(value);
             }, undefined);
 
-            await startDev(devMode, noBuild);
+            const stage = devArgs.reduce<string | undefined>((found, value) => {
+                if (found) {
+                    return found;
+                }
+
+                return asStage(value);
+            }, undefined);
+
+            await startDev(devMode, noBuild, stage);
             return true;
         }
 


### PR DESCRIPTION
## Summary

ScoutPass's `bun lc` launcher had no environment/stage concept — its compose files hardcoded env (`LCN_URL: http://localhost:4000/trpc` etc.). That's the exact configuration that surfaced the local-docker-silently-hits-prod network bug in `getBespokeLearnCard` (separate fix). This brings scouts to parity with learn-card-app's lc: per-stage env lives in reviewable config files and is injected by the CLI.

Jira: [LC-1943](https://welibrary.atlassian.net/browse/LC-1943)

## Changes

- **`environments/scoutpass/config.json`** — base (production) config: scoutnetwork.org URLs, mirroring learn-card-app's environments schema (`apis.brainService` / `brainServiceApi` / `cloudService` / `lcaApi` / `xapi`)
- **`environments/scoutpass/config.local.json`** — local overlay matching today's docker stack values, plus `sentryEnv: scouts-development`
- **`scripts/lc.ts`** — stage discovery (`config.<stage>.json` overlays + implicit `production`), deepMerge resolution, config→env mapping, stage arg on `dev` / `start` / `docker-start` (default `local`), and a new `lc resolve [stage]` command that prints the merged config + injected env
- **`compose.yaml` / `compose-local.yaml`** — env uses `${VAR:-default}` substitution: lc-injected env flows through, bare `docker compose up` keeps today's defaults byte-for-byte

Scouts has no staging environment — stage discovery naturally yields just `local` and `production`.

## Verification

- `bun run lc resolve local` / `resolve production` print correct merged config + env; unknown stage prints available stages
- `docker compose -f compose-local.yaml config` without env → today's localhost defaults; with injected env → overridden values (verified both)
- `bun run lc help` shows the new Environments section with discovered stages

(No unit tests: scouts has no vitest infra — its only test setup is Playwright — and this is interactive dev tooling; `lc resolve` provides direct verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LC-1943]: https://welibrary.atlassian.net/browse/LC-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add multi-stage environment configuration support to ScoutPass lc CLI with environment discovery, config merging, and dynamic env var injection.

Main changes:
- Implemented stage discovery from `environments/scoutpass/` directory with base config.json and config.<stage>.json overlays merged via deepMerge
- Enhanced lc CLI commands (dev, start, docker-start) to accept optional stage argument and inject resolved environment variables (LCN_URL, CLOUD_URL, API_URL, SENTRY_ENV)
- Updated Docker compose files to use `${VAR:-default}` substitution for environment variables enabling lc CLI env injection while preserving defaults

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
