### PR TITLE
fix(side-nav): remove dark right-edge line + stop width shrink on load

### DIFF
--- a/.changeset/nine-experts-refuse.md
+++ b/.changeset/nine-experts-refuse.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix(side-nav): remove dark right-edge line + stop width shrink on load

--- a/apps/learn-card-app/src/assets/sass/nav.scss
+++ b/apps/learn-card-app/src/assets/sass/nav.scss
@@ -79,11 +79,31 @@ ion-tab-bar.lc-footer-nav {
     }
 }
 
+// Pin Ionic's side-pane width from the first paint. Without this the pane
+// renders at Ionic's default (--side-max-width: 28% ≈ 400px on desktop) and
+// then the min/max-width below + `transition` animate it DOWN to 290 — which
+// reads as a width "shrink" on initial load. Setting the vars on the split-pane
+// host makes it 290 (and 135 collapsed) immediately; the transition still drives
+// the collapse animation.
+.side-menu-split-pane-container-visible {
+    --side-min-width: 290px;
+    --side-max-width: 290px;
+    --side-width: 290px;
+}
+
+.side-menu-split-pane-container-collapsed {
+    --side-min-width: 135px;
+    --side-max-width: 135px;
+    --side-width: 135px;
+}
+
 .side-menu-split-pane-container-visible.split-pane-md.split-pane-visible > .split-pane-side {
     // LC-1921: Side Nav widened 270 → 290 to match Figma.
     min-width: 290px;
     max-width: 290px;
-    border-right: var(--border);
+    // border-right removed: the drop shadow is the edge treatment. Ionic's
+    // default --border (1px solid rgba(0,0,0,0.13)) was painting a dark hairline.
+    border-right: none;
     border-left: 0;
     // LC-1921: subtle drop shadow on the desktop side nav's right edge.
     // position + z-index are required so the shadow paints OVER the adjacent
@@ -99,7 +119,9 @@ ion-tab-bar.lc-footer-nav {
 .side-menu-split-pane-container-collapsed.split-pane-md.split-pane-visible > .split-pane-side {
     min-width: 135px;
     max-width: 135px;
-    border-right: var(--border);
+    // border-right removed: the drop shadow is the edge treatment. Ionic's
+    // default --border (1px solid rgba(0,0,0,0.13)) was painting a dark hairline.
+    border-right: none;
     border-left: 0;
     transition: all 0.3s ease-in;
 }


### PR DESCRIPTION
## Overview
Two small desktop side-nav (LC-1921) polish bugs found during staging QA.

### 🎟 Relevant Jira Issues
Related to: LC-1921

### Fixes
1. **Dark line on the side-nav's right edge** — `border-right` used Ionic's default `--border` (`1px solid rgba(0,0,0,0.13)`), painting a dark hairline. The intended edge treatment is the Figma drop shadow, so `border-right: none`.
2. **Width "shrink" animation on first load** — `IonSplitPane` set no width vars, so it rendered at Ionic's default `--side-max-width: 28%` (~400px) then animated down to 290 via `min/max-width` + `transition: all`. Pinned `--side-min/max/width` on the split-pane container so it's 290px (135px collapsed) from the first paint. The transition still drives the collapse (290↔135) animation.

### 🔍 Types of Changes
- [x] Bug fix (non-breaking)

### 🔬 QA
- Desktop: side-nav right edge shows only the soft drop shadow (no dark hairline); on hard refresh the nav is 290px immediately with no width animation; collapse/expand still animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix side navigation visual issues by removing dark border and preventing width shrinking on initial load.

Main changes:
- Pinned Ionic split-pane width variables (290px visible, 135px collapsed) to prevent default animation from appearing as shrink
- Replaced dark `border-right: var(--border)` with `border-right: none` on both visible and collapsed side pane states
- Added detailed comments explaining Ionic's default width behavior and drop shadow as edge treatment

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
