### PR TITLE
fix: Fix Verification Flow

### DIFF
--- a/.changeset/old-sides-repair.md
+++ b/.changeset/old-sides-repair.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: Fix Verification Flow

--- a/apps/learn-card-app/src/helpers/contract.helpers.ts
+++ b/apps/learn-card-app/src/helpers/contract.helpers.ts
@@ -68,6 +68,10 @@ export const VERIFIABLE_DATA_CONTRACT_CATEGORIES = [
 export const isVerifiableDataContractCategory = (category: string) =>
     VERIFIABLE_DATA_CONTRACT_CATEGORIES.includes(category as CredentialCategoryEnum);
 
+export const isAiContractCategory = (category: string) =>
+    AI_CONTRACT_CATEGORIES.includes(category as CredentialCategoryEnum) ||
+    AI_CONTRACT_CREDENTIAL_TYPE_OVERRIDES.includes(category);
+
 export const contractAnonImageSrc = 'https://cdn.filestackcontent.com/52hRlXLIQVBi4fYpB1xw';
 
 export const getPersonalEntry = (key: string, user?: CurrentUser | null, anonymize = true) => {

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -671,6 +671,7 @@ const ClaimFromRequest: React.FC = () => {
                         verifiablePresentationRequest={exchangeState.data}
                         onSubmit={handleRequest}
                         strategy={exchangeState.strategy}
+                        onCancel={() => history.push('/')}
                     />
                 );
             case ExchangeState.AcceptCredentials:

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -70,7 +70,7 @@ import {
     homeOutline,
     refreshOutline,
 } from 'ionicons/icons';
-import { AlertCircle, RefreshCw, Home, HelpCircle, MessageCircle } from 'lucide-react';
+import { AlertCircle, RefreshCw, Home, HelpCircle, MessageCircle, CheckCircle } from 'lucide-react';
 import LoggedOutRequest from './LoggedOutRequest';
 import { getInfoFromCredential } from 'learn-card-base/components/CredentialBadge/CredentialVerificationDisplay';
 
@@ -415,6 +415,38 @@ const ExchangeErrorDisplay: React.FC<{
     );
 };
 
+const ExchangeSuccessDisplay: React.FC<{
+    title?: string;
+    description?: string;
+    onDone: () => void;
+}> = ({
+    title = 'Shared Successfully',
+    description = 'Your credentials were shared successfully.',
+    onDone,
+}) => (
+    <div className="min-h-full bg-gradient-to-br from-emerald-50 via-white to-emerald-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-3xl shadow-xl max-w-md w-full overflow-hidden">
+            <div className="bg-gradient-to-r from-emerald-500 to-emerald-600 px-6 py-8 text-center">
+                <div className="w-20 h-20 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-4">
+                    <CheckCircle className="w-10 h-10 text-white" />
+                </div>
+                <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
+                <p className="text-emerald-100 text-sm">You're all set</p>
+            </div>
+            <div className="p-6">
+                <p className="text-grayscale-600 text-center text-sm mb-6">{description}</p>
+                <button
+                    onClick={onDone}
+                    className="w-full py-4 px-6 bg-grayscale-900 text-white font-semibold rounded-[20px] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                >
+                    <Home className="w-5 h-5" />
+                    Done
+                </button>
+            </div>
+        </div>
+    </div>
+);
+
 const ClaimFromRequest: React.FC = () => {
     const [isFront, setIsFront] = useState(true);
     const [loading, setLoading] = useState(false);
@@ -471,7 +503,16 @@ const ClaimFromRequest: React.FC = () => {
 
             if (!response.ok) throw new Error(`${response.status}`);
 
-            const responseData = await response.json();
+            const responseText = await response.text();
+            let responseData: any = {};
+            if (responseText) {
+                try {
+                    responseData = JSON.parse(responseText);
+                } catch (parseError) {
+                    log.warn('Non-JSON exchange response, treating as empty', parseError);
+                    responseData = {};
+                }
+            }
             const { type, data, strategy } = normalizeRequestResponseData(responseData);
 
             // Server sent a Verifiable Presentation Request
@@ -511,6 +552,21 @@ const ClaimFromRequest: React.FC = () => {
                 setExchangeState({ state: ExchangeState.Redirect, data, strategy });
                 // Server sent something else: https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange
             } else {
+                const submittedPresentation =
+                    !!body?.verifiablePresentation ||
+                    Object.prototype.hasOwnProperty.call(body ?? {}, '@context');
+                const isEmptyResponse = !responseData || Object.keys(responseData).length === 0;
+
+                // VC-API: an empty 2xx response after presenting means the exchange completed
+                // with no further steps — an implicit success (not an error).
+                if (submittedPresentation && isEmptyResponse) {
+                    setExchangeState({
+                        state: ExchangeState.Finished,
+                        data: { description: 'Your credentials were shared successfully.' },
+                    });
+                    return;
+                }
+
                 setExchangeState({
                     state: ExchangeState.Error,
                     data: responseData?.message || 'Unknown response from server',
@@ -633,6 +689,14 @@ const ClaimFromRequest: React.FC = () => {
                         verifiablePresentationRequest={exchangeState.data}
                         onSubmit={handleRequest}
                         strategy={exchangeState.strategy}
+                    />
+                );
+            case ExchangeState.Finished:
+                return (
+                    <ExchangeSuccessDisplay
+                        title={exchangeState.data?.title}
+                        description={exchangeState.data?.description}
+                        onDone={() => history.push('/')}
                     />
                 );
             case ExchangeState.Loading:

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangePresentationRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangePresentationRequest.tsx
@@ -27,12 +27,14 @@ interface ExchangePresentationRequestProps {
     verifiablePresentationRequest: any; // Contains the verifiablePresentationRequest from the server
     strategy?: VCAPIRequestStrategy;
     onSubmit: (body: { verifiablePresentation: VP } | VP) => void;
+    onCancel?: () => void;
 }
 
 const ExchangePresentationRequest: React.FC<ExchangePresentationRequestProps> = ({
     verifiablePresentationRequest,
     onSubmit,
     strategy,
+    onCancel,
 }) => {
     const currentUser = useCurrentUser();
 
@@ -48,6 +50,7 @@ const ExchangePresentationRequest: React.FC<ExchangePresentationRequestProps> = 
 
     const handleReject = () => {
         log.info('reject');
+        onCancel?.();
     };
 
     return (

--- a/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
@@ -66,7 +66,7 @@ const VCToShare: React.FC<{
             const presentation =
                 event?.credentialRequestOptions?.web?.VerifiablePresentation ||
                 verifiablePresentationRequest;
-            const { challenge, domain } = presentation;
+            const { challenge, domain } = presentation ?? {};
 
             try {
                 chapiStore.set.isChapiInteraction(null);
@@ -75,16 +75,7 @@ const VCToShare: React.FC<{
                 log.error(e);
             }
 
-            // TODO: Move this logic into LearnCard - LearnCard should handle presentation flow.
-            const vpToShare = {
-                '@context': [
-                    'https://www.w3.org/2018/credentials/v1',
-                    'https://w3id.org/security/suites/ed25519-2020/v1',
-                ],
-                type: ['VerifiablePresentation'],
-                verifiableCredential: vcsToShare,
-                holder: wallet.id.did(),
-            };
+            const vpToShare = await wallet.invoke.newPresentation(vcsToShare as any);
 
             log.info('✍️ Issuing VP to respond to CHAPI event', vpToShare);
 
@@ -109,7 +100,9 @@ const VCToShare: React.FC<{
             }
             setIsLoading(false);
             handleCloseModal();
-        } catch {
+        } catch (e) {
+            log.error('share.credentials.failed', e);
+            setIsLoading(false);
             setError('Error sharing credential(s). Please try again.');
         }
     };

--- a/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
@@ -119,13 +119,9 @@ const VCToShare: React.FC<{
                         Review
                     </button>
                     <button
-                        className={
-                            vcsToShare.length === 0
-                                ? 'bg-indigo-700 opacity-50 rounded-full text-white font-poppins h-10 w-24 text-2xl m-1.5 shadow-bottom'
-                                : 'bg-indigo-700 rounded-full text-white font-poppins h-10 w-24 text-2xl m-1.5 shadow-bottom'
-                        }
+                        className="bg-grayscale-900 rounded-[20px] text-white font-poppins font-medium h-10 px-6 text-sm m-1.5 hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                         onClick={accept}
-                        disabled={vcsToShare.length === 0 ? true : false}
+                        disabled={vcsToShare.length === 0 || (isLoading && !error)}
                     >
                         {isLoading && !error ? 'SHARING...' : 'SHARE'}
                     </button>

--- a/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
@@ -128,9 +128,9 @@ const VCToShare: React.FC<{
                 </IonHeader>
                 <IonGrid>
                     {error && <p className="text-center text-rose-600 text-lg">{error}</p>}
-                    <IonCol className="flex flex-row items-center flex-wrap mb-48 w-full  achievements-list-container">
+                    <div className="flex flex-row flex-wrap items-start justify-center gap-4 mb-48 w-full achievements-list-container [&>ion-col]:!w-[220px] [&>ion-col]:!max-w-[220px] [&>ion-col]:!flex-none [&>ion-col]:!p-0">
                         {renderCredentialList}
-                    </IonCol>
+                    </div>
                 </IonGrid>
             </IonRow>
         </IonPage>

--- a/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
@@ -111,7 +111,7 @@ const VCToShare: React.FC<{
 
     return (
         <IonPage>
-            <IonRow className="bg-grayscale-100 m-auto flex flex-col mobile:w-[85%] md:w-[509px] lg:w-[724px] h-5/6 max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-2rem)] rounded-3xl overflow-hidden font-poppins">
+            <IonRow className="bg-grayscale-100 m-auto flex flex-col mobile:w-[85%] md:w-[509px] desktop:w-[724px] h-5/6 max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-2rem)] rounded-3xl overflow-hidden font-poppins">
                 <header className="shrink-0 bg-white flex items-center justify-between gap-3 px-6 py-4 border-b border-grayscale-200">
                     <div className="flex items-center gap-3 min-w-0">
                         <button
@@ -146,7 +146,7 @@ const VCToShare: React.FC<{
                                 Sharing...
                             </span>
                         ) : (
-                            'SHARE'
+                            'Share'
                         )}
                     </button>
                 </header>

--- a/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/VCToShare.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('v-c-to-share');
 
-import { IonHeader, IonRow, IonCol, IonGrid, IonPage } from '@ionic/react';
+import { IonRow, IonPage } from '@ionic/react';
 import CaretLeft from 'learn-card-base/svgs/CaretLeft';
 import BoostEarnedCard from 'apps/learn-card-app/src/components/boost/boost-earned-card/BoostEarnedCard';
 import { getDefaultCategoryForCredential } from 'learn-card-base/helpers/credentialHelpers';
@@ -107,31 +107,94 @@ const VCToShare: React.FC<{
         }
     };
 
+    const selectedCount = vcsToShare?.length ?? 0;
+
     return (
         <IonPage>
-            <IonRow className="bg-grayscale-100 m-auto flex mobile:w-[85%] md:w-[509px] lg:w-[724px] h-5/6 rounded-3xl overflow-auto">
-                <IonHeader className="bg-white flex items-center justify-between mobile:px-5 mobile:py-2.5 md:px-10 md:py-5">
-                    <button
-                        className="flex items-center justify-center font-poppins text-grayscale-900 text-xl m-1.5"
-                        onClick={() => handleCloseModal()}
-                    >
-                        <CaretLeft className="h-auto w-3 mr-5" />
-                        Review
-                    </button>
-                    <button
-                        className="bg-grayscale-900 rounded-[20px] text-white font-poppins font-medium h-10 px-6 text-sm m-1.5 hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
-                        onClick={accept}
-                        disabled={vcsToShare.length === 0 || (isLoading && !error)}
-                    >
-                        {isLoading && !error ? 'SHARING...' : 'SHARE'}
-                    </button>
-                </IonHeader>
-                <IonGrid>
-                    {error && <p className="text-center text-rose-600 text-lg">{error}</p>}
-                    <div className="flex flex-row flex-wrap items-start justify-center gap-4 mb-48 w-full achievements-list-container [&>ion-col]:!w-[220px] [&>ion-col]:!max-w-[220px] [&>ion-col]:!flex-none [&>ion-col]:!p-0">
-                        {renderCredentialList}
+            <IonRow className="bg-grayscale-100 m-auto flex flex-col mobile:w-[85%] md:w-[509px] lg:w-[724px] h-5/6 max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-2rem)] rounded-3xl overflow-hidden font-poppins">
+                <header className="shrink-0 bg-white flex items-center justify-between gap-3 px-6 py-4 border-b border-grayscale-200">
+                    <div className="flex items-center gap-3 min-w-0">
+                        <button
+                            type="button"
+                            aria-label="Go back"
+                            className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full hover:bg-grayscale-10 transition-colors"
+                            onClick={() => handleCloseModal()}
+                        >
+                            <CaretLeft className="h-auto w-3 text-grayscale-900" />
+                        </button>
+                        <div className="text-left min-w-0">
+                            <h1 className="text-xl font-semibold text-grayscale-900 leading-tight">
+                                Review
+                            </h1>
+                            <p className="text-xs text-grayscale-500 mt-0.5 truncate">
+                                {selectedCount === 0
+                                    ? 'No credentials selected'
+                                    : `Sharing ${selectedCount} credential${
+                                          selectedCount === 1 ? '' : 's'
+                                      }`}
+                            </p>
+                        </div>
                     </div>
-                </IonGrid>
+                    <button
+                        className="shrink-0 bg-grayscale-900 rounded-[20px] text-white font-medium h-10 px-6 text-sm hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+                        onClick={accept}
+                        disabled={selectedCount === 0 || (isLoading && !error)}
+                    >
+                        {isLoading && !error ? (
+                            <span className="flex items-center justify-center gap-2">
+                                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                Sharing...
+                            </span>
+                        ) : (
+                            'SHARE'
+                        )}
+                    </button>
+                </header>
+
+                <div className="flex-1 overflow-auto px-4 py-5">
+                    {error && (
+                        <div className="mb-5 mx-auto max-w-[420px] p-3 bg-red-50 border border-red-100 rounded-2xl">
+                            <span className="text-sm text-red-700 leading-relaxed">{error}</span>
+                        </div>
+                    )}
+
+                    {selectedCount === 0 ? (
+                        <div className="flex flex-col items-center justify-center text-center px-6 py-16">
+                            <div className="w-16 h-16 rounded-full bg-grayscale-100 flex items-center justify-center mb-4">
+                                <svg
+                                    className="w-8 h-8 text-grayscale-400"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="1.75"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                >
+                                    <rect x="3" y="4" width="18" height="16" rx="3" />
+                                    <path d="M3 9h18" />
+                                    <path d="M8 14h5" />
+                                </svg>
+                            </div>
+                            <h2 className="text-base font-semibold text-grayscale-900">
+                                No credentials selected
+                            </h2>
+                            <p className="text-sm text-grayscale-500 mt-1 max-w-[260px]">
+                                Go back and choose the credentials you'd like to share.
+                            </p>
+                            <button
+                                type="button"
+                                className="mt-5 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors"
+                                onClick={() => handleCloseModal()}
+                            >
+                                Back to Selection
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="flex flex-row flex-wrap items-start justify-center gap-4 pb-6 w-full achievements-list-container [&>ion-col]:!w-[220px] [&>ion-col]:!max-w-[220px] [&>ion-col]:!flex-none [&>ion-col]:!p-0">
+                            {renderCredentialList}
+                        </div>
+                    )}
+                </div>
             </IonRow>
         </IonPage>
     );

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -256,10 +256,10 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                         <div role="presentation" ref={infiniteScrollRef} />
                                     </IonRow>
                                 </IonGrid>
-                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[520px] z-9999 bg-white border-t border-grayscale-200 lg:border lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)] font-poppins">
-                                    <div className="mx-auto w-full max-w-[720px] px-5 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] lg:py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                        <div className="text-center sm:text-left">
-                                            <p className="text-sm font-medium text-grayscale-700">
+                                <footer className="fixed bottom-0 w-full desktop:bottom-5 desktop:right-10 desktop:w-[520px] z-9999 bg-white border-t border-grayscale-200 desktop:border desktop:rounded-[20px] shadow-footer desktop:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)] font-poppins">
+                                    <div className="mx-auto w-full max-w-[720px] px-5 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] desktop:py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                        <div className="text-center sm:text-left shrink-0">
+                                            <p className="text-sm font-medium text-grayscale-700 whitespace-nowrap">
                                                 {selectedVcs?.length}{' '}
                                                 {selectedVcs?.length === 1
                                                     ? 'credential'
@@ -267,20 +267,20 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                                 selected
                                             </p>
                                             {credentialQuery.length > 0 && !hasSuggested && (
-                                                <p className="text-xs text-grayscale-500 mt-0.5">
+                                                <p className="text-xs text-grayscale-500 mt-0.5 whitespace-nowrap">
                                                     Loading suggestions...
                                                 </p>
                                             )}
                                         </div>
                                         <div className="flex items-center gap-3 w-full sm:w-auto">
                                             <button
-                                                className="flex-1 sm:flex-none sm:w-[130px] h-12 rounded-[20px] bg-white border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors"
+                                                className="flex-1 sm:flex-none sm:w-[104px] h-12 rounded-[20px] bg-white border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors"
                                                 onClick={reject}
                                             >
                                                 Quit
                                             </button>
                                             <button
-                                                className="flex-1 sm:flex-none sm:w-[180px] h-12 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+                                                className="flex-1 sm:flex-none sm:w-[150px] h-12 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                                                 onClick={() => presentModal()}
                                                 disabled={selectedVcs?.length === 0 ? true : false}
                                             >

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -201,7 +201,7 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
         <IonPage>
             <IonContent fullscreen>
                 <IonRow className="bg-grayscale-100 w-full flex items-center justify-center h-full">
-                    <IonCol className="text-center p-0 h-full">
+                    <IonCol className="text-center p-0 h-full pt-[env(safe-area-inset-top)]">
                         {!credentialsLoading && (
                             <h1 className="md:text-5xl mobile:text-4xl text-left m-5 md:ml-[5%] min-[1400px]:ml-[100px] text-grayscale-900 font-poppins font-bold">
                                 Select Credentials
@@ -245,7 +245,7 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                         <div role="presentation" ref={infiniteScrollRef} />
                                     </IonRow>
                                 </IonGrid>
-                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[500px] z-9999 bg-white border-t border-grayscale-200 p-2.5 lg:p-5 lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)]">
+                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[500px] z-9999 bg-white border-t border-grayscale-200 p-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] lg:p-5 lg:pb-5 lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)]">
                                     <h1 className="text-left text-base text-grayscale-900 font-bold font-poppins mobile:pt-[5px] mobile:pl-[20px]">
                                         {selectedVcs?.length > 1
                                             ? selectedVcs?.length + ' Credentials'

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -240,12 +240,12 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                     }
                                 />
                                 <IonGrid className="max-w-[1000px] min-[1400px]:ml-[65px]">
-                                    <IonRow className="p-0 flex flex-row items-center flex-wrap w-full mobile:mb-60 xl:mb-64 achievements-list-container">
+                                    <IonRow className="p-0 flex flex-row items-center flex-wrap w-full mb-60 xl:mb-64 achievements-list-container">
                                         {renderCredentialList}
                                         <div role="presentation" ref={infiniteScrollRef} />
                                     </IonRow>
                                 </IonGrid>
-                                <footer className="fixed mobile:bottom-0 mobile:w-full lg:bottom-5 lg:right-10 lg:w-[500px] z-9999 bg-white border-t border-grayscale-200 mobile:p-2.5 lg:p-5 lg:rounded-[20px] mobile:shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)]">
+                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[500px] z-9999 bg-white border-t border-grayscale-200 p-2.5 lg:p-5 lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)]">
                                     <h1 className="text-left text-base text-grayscale-900 font-bold font-poppins mobile:pt-[5px] mobile:pl-[20px]">
                                         {selectedVcs?.length > 1
                                             ? selectedVcs?.length + ' Credentials'
@@ -261,8 +261,8 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                         <button
                                             className={
                                                 selectedVcs?.length === 0
-                                                    ? 'bg-indigo-700 opacity-50 rounded-[40px] text-white font-poppins h-12 mobile:w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
-                                                    : 'bg-indigo-700 rounded-[40px] text-white font-poppins h-12 mobile:w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
+                                                    ? 'bg-indigo-700 opacity-50 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
+                                                    : 'bg-indigo-700 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
                                             }
                                             onClick={() => presentModal()}
                                             disabled={selectedVcs?.length === 0 ? true : false}
@@ -270,7 +270,7 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                             REVIEW
                                         </button>
                                         <button
-                                            className="bg-grayscale-700 rounded-[40px] text-white font-poppins h-12 mobile:w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]"
+                                            className="bg-grayscale-700 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]"
                                             onClick={reject}
                                         >
                                             QUIT

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -15,7 +15,10 @@ import {
     useGetResolvedCredentials,
 } from 'learn-card-base';
 
-import { isVerifiableDataContractCategory } from '../../../helpers/contract.helpers';
+import {
+    isAiContractCategory,
+    isVerifiableDataContractCategory,
+} from '../../../helpers/contract.helpers';
 
 import { getUniqueId } from 'learn-card-base/helpers/credentials/ids';
 import Lottie from 'react-lottie-player';
@@ -104,6 +107,8 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
         // Internal "My Skills Profile" data is self-issued verifiable data, not shareable credentials — exclude it like the wallet does.
         if (isVerifiableDataRecord(credential.record)) return false;
         if (isVerifiableDataContractCategory(credential.category)) return false;
+        // AI session/pathway metadata isn't a real credential and isn't shown in the wallet grid.
+        if (isAiContractCategory(credential.category)) return false;
         if (!credential.loading && !credential.vc) return false;
 
         if (!searchInput) return true;

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -10,9 +10,12 @@ import {
     CredentialCategoryEnum,
     CurrentUser,
     categoryMetadata,
+    isVerifiableDataRecord,
     useGetCredentialList,
     useGetResolvedCredentials,
 } from 'learn-card-base';
+
+import { isVerifiableDataContractCategory } from '../../../helpers/contract.helpers';
 
 import { getUniqueId } from 'learn-card-base/helpers/credentials/ids';
 import Lottie from 'react-lottie-player';
@@ -98,6 +101,9 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
 
     const vcsToDisplay = allCredentials.filter(credential => {
         if (credential.category === 'Hidden') return false;
+        // Internal "My Skills Profile" data is self-issued verifiable data, not shareable credentials — exclude it like the wallet does.
+        if (isVerifiableDataRecord(credential.record)) return false;
+        if (isVerifiableDataContractCategory(credential.category)) return false;
         if (!credential.loading && !credential.vc) return false;
 
         if (!searchInput) return true;
@@ -259,18 +265,14 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                     )}
                                     <section className="flex items-center justify-evenly flex-wrap mt-5">
                                         <button
-                                            className={
-                                                selectedVcs?.length === 0
-                                                    ? 'bg-indigo-700 opacity-50 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
-                                                    : 'bg-indigo-700 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]'
-                                            }
+                                            className="bg-grayscale-900 rounded-[20px] text-white font-poppins font-medium h-12 w-full max-w-[300px] lg:w-[200px] text-base m-1.5 hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                                             onClick={() => presentModal()}
                                             disabled={selectedVcs?.length === 0 ? true : false}
                                         >
                                             REVIEW
                                         </button>
                                         <button
-                                            className="bg-grayscale-700 rounded-[40px] text-white font-poppins h-12 w-full max-w-[300px] lg:w-[200px] text-xl m-1.5 shadow-[0px_4px_0px_0px_rgba(0,0,0,0.25)]"
+                                            className="bg-white border border-grayscale-300 rounded-[20px] text-grayscale-700 font-poppins font-medium h-12 w-full max-w-[300px] lg:w-[200px] text-base m-1.5 hover:bg-grayscale-10 transition-colors"
                                             onClick={reject}
                                         >
                                             QUIT

--- a/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
+++ b/apps/learn-card-app/src/pages/credentialStorage/vpr/VprQueryByExample.tsx
@@ -256,33 +256,38 @@ const VprQueryByExample: React.FC<VprQueryByExampleProps> = ({
                                         <div role="presentation" ref={infiniteScrollRef} />
                                     </IonRow>
                                 </IonGrid>
-                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[500px] z-9999 bg-white border-t border-grayscale-200 p-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] lg:p-5 lg:pb-5 lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)]">
-                                    <h1 className="text-left text-base text-grayscale-900 font-bold font-poppins mobile:pt-[5px] mobile:pl-[20px]">
-                                        {selectedVcs?.length > 1
-                                            ? selectedVcs?.length + ' Credentials'
-                                            : selectedVcs?.length + ' Credential'}{' '}
-                                        Selected
-                                    </h1>
-                                    {credentialQuery.length === 0 || hasSuggested ? (
-                                        <></>
-                                    ) : (
-                                        <span>Loading credential suggestions...</span>
-                                    )}
-                                    <section className="flex items-center justify-evenly flex-wrap mt-5">
-                                        <button
-                                            className="bg-grayscale-900 rounded-[20px] text-white font-poppins font-medium h-12 w-full max-w-[300px] lg:w-[200px] text-base m-1.5 hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
-                                            onClick={() => presentModal()}
-                                            disabled={selectedVcs?.length === 0 ? true : false}
-                                        >
-                                            REVIEW
-                                        </button>
-                                        <button
-                                            className="bg-white border border-grayscale-300 rounded-[20px] text-grayscale-700 font-poppins font-medium h-12 w-full max-w-[300px] lg:w-[200px] text-base m-1.5 hover:bg-grayscale-10 transition-colors"
-                                            onClick={reject}
-                                        >
-                                            QUIT
-                                        </button>
-                                    </section>
+                                <footer className="fixed bottom-0 w-full lg:bottom-5 lg:right-10 lg:w-[520px] z-9999 bg-white border-t border-grayscale-200 lg:border lg:rounded-[20px] shadow-footer lg:shadow-[0px_0px_8px_0px_rgba(0,0,0,0.10)] font-poppins">
+                                    <div className="mx-auto w-full max-w-[720px] px-5 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] lg:py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                        <div className="text-center sm:text-left">
+                                            <p className="text-sm font-medium text-grayscale-700">
+                                                {selectedVcs?.length}{' '}
+                                                {selectedVcs?.length === 1
+                                                    ? 'credential'
+                                                    : 'credentials'}{' '}
+                                                selected
+                                            </p>
+                                            {credentialQuery.length > 0 && !hasSuggested && (
+                                                <p className="text-xs text-grayscale-500 mt-0.5">
+                                                    Loading suggestions...
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="flex items-center gap-3 w-full sm:w-auto">
+                                            <button
+                                                className="flex-1 sm:flex-none sm:w-[130px] h-12 rounded-[20px] bg-white border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors"
+                                                onClick={reject}
+                                            >
+                                                Quit
+                                            </button>
+                                            <button
+                                                className="flex-1 sm:flex-none sm:w-[180px] h-12 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+                                                onClick={() => presentModal()}
+                                                disabled={selectedVcs?.length === 0 ? true : false}
+                                            >
+                                                Review
+                                            </button>
+                                        </div>
+                                    </div>
                                 </footer>
                             </div>
                         )}

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
@@ -19,7 +19,7 @@ import {
     isClrCredential,
 } from 'learn-card-base';
 
-import { BoostCategoryOptionsEnum, boostCategoryMetadata } from 'learn-card-base';
+import { BoostCategoryOptionsEnum, boostCategoryMetadata, getBoostMetadata } from 'learn-card-base';
 
 type CredentialBadgeProps = {
     boostType?: BoostCategoryOptionsEnum;
@@ -73,8 +73,9 @@ export const CredentialBadgeNew: React.FC<CredentialBadgeProps> = ({
     clrLogoSrc,
 }) => {
     const defaultBoostType = BoostCategoryOptionsEnum.socialBadge;
+    // boostType may be a CredentialCategoryEnum with no boostCategoryMetadata entry; getBoostMetadata resolves both enums and falls back to default to avoid a destructuring crash.
     const { subColor, IconComponent, SolidIconComponent, badgeBackgroundColor } =
-        boostCategoryMetadata[boostType ?? defaultBoostType];
+        getBoostMetadata(boostType ?? defaultBoostType) ?? boostCategoryMetadata[defaultBoostType];
 
     let _colorOverride = badgeBackgroundColor ?? 'gray-500';
     let _subColorOverride = subColor ?? 'gray-300';


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

The VPQR / VC-API verification flow (selecting credentials to share with a verifier, then presenting them over an exchange) was broken end to end. This PR gets that whole flow working and cleans up the UX along the way.

#### 🥴 TL; RL:

Sharing credentials via a verification request now actually works — it no longer crashes, no longer shows junk "credentials" that aren't really credentials, no longer fails to sign the presentation, and correctly treats a completed exchange as success instead of an error.

**Before**

<img width="1511" height="903" alt="Screenshot 2026-07-07 at 5 33 13 PM" src="https://github.com/user-attachments/assets/d65cb85e-8be8-4d37-bc5b-48de6523544c" />

**After**

<img width="1499" height="865" alt="Screenshot 2026-07-07 at 5 34 05 PM" src="https://github.com/user-attachments/assets/b12e5b9f-51ad-4091-bda6-bd34b6ddbd61" />


#### How to Test
Go to:
https://verifier.staging.prettygoodskills.com/jobs

And create a skills verification, then go to passport => use a claim link => paste the interaction URL.


#### 💡 Feature Breakdown

**Bugs fixed (the important part):**

- **Crash on the select screen.** Wallets that contain internal "My Skills Profile" items (Self-Assigned Skills, Job Stability, etc.) crashed the badge component because those categories have no badge metadata. Added a safe fallback in `CredentialBadgeNew.tsx`.
- **Sharing failed with "Protected term redefinition."** The presentation was hardcoded to the old VC v1 JSON-LD context, which conflicts when the selected credentials are VC v2. Now the VP is built with `wallet.invoke.newPresentation(...)` so the correct context is used and the signing suite context is injected automatically (`VCToShare.tsx`).
- **Silent failures.** The share `catch` block swallowed the real error. It now logs the underlying error so failures are diagnosable.
- **Empty `{}` exchange response treated as an error.** Per the VC-API spec, an empty 2xx response after presenting means the exchange is complete. We now treat this as an implicit success and show a success screen instead of the error screen (`ClaimFromRequest.tsx`).
- **"Quit" did nothing in the exchange flow.** It only worked for the CHAPI path; in the VC-API path the reject handler just logged. Quit now exits back home.

**Noise removed from the share list:**

- Internal verifiable-data ("My Skills Profile") and AI session/pathway metadata are no longer listed as shareable credentials — matching what the wallet already hides. This is a targeted blocklist (not the wallet's 7-category allow-list) so real credentials like courses, memberships, merit badges, and IDs still show.

**UI/UX cleanup on `VprQueryByExample.tsx` and `VCToShare.tsx`:**

- Fixed the mobile footer being invisible (it used a `mobile:` breakpoint that only applies ≥991px, so real phones got no styles — the Review/Quit bar disappeared).
- Added top/bottom safe-area insets.
- Restyled Review/Quit/Share buttons to the app's design tokens (dropped the off-limits indigo + hard shadows).
- Redesigned the Review modal header, added a proper empty state, and fixed the squished review cards.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

Use a VC-API verification request that runs an exchange (tested against a `transactions.staging.prettygoodskills.com/workflows/verify/exchanges/...` link).

1. Open the verification request in the app. You land on the "Select Credentials" screen.
2. Confirm internal items (Self-Assigned Skills, Job Stability, Work Life Balance, Professional Title, Role Experience) and AI items (Learning Pathway, AI sessions) are **not** listed — but normal credentials still are.
3. Select one or more credentials → **Review**. Cards should look clean (not squished), header looks right.
4. Deselect everything in Review → you should see a proper empty state.
5. **Share.** The exchange completes and you should see a success screen (not an error), even though the server responds with `{}`.
6. Back on the select screen, tap **Quit** → it should return you home.
7. On a phone/small viewport, confirm the Review/Quit bar is visible and tappable (it was previously missing on mobile).

#### 📱 🖥 Which devices would you like help testing on?

iOS Native / Android Native / Chromium — especially mobile viewports for the footer + safe areas.

# Documentation

#### 💭 Documentation Notes

No user-facing or SDK docs needed — this is a bug-fix + UX pass on an existing app flow with no API changes.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix credential verification flow to properly handle VC-API empty responses, improve UI/UX for credential sharing, and filter internal data records from presentation requests.

Main changes:
- Added `isAiContractCategory` helper and filtering logic to exclude AI contracts and verifiable data records from credential selection in VPR
- Implemented empty response handling in exchange flow to recognize implicit success on 2xx with no body, with new `ExchangeSuccessDisplay` component
- Refactored VCToShare and VprQueryByExample UI layouts with improved footer positioning, error handling, and credential count display
- Fixed response parsing to handle non-JSON responses and added optional `onCancel` callback to ExchangePresentationRequest
- Updated CredentialBadgeNew to safely resolve boost metadata with fallback to avoid destructuring errors

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
