### PR TITLE
fix: Add Journeys Back

### DIFF
--- a/.changeset/stale-bananas-jam.md
+++ b/.changeset/stale-bananas-jam.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: Add Journeys Back

--- a/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
@@ -10,9 +10,14 @@ import ProfileAlertsIsland from '../../components/main-header/ProfileAlertsIslan
 import AppStoreDetailModal from '../launchPad/AppStoreDetailModal';
 import AppGrid from './AppGrid';
 import AppGridTile from './AppGridTile';
-import { LEARNCARD_APP_SHORTCUTS, LearnCardAppShortcut } from './learnCardAppShortcuts';
+import {
+    LEARNCARD_APP_SHORTCUTS,
+    JOURNEYS_SHORTCUT,
+    LearnCardAppShortcut,
+} from './learnCardAppShortcuts';
 import useOpenBoostTemplateSelector from './useOpenBoostTemplateSelector';
 import useMoreApps from './useMoreApps';
+import { usePathwaysEnabled } from '../pathways/hooks/usePathwaysEnabled';
 
 const DEEP_LINK_PARAMS = ['connectTo', 'uri', 'embedUrl'];
 
@@ -36,6 +41,15 @@ const MyAppsLanding: React.FC = () => {
     const openBoost = useOpenBoostTemplateSelector();
     const { apps: moreApps, isSuggested, isLoading: isLoadingMore } = useMoreApps();
     const [searchInput, setSearchInput] = useState('');
+    const pathwaysEnabled = usePathwaysEnabled();
+
+    const shortcuts = useMemo(
+        () =>
+            pathwaysEnabled
+                ? [JOURNEYS_SHORTCUT, ...LEARNCARD_APP_SHORTCUTS]
+                : LEARNCARD_APP_SHORTCUTS,
+        [pathwaysEnabled]
+    );
 
     // Existing /launchpad deep-link flows (partner connect, consent, embed) are
     // handled by the browse view — hand them off, preserving the query string.
@@ -170,7 +184,7 @@ const MyAppsLanding: React.FC = () => {
                     ) : (
                         <>
                             <AppGrid heading="LearnCard Apps">
-                                {LEARNCARD_APP_SHORTCUTS.map(renderShortcutTile)}
+                                {shortcuts.map(renderShortcutTile)}
                             </AppGrid>
 
                             <AppGrid heading="More Apps">

--- a/apps/learn-card-app/src/pages/myApps/learnCardAppShortcuts.tsx
+++ b/apps/learn-card-app/src/pages/myApps/learnCardAppShortcuts.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { AiInsightsIconWithShape } from 'learn-card-base/svgs/wallet/AiInsightsIcon';
 import { AiPathwaysIconWithShape } from 'learn-card-base/svgs/wallet/AiPathwaysIcon';
+import { ExperiencesIconWithShape } from 'learn-card-base/svgs/wallet/ExperiencesIcon';
 import { AiSessionsIconWithShape } from 'learn-card-base/svgs/wallet/AiSessionsIcon';
 import { SkillsIconWithShape } from 'learn-card-base/svgs/wallet/SkillsIcon';
 import { FamiliesIconWithShape } from 'learn-card-base/svgs/wallet/FamiliesIcon';
@@ -28,6 +29,33 @@ export type LearnCardAppShortcut = {
 };
 
 const route = (path: string) => (h: ShortcutActionHelpers) => () => h.push(path);
+
+// Retint the reused Experiences icon into the indigo family so it reads as one
+// cohesive tile on the indigo gradient (indigo = Pathways v2 wayfinding accent).
+// Yellow summit flag kept as the one warm focal pop.
+const JourneysTileIcon: React.FC<{ className?: string }> = props => (
+    <ExperiencesIconWithShape
+        {...props}
+        palette={{
+            primary: '#C7D2FE',
+            primaryLight: '#E0E7FF',
+            accent: '#FEF08A',
+            stroke: '#4F46E5',
+        }}
+    />
+);
+
+// Kept out of LEARNCARD_APP_SHORTCUTS: MyAppsLanding renders this only when
+// usePathwaysEnabled() passes, so the tile can't drift from the (identically
+// gated) /pathways route. Icon is a placeholder until design ships a real one.
+export const JOURNEYS_SHORTCUT: LearnCardAppShortcut = {
+    key: 'journeys',
+    title: 'Journeys',
+    gradientFrom: '#A5B4FC',
+    gradientTo: '#6366F1',
+    Icon: JourneysTileIcon,
+    getAction: route('/pathways'),
+};
 
 export const LEARNCARD_APP_SHORTCUTS: LearnCardAppShortcut[] = [
     {


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

The recent My Apps / launchpad reorg left Pathways v2 ("Journeys") with no entry point on the new My Apps landing. The `/pathways` route was still mounted and gated correctly, but the only way in was the side-menu link — so even with the feature flag on, users couldn't reach Journeys from the main hub.

This adds a "Journeys" tile back to the "LearnCard Apps" grid on the My Apps landing.

<img width="884" height="268" alt="Screenshot 2026-07-08 at 11 56 37 AM" src="https://github.com/user-attachments/assets/42cd0457-0f35-4a98-a546-a97f42062516" />

#### 🥴 TL; RL:

Adds a Journeys tile to My Apps that links to `/pathways`, shown only when the feature is enabled.

#### 💡 Feature Breakdown

- New `JOURNEYS_SHORTCUT` in `learnCardAppShortcuts.tsx`, linking to `/pathways`.
- `MyAppsLanding.tsx` prepends the tile to the shortcuts grid, gated by `usePathwaysEnabled()` — the same hook that gates the route, so the tile and route can never drift (no tile pointing at an unmounted route).
- The tile reuses the existing Experiences (mountain + flag) icon, retinted into the indigo family to match the tile gradient. Indigo is the Pathways v2 wayfinding accent. This is a placeholder until design ships a dedicated Journeys icon.

#### 🛠 Important tradeoffs made:

`JOURNEYS_SHORTCUT` is kept out of the static `LEARNCARD_APP_SHORTCUTS` array because it needs a runtime flag check; the array itself has no flag awareness.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

Journeys visibility requires **both** the tenant `features.pathways` config **and** the `enableJourneys` LaunchDarkly flag to be on (see `usePathwaysEnabled.ts`).

1. With `enableJourneys` **off** for your user: open My Apps → confirm there is **no** Journeys tile.
2. With `enableJourneys` **on**: open My Apps → a "Journeys" tile appears first in the "LearnCard Apps" grid.
3. Tap the tile → lands on `/pathways` (redirects to the map or onboarding depending on whether you have an active pathway).
4. Confirm the tile icon (mountain + flag) reads cleanly on the indigo gradient.

#### 📱 🖥 Which devices would you like help testing on?

Chromium / iOS / Android

#### 🧪 Code Coverage

No new tests — small UI wiring change; visibility logic is the existing, already-covered `usePathwaysEnabled` gate.

# Documentation

#### 💭 Documentation Notes

No docs needed — restores an existing entry point behind an existing feature flag. No API changes.
