### PR TITLE
fix: align Boosts→Badges terminology in wallet category (LCA)

### DIFF
--- a/.changeset/tired-readers-stop.md
+++ b/.changeset/tired-readers-stop.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: align Boosts→Badges terminology in wallet category (LCA)

--- a/apps/learn-card-app/src/components/boost/boost-options/boostOptions.ts
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostOptions.ts
@@ -39,7 +39,7 @@ export const boostVCTypeOptions = {
     [BoostUserTypeEnum.self]: [
         {
             id: 1,
-            title: 'Boosts',
+            title: 'Badges',
             IconComponent: BoostsIcon,
             iconClassName: 'text-white',
             iconCircleClass: 'bg-blue-500',
@@ -131,7 +131,7 @@ export const boostVCTypeOptions = {
         },
         {
             id: 1,
-            title: 'Boosts',
+            title: 'Badges',
             IconComponent: BoostsIcon,
             iconClassName: 'text-white',
             iconCircleClass: 'bg-blue-500',

--- a/apps/learn-card-app/src/components/boost/boost-options/boostVCTypeOptions/BoostVCTypeOptions.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostVCTypeOptions/BoostVCTypeOptions.tsx
@@ -169,7 +169,7 @@ export const BoostVCTypeOptions: React.FC<BoostVCTypeOptionsProps> = ({
                                 className="bg-cyan-100 text-grayscale-900 text-[17px] py-1.5 rounded-[20px] font-poppins font-semibold w-full h-[50px] flex justify-center items-center shadow-[0px_2px_3px_rgba(0,0,0,0.25)]"
                             >
                                 <BoostWizardIcon className="w-[45px]" />
-                                AI Boost Wizard
+                                AI Badge Wizard
                             </button>
                         )}
                         <button

--- a/apps/learn-card-app/src/components/boost/boost-options/boostVCTypeOptions/BoostWizard.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostVCTypeOptions/BoostWizard.tsx
@@ -85,7 +85,7 @@ const BoostWizard: React.FC<BoostWizardProps> = ({ boostUserType }) => {
         initializeWallet();
     }, [initWallet]);
 
-    const title = 'AI Boost Wizard';
+    const title = 'AI Badge Wizard';
     const boostOptions = boostVCTypeOptions[boostUserType];
 
     const subtext =

--- a/apps/learn-card-app/src/components/boost/boost-select-menu/BoostSelectMenu.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-select-menu/BoostSelectMenu.tsx
@@ -163,7 +163,7 @@ const BoostSelectMenu: React.FC<BoostSelectMenuProps> = ({
                         }}
                     >
                         <Wand color="#FFFFFF" opacity="full" className="mr-[10px]" />
-                        AI Boost Wizard
+                        AI Badge Wizard
                     </button>
                 </IonCol>
             </IonRow>
@@ -222,7 +222,11 @@ const BoostSelectMenu: React.FC<BoostSelectMenuProps> = ({
                             <div className="flex flex-col w-full h-full items-center justify-center">
                                 <div className="max-w-[160px] m-auto flex justify-center  min-h-[50px]"></div>
                                 <p className="mt-2 font-poppins text-xl text-grayscale-900">
-                                    No Boosts yet!
+                                    {`No ${
+                                        selectedVCType === BoostCategoryOptionsEnum.all
+                                            ? 'Boosts'
+                                            : title
+                                    } yet!`}
                                 </p>
                             </div>
                         )}

--- a/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateSelectorBody.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateSelectorBody.tsx
@@ -245,7 +245,13 @@ const BoostTemplateSelectorBody: React.FC<BoostTemplateSelectorBodyProps> = ({
                     {!boostsLoading && boostsList?.length === 0 && (
                         <div className="flex flex-col w-full h-full items-center justify-center">
                             <p className="mt-2 font-poppins text-xl text-grayscale-900">
-                                {searchInput ? 'No results found' : 'No Boosts yet!'}
+                                {searchInput
+                                    ? 'No results found'
+                                    : `No ${
+                                          selectedCategory === BoostCategoryOptionsEnum.all
+                                              ? 'Boosts'
+                                              : boostCategoryMetadata[selectedCategory].title
+                                      } yet!`}
                             </p>
                         </div>
                     )}

--- a/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateSelectorFooter.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateSelectorFooter.tsx
@@ -85,7 +85,7 @@ const BoostTemplateSelectorFooter: React.FC<BoostTemplateSelectorFooterProps> = 
                 }}
                 className="bg-cyan-101 text-grayscale-900 text-[17px] px-[20px] py-[5px] rounded-[40px] font-poppins font-[600] w-full flex gap-[5px] justify-center items-center shadow-button-bottom border-[2px] border-solid border-white mb-[10px] max-w-[600px] mx-auto"
             >
-                AI Boost Wizard
+                AI Badge Wizard
                 <BoostWizardIcon className="h-[35px] w-[35px]" />
             </button>
             <div className="max-w-[600px] flex items-center justify-between mx-auto w-full gap-[10px]">

--- a/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateTypeModal.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-template/BoostTemplateTypeModal.tsx
@@ -56,7 +56,7 @@ const BoostTemplateTypeModal: React.FC<BoostTemplateTypeModalProps> = ({
                         autocapitalize="on"
                         value={boostType}
                         onIonInput={e => setBoostType(e?.detail?.value)}
-                        placeholder="Boost type..."
+                        placeholder={`${titleSingular} type...`}
                         className="relative bg-grayscale-100 text-grayscale-900 placeholder:text-grayscale-500 rounded-[15px] px-[15px] py-[5px]"
                         rows={3}
                         maxlength={22}

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
@@ -97,7 +97,7 @@ export const useVerification = (credential: VC) => {
 const RibbonCategory: React.FC<{ categoryType: BoostCategoryOptionsEnum }> = ({ categoryType }) => {
     switch (categoryType) {
         case BoostCategoryOptionsEnum.socialBadge:
-            return <span className="text-[12px] font-semibold text-blue-500">Boost</span>;
+            return <span className="text-[12px] font-semibold text-blue-500">Badge</span>;
         case BoostCategoryOptionsEnum.achievement:
             return <span className="text-[12px] font-semibold text-pink-400">Achievement</span>;
         case BoostCategoryOptionsEnum.learningHistory:

--- a/apps/learn-card-app/src/components/category-descriptor/CategoryDescriptorModal.tsx
+++ b/apps/learn-card-app/src/components/category-descriptor/CategoryDescriptorModal.tsx
@@ -23,7 +23,7 @@ const CategoryDescriptorModal: React.FC<{
                 category = BoostCategoryOptionsEnum.learningHistory;
                 break;
 
-            case 'Boosts':
+            case 'Badges':
                 imgSrc = walletSubtypeToDefaultImageSrc(WalletCategoryTypes.socialBadges);
                 category = BoostCategoryOptionsEnum.socialBadge;
                 break;

--- a/apps/learn-card-app/src/components/learncard/checklist/checklist-steps/AchievementTypeSelectorModal.tsx
+++ b/apps/learn-card-app/src/components/learncard/checklist/checklist-steps/AchievementTypeSelectorModal.tsx
@@ -17,7 +17,7 @@ const CATEGORY_DISPLAY_LABELS: Record<string, string> = {
     'Work History': 'Experiences',
     'Learning History': 'Studies',
     'Achievement': 'Achievements',
-    'Social Badge': 'Boosts',
+    'Social Badge': 'Badges',
     'ID': 'IDs',
     'Membership': 'Membership',
 };

--- a/apps/learn-card-app/src/components/main-subheader/MainSubHeader.types.ts
+++ b/apps/learn-card-app/src/components/main-subheader/MainSubHeader.types.ts
@@ -79,7 +79,7 @@ export const SubheaderContentType: Record<
         helperTextClickable: 'learning journey',
     },
     [SubheaderTypeEnum.SocialBadge]: {
-        title: 'Boosts',
+        title: 'Badges',
         IconComponent: BoostsIcon,
         iconColor: 'text-blue-700',
         iconPadding: 'pt-[3.75px] pr-[6.75px] pb-[4.622px] pl-[5.75px]',

--- a/apps/learn-card-app/src/pages/launchPad/CredentialCard.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/CredentialCard.tsx
@@ -38,7 +38,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ record, isNew, index })
     const categoryDisplayMap: Record<string, string> = {
         'Learning History': 'Studies',
         'Work History': 'Experiences',
-        'Social Badge': 'Boosts',
+        'Social Badge': 'Badges',
         'Accomodation': 'Assistance',
         'Accomplishment': 'Portfolio',
     };

--- a/apps/learn-card-app/src/pages/wallet/CredentialPage.tsx
+++ b/apps/learn-card-app/src/pages/wallet/CredentialPage.tsx
@@ -45,7 +45,7 @@ const categoryToConfig: Record<string, CategoryConfig> = {
         boostCategory: CredentialCategoryEnum.socialBadge, // category
         subheaderType: SubheaderTypeEnum.SocialBadge, // header type
 
-        title: 'Boosts',
+        title: 'Badges',
         iconColor: 'text-blue-700',
         dividerLineColor: 'blue-400',
         searchInputColor: 'blue-400',

--- a/apps/learn-card-app/src/pages/wallet/constants.ts
+++ b/apps/learn-card-app/src/pages/wallet/constants.ts
@@ -126,7 +126,7 @@ export const walletPageData: WalletPageItem[] = [
     },
     {
         id: 5,
-        title: 'Boosts',
+        title: 'Badges',
         bgColor: 'bg-blue-300',
         bgColorSecondary: 'bg-blue-500',
         subtype: WalletCategoryTypes.socialBadges,

--- a/packages/learn-card-base/src/components/sidemenu/sidemenuHelpers.ts
+++ b/packages/learn-card-base/src/components/sidemenu/sidemenuHelpers.ts
@@ -196,7 +196,7 @@ export const sidemenuLinks: Record<BrandingEnum, SideMenuLinks[]> = {
         },
         {
             id: 2,
-            name: 'Boosts',
+            name: 'Badges',
             IconComponent: BoostsTwoTonedIcon,
             path: '/socialBadges',
             type: SideMenuLinksEnum.socialBadges,

--- a/packages/learn-card-base/src/types/boostAndCredentialMetadata.ts
+++ b/packages/learn-card-base/src/types/boostAndCredentialMetadata.ts
@@ -199,10 +199,10 @@ export type BoostCategoryMetadata = {
 // ! MUST ALIGN WITH -> learn-card-base/src/components/issueVC -> constants.ts -> { AchievementTypes }
 export const boostCategoryMetadata: Record<BoostCategoryOptionsEnum, BoostCategoryMetadata> = {
     [BoostCategoryOptionsEnum.socialBadge]: {
-        displayName: 'Boost',
-        title: 'Boosts',
-        titleSingular: 'Boost',
-        plural: 'Boosts',
+        displayName: 'Badge',
+        title: 'Badges',
+        titleSingular: 'Badge',
+        plural: 'Badges',
 
         // scouts
         subTitle: 'Social Boost',


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

_None linked yet — follow-up cleanup to the LCA redesign that renamed the `Boosts` wallet category to `Badges`. Happy to attach a ticket._

#### 📚 What is the context and goal of this PR?

The LCA redesign renamed the `socialBadge` wallet category from **"Boosts"** to **"Badges"**, but the rename only landed in **one** of the app's two sources of category display names:

- **Theme labels** (`defaultCategories.ts` → `labels: { singular: 'Badge', plural: 'Badges' }`), read by `MainSubHeader` — these were updated, so the category page header already reads "Badges".
- **`boostCategoryMetadata`** (`packages/learn-card-base/.../boostAndCredentialMetadata.ts`), read by the **boost-creation / template flow** — these still said "Boost(s)".

The result was inconsistent terminology: the wallet page said "Badges" while the category filter, the "New Boost" modal, and the template picker still said "Boosts".

Goal: make the **category noun** read "Badge(s)" everywhere a user sees it, while **keeping "Boost" as the verb / generic product concept** (the `/boost` template system, "New Template", boosting someone).

#### 🥴 TL; RL:

Renamed the `socialBadge` category's **display** name from "Boost(s)" → "Badge(s)" across the creation flow, filter, side menu, and card ribbon (data keys untouched). "Boost" stays as the verb. Also fixed a crash and renamed the AI wizard to **"AI Badge Wizard"** per product.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

**Category label "Boost(s)" → "Badge(s)":**
- `boostAndCredentialMetadata.ts` — `displayName / title / titleSingular / plural` for `socialBadge` (the central object; cascades to the **category filter**, the **template-picker header**, and the **"New Badge" modal** title)
- `sidemenuHelpers.ts` — side-menu link
- `BoostPreview.tsx` — card category ribbon
- `wallet/constants.ts`, `CredentialPage.tsx`, `launchPad/CredentialCard.tsx`, `AchievementTypeSelectorModal.tsx`, `MainSubHeader.types.ts`, `boostOptions.ts` — display labels / maps

**🐞 Bug fix — `CategoryDescriptorModal.tsx`:** the "social milestones." link on the Badges page threw `Error('Invalid title provided')`, because the theme now passes `"Badges"` but the modal's `switch` only matched `"Boosts"` (fell through to `default`). Updated the case to `"Badges"`.

**Category-aware copy:**
- `BoostTemplateTypeModal.tsx` — placeholder `"Boost type…"` → `` `${titleSingular} type…` `` → "Badge type…" under Badges
- `BoostTemplateSelectorBody.tsx` + `BoostSelectMenu.tsx` — `"No Boosts yet!"` → `` `No ${category} yet!` `` (generic "Boosts" kept only for the "All" aggregate)

**AI wizard:** "AI Boost Wizard" → **"AI Badge Wizard"** (all 4 usages).

#### 🛠 Important tradeoffs made:

- **Kept "Boost" as the verb / generic product term** — "Boost Myself/Others", "New Template", the `/boost` system, and non-Badge empty states (`BoostGroupedBySkillsModal`, `BoostManagedIDCard`) are unchanged.
- **The AI wizard was renamed globally** to "AI Badge Wizard" (per product), even though it can build other categories and appears in the "All" menu — chosen over a category-aware label for simplicity.
- **Data vs. display:** enum string values (`'Social Badge'`), the icon-**palette** key (`loadJsonTheme` `CATEGORY_TO_PALETTE_KEY[socialBadge] = 'Boosts'`), and `walletFolder` keys were intentionally **left untouched** — changing them would break lookups.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

In the LearnCard app, in the **Badges** category:
1. Open the **category filter** dropdown → the entry reads **"Badges"** (was "Boosts").
2. **+ / New** → the modal title reads **"New Badge"** with placeholder **"Badge type…"**.
3. **Template picker** → header reads **"Badges"**; footer button reads **"AI Badge Wizard"**.
4. On the Badges wallet page, tap **"social milestones."** → the descriptor modal opens (previously threw `Invalid title provided`).
5. Sanity-check a non-Badge category (e.g. Achievements) still reads its own label ("New Achievement", "Achievement type…").

#### 📱 🖥 Which devices would you like help testing on?

Chromium / iOS Simulator.

#### 🧪 Code Coverage

No automated tests added — this is a display-string change with no logic branching beyond simple category-aware fallbacks. Verified statically: `tsc --noEmit` error count is **identical with and without this diff (2044 → 2044)**, i.e. **zero new type errors**. Live end-to-end QA in the running app is still pending (see checklist).

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs**

-   [ ] Tutorial
-   [ ] How-To Guide
-   [ ] Reference
-   [ ] Concept
-   [ ] App Flows

**Internal/AI Docs**

-   [ ] AGENTS.md
-   [ ] Code comments/JSDoc

**Visual Documentation**

-   [ ] Mermaid diagram

#### 💭 Documentation Notes

Terminology-only change to existing UI. No API, SDK, flow, or architecture changes, so no docs updates are required.

# ✅ PR Checklist

-   [ ] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier — lint-staged ran Prettier on commit)
-   [ ] I have **manually tested** common end-2-end cases <!-- static/typecheck only so far; live QA pending -->
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes <!-- not run; typecheck baseline unchanged -->
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (no new events — label-only change)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible (display-only; enum values, palette keys, and wallet-folder keys unchanged)
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)
