### PR TITLE
fix: App page tile icons + More Apps launch behavior (LC-1928)

### DIFF
--- a/.changeset/calm-poets-marry.md
+++ b/.changeset/calm-poets-marry.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: App page tile icons + More Apps launch behavior 

--- a/apps/learn-card-app/src/pages/launchPad/AppStoreListItem.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/AppStoreListItem.tsx
@@ -1,21 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import type { AppStoreListing, InstalledApp } from '@learncard/types';
 
 import { IonItem, IonSpinner } from '@ionic/react';
-import { useModal, ModalTypes, useWallet } from 'learn-card-base';
-import { ShieldAlert } from 'lucide-react';
 import { ThreeDotVertical } from '@learncard/react';
 
 import useTheme from '../../theme/hooks/useTheme';
 import { ColorSetEnum } from '../../theme/colors';
-import AppStoreDetailModal from './AppStoreDetailModal';
-import { EmbedIframeModal } from './EmbedIframeModal';
-import { useConsentFlowByUri } from '../consentFlow/useConsentFlow';
-import GuardianConsentLaunchModal from './GuardianConsentLaunchModal';
-import AiTutorConnectedView from './AiTutorConnectedView';
-import { useGuardianGate } from '../../hooks/useGuardianGate';
-import { checkAppInstallEligibility } from '@learncard/helpers';
-import { openExternalLink } from '../../helpers/externalLinkHelpers';
+import useAppLaunch from './useAppLaunch';
 
 type AppStoreListItemProps = {
     listing: AppStoreListing | InstalledApp;
@@ -33,240 +24,17 @@ const AppStoreListItem: React.FC<AppStoreListItemProps> = ({
     const { getColorSet } = useTheme();
     const colors = getColorSet(ColorSetEnum.launchPad);
 
-    const { newModal, closeModal } = useModal({
-        desktop: ModalTypes.Right,
-        mobile: ModalTypes.Right,
-    });
-
     const buttonClass = `flex items-center justify-center rounded-full font-[600] px-[20px] py-[5px] normal text-base font-poppins ${colors?.buttons?.unconnected}`;
     const connectedButtonClass = `flex items-center justify-center rounded-full font-[600] px-[20px] py-[5px] normal text-base font-poppins ${colors?.buttons?.connected}`;
 
-    // Parse launch config
-    const launchConfig = useMemo(() => {
-        try {
-            return JSON.parse(listing.launch_config_json);
-        } catch {
-            return {};
-        }
-    }, [listing.launch_config_json]);
-
-    // Consent flow hooks for redirect on launch
-    const contractUri: string | undefined = launchConfig?.contractUri;
-    const { contract, hasConsented } = useConsentFlowByUri(contractUri);
-
-    const { initWallet } = useWallet();
-
-    // Guardian gate for child profiles
-    const { userAge, isChildProfile } = useGuardianGate();
-
-    // Separate min_age (hard block) from age_rating (soft block with guardian approval)
-    const listingAny = listing as any;
-    const minAge: number | undefined = listingAny.min_age;
-    const ageRating: string | undefined = listingAny.age_rating;
-
-    // Hard block: min_age violation (hide app entirely, block installation)
-    // Only applies when userAge is known
-    const isHardBlocked = useMemo(
-        () =>
-            checkAppInstallEligibility({
-                isChildProfile,
-                userAge,
-                minAge,
-                ageRating,
-                hasContract: Boolean(contractUri),
-            }).action === 'hard_blocked',
-        [ageRating, contractUri, isChildProfile, minAge, userAge]
-    );
-
-    // Show age restriction blocked modal
-    const showAgeBlockedModal = () => {
-        newModal(
-            <div className="flex flex-col h-full w-full bg-white max-w-[500px] mx-auto">
-                <div
-                    className="border-b border-grayscale-200 p-6"
-                    style={{ paddingTop: 'max(1.5rem, env(safe-area-inset-top))' }}
-                >
-                    <h2 className="text-2xl font-bold text-grayscale-900 text-center">
-                        Age Restricted
-                    </h2>
-                </div>
-
-                <div className="flex-1 p-6 overflow-auto">
-                    <div className="flex flex-col items-center text-center space-y-4">
-                        <div className="w-20 h-20 rounded-full bg-red-100 flex items-center justify-center">
-                            <ShieldAlert className="w-10 h-10 text-red-600" />
-                        </div>
-
-                        <div className="w-16 h-16 rounded-2xl overflow-hidden bg-grayscale-100 flex items-center justify-center shadow-md">
-                            <img
-                                src={listing.icon_url}
-                                alt={listing.display_name}
-                                className="w-full h-full object-cover"
-                                onError={e => {
-                                    (e.target as HTMLImageElement).src =
-                                        'https://cdn.filestackcontent.com/Ja9TRvGVRsuncjqpxedb';
-                                }}
-                            />
-                        </div>
-
-                        <div>
-                            <p className="text-lg font-semibold text-grayscale-900 mb-2">
-                                {listing.display_name}
-                            </p>
-
-                            <p className="text-sm text-grayscale-600">
-                                This app requires users to be <strong>{minAge}+</strong> years old.
-                            </p>
-                        </div>
-
-                        <div className="bg-red-50 border border-red-100 rounded-lg p-4 w-full text-left">
-                            <p className="text-sm text-red-800">
-                                Based on your profile's date of birth, you do not meet the minimum
-                                age requirement for this app.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
-                <div
-                    className="flex items-center justify-center gap-4 p-6 border-t border-grayscale-200 bg-white"
-                    style={{
-                        paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
-                    }}
-                >
-                    <button
-                        onClick={closeModal}
-                        className="px-8 py-3 text-lg font-semibold text-white bg-grayscale-600 rounded-full hover:bg-grayscale-700 transition-colors"
-                    >
-                        OK
-                    </button>
-                </div>
-            </div>,
-            {
-                sectionClassName: '!max-w-[500px]',
-                hideButton: true,
-            },
-            { desktop: ModalTypes.Center, mobile: ModalTypes.FullScreen }
-        );
-    };
-
-    const handleOpenDetail = () => {
-        newModal(
-            <AppStoreDetailModal
-                listing={listing}
-                isInstalled={isInstalled}
-                onInstallSuccess={onInstallSuccess}
-            />
-        );
-    };
-
-    const proceedWithLaunch = async () => {
-        // For consent flow apps, redirect with did and delegate VP
-        if (hasConsented && contract) {
-            // Guardian consent apps need profile selection flow
-            if (contract.needsGuardianConsent) {
-                const redirectUrl =
-                    launchConfig.redirectUri?.trim() || contract.redirectUrl?.trim();
-
-                if (redirectUrl) {
-                    newModal(
-                        <GuardianConsentLaunchModal
-                            contractDetails={contract}
-                            redirectUrl={redirectUrl}
-                        />,
-                        { sectionClassName: '!bg-transparent !shadow-none' },
-                        { desktop: ModalTypes.Center, mobile: ModalTypes.FullScreen }
-                    );
-                    return;
-                }
-            }
-
-            // Prefer app listing URL, then contract redirectUrl
-            const redirectUrl = launchConfig.redirectUri?.trim() || contract.redirectUrl?.trim();
-
-            if (redirectUrl) {
-                const wallet = await initWallet();
-                const urlObj = new URL(redirectUrl);
-
-                // Add user's did to redirect url
-                urlObj.searchParams.set('did', wallet.id.did());
-
-                // Add delegate credential VP if contract has an owner
-                if (contract.owner?.did) {
-                    const unsignedDelegateCredential = wallet.invoke.newCredential({
-                        type: 'delegate',
-                        subject: contract.owner.did,
-                        access: ['read', 'write'],
-                    });
-
-                    const delegateCredential = await wallet.invoke.issueCredential(
-                        unsignedDelegateCredential
-                    );
-
-                    const unsignedDidAuthVp = await wallet.invoke.newPresentation(
-                        delegateCredential
-                    );
-
-                    const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
-                        proofPurpose: 'authentication',
-                        proofFormat: 'jwt',
-                    })) as any as string;
-
-                    urlObj.searchParams.set('vp', vp);
-                }
-
-                window.open(urlObj.toString(), '_blank');
-                return;
-            }
-        }
-
-        // AI Tutor apps - open full connected view with topics
-        if ((listing.launch_type as string) === 'AI_TUTOR' && launchConfig.aiTutorUrl) {
-            newModal(
-                <AiTutorConnectedView
-                    listing={listing}
-                    launchConfig={{
-                        aiTutorUrl: launchConfig.aiTutorUrl,
-                        contractUri: launchConfig.contractUri,
-                    }}
-                />
-            );
-            return;
-        }
-
-        // Default launch behavior
-        if (listing.launch_type === 'EMBEDDED_IFRAME' && launchConfig.url) {
-            newModal(
-                <EmbedIframeModal
-                    embedUrl={launchConfig.url}
-                    appId={(listing as any).slug || listing.listing_id}
-                    appName={listing.display_name}
-                    launchConfig={launchConfig}
-                    isInstalled={isInstalled || !!installedAt}
-                />
-            );
-        } else if (listing.launch_type === 'DIRECT_LINK' && launchConfig.url) {
-            await openExternalLink(launchConfig.url);
-        } else if (listing.launch_type === 'SECOND_SCREEN' && launchConfig.url) {
-            window.open(launchConfig.url, '_blank');
-        } else {
-            // Fallback to opening detail modal if launch type is not configured
-            handleOpenDetail();
-        }
-    };
-
-    const handleLaunch = async () => {
-        // Hard block: min_age violation - show blocked modal
-        if (isHardBlocked) {
-            showAgeBlockedModal();
-            return;
-        }
-
-        await proceedWithLaunch();
-    };
-
-    // Check if this is an InstalledApp (has installed_at property)
-    const installedAt = 'installed_at' in listing ? listing.installed_at : null;
+    const {
+        handleLaunch,
+        handleOpenDetail,
+        showAgeBlockedModal,
+        isHardBlocked,
+        launchConfig,
+        installedAt,
+    } = useAppLaunch({ listing, isInstalled, onInstallSuccess });
 
     // Hide app entirely if user is hard-blocked by min_age
     if (isHardBlocked) {

--- a/apps/learn-card-app/src/pages/launchPad/useAppLaunch.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/useAppLaunch.tsx
@@ -1,0 +1,276 @@
+import React, { useMemo } from 'react';
+import type { AppStoreListing, InstalledApp } from '@learncard/types';
+
+import { useModal, ModalTypes, useWallet } from 'learn-card-base';
+import { ShieldAlert } from 'lucide-react';
+import { checkAppInstallEligibility } from '@learncard/helpers';
+
+import { useConsentFlowByUri } from '../consentFlow/useConsentFlow';
+import { useGuardianGate } from '../../hooks/useGuardianGate';
+import { openExternalLink } from '../../helpers/externalLinkHelpers';
+import AppStoreDetailModal from './AppStoreDetailModal';
+import { EmbedIframeModal } from './EmbedIframeModal';
+import GuardianConsentLaunchModal from './GuardianConsentLaunchModal';
+import AiTutorConnectedView from './AiTutorConnectedView';
+
+const FALLBACK_ICON = 'https://cdn.filestackcontent.com/Ja9TRvGVRsuncjqpxedb';
+
+type UseAppLaunchArgs = {
+    listing: AppStoreListing | InstalledApp;
+    isInstalled?: boolean;
+    onInstallSuccess?: () => void;
+};
+
+/**
+ * Shared "open an installed app" behavior for the app store.
+ *
+ * Encapsulates the launch flow used by both the browse list row
+ * (AppStoreListItem) and the My Apps grid tile (MoreAppTile): consent-flow
+ * redirect with delegate VP, AI Tutor, embedded iframe, direct/second-screen
+ * links, age hard-block, and a fallback to the detail modal when a listing has
+ * no launchable config. Modals are opened fresh via `newModal`, so this is safe
+ * to call from a surface that isn't already inside a modal.
+ */
+const useAppLaunch = ({ listing, isInstalled = false, onInstallSuccess }: UseAppLaunchArgs) => {
+    const { newModal, closeModal } = useModal({
+        desktop: ModalTypes.Right,
+        mobile: ModalTypes.Right,
+    });
+
+    // Parse launch config
+    const launchConfig = useMemo(() => {
+        try {
+            return JSON.parse(listing.launch_config_json);
+        } catch {
+            return {};
+        }
+    }, [listing.launch_config_json]);
+
+    // Consent flow hooks for redirect on launch
+    const contractUri: string | undefined = launchConfig?.contractUri;
+    const { contract, hasConsented } = useConsentFlowByUri(contractUri);
+
+    const { initWallet } = useWallet();
+
+    // Guardian gate for child profiles
+    const { userAge, isChildProfile } = useGuardianGate();
+
+    // Separate min_age (hard block) from age_rating (soft block with guardian approval)
+    const listingAny = listing as any;
+    const minAge: number | undefined = listingAny.min_age;
+    const ageRating: string | undefined = listingAny.age_rating;
+
+    // Hard block: min_age violation (hide app entirely, block installation)
+    // Only applies when userAge is known
+    const isHardBlocked = useMemo(
+        () =>
+            checkAppInstallEligibility({
+                isChildProfile,
+                userAge,
+                minAge,
+                ageRating,
+                hasContract: Boolean(contractUri),
+            }).action === 'hard_blocked',
+        [ageRating, contractUri, isChildProfile, minAge, userAge]
+    );
+
+    // Check if this is an InstalledApp (has installed_at property)
+    const installedAt = 'installed_at' in listing ? listing.installed_at : null;
+
+    const handleOpenDetail = () => {
+        newModal(
+            <AppStoreDetailModal
+                listing={listing}
+                isInstalled={isInstalled}
+                onInstallSuccess={onInstallSuccess}
+            />
+        );
+    };
+
+    // Show age restriction blocked modal
+    const showAgeBlockedModal = () => {
+        newModal(
+            <div className="flex flex-col h-full w-full bg-white max-w-[500px] mx-auto">
+                <div
+                    className="border-b border-grayscale-200 p-6"
+                    style={{ paddingTop: 'max(1.5rem, env(safe-area-inset-top))' }}
+                >
+                    <h2 className="text-2xl font-bold text-grayscale-900 text-center">
+                        Age Restricted
+                    </h2>
+                </div>
+
+                <div className="flex-1 p-6 overflow-auto">
+                    <div className="flex flex-col items-center text-center space-y-4">
+                        <div className="w-20 h-20 rounded-full bg-red-100 flex items-center justify-center">
+                            <ShieldAlert className="w-10 h-10 text-red-600" />
+                        </div>
+
+                        <div className="w-16 h-16 rounded-2xl overflow-hidden bg-grayscale-100 flex items-center justify-center shadow-md">
+                            <img
+                                src={listing.icon_url}
+                                alt={listing.display_name}
+                                className="w-full h-full object-cover"
+                                onError={e => {
+                                    (e.target as HTMLImageElement).src = FALLBACK_ICON;
+                                }}
+                            />
+                        </div>
+
+                        <div>
+                            <p className="text-lg font-semibold text-grayscale-900 mb-2">
+                                {listing.display_name}
+                            </p>
+
+                            <p className="text-sm text-grayscale-600">
+                                This app requires users to be <strong>{minAge}+</strong> years old.
+                            </p>
+                        </div>
+
+                        <div className="bg-red-50 border border-red-100 rounded-lg p-4 w-full text-left">
+                            <p className="text-sm text-red-800">
+                                Based on your profile's date of birth, you do not meet the minimum
+                                age requirement for this app.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div
+                    className="flex items-center justify-center gap-4 p-6 border-t border-grayscale-200 bg-white"
+                    style={{
+                        paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
+                    }}
+                >
+                    <button
+                        onClick={closeModal}
+                        className="px-8 py-3 text-lg font-semibold text-white bg-grayscale-600 rounded-full hover:bg-grayscale-700 transition-colors"
+                    >
+                        OK
+                    </button>
+                </div>
+            </div>,
+            {
+                sectionClassName: '!max-w-[500px]',
+                hideButton: true,
+            },
+            { desktop: ModalTypes.Center, mobile: ModalTypes.FullScreen }
+        );
+    };
+
+    const proceedWithLaunch = async () => {
+        // For consent flow apps, redirect with did and delegate VP
+        if (hasConsented && contract) {
+            // Guardian consent apps need profile selection flow
+            if (contract.needsGuardianConsent) {
+                const redirectUrl =
+                    launchConfig.redirectUri?.trim() || contract.redirectUrl?.trim();
+
+                if (redirectUrl) {
+                    newModal(
+                        <GuardianConsentLaunchModal
+                            contractDetails={contract}
+                            redirectUrl={redirectUrl}
+                        />,
+                        { sectionClassName: '!bg-transparent !shadow-none' },
+                        { desktop: ModalTypes.Center, mobile: ModalTypes.FullScreen }
+                    );
+                    return;
+                }
+            }
+
+            // Prefer app listing URL, then contract redirectUrl
+            const redirectUrl = launchConfig.redirectUri?.trim() || contract.redirectUrl?.trim();
+
+            if (redirectUrl) {
+                const wallet = await initWallet();
+                const urlObj = new URL(redirectUrl);
+
+                // Add user's did to redirect url
+                urlObj.searchParams.set('did', wallet.id.did());
+
+                // Add delegate credential VP if contract has an owner
+                if (contract.owner?.did) {
+                    const unsignedDelegateCredential = wallet.invoke.newCredential({
+                        type: 'delegate',
+                        subject: contract.owner.did,
+                        access: ['read', 'write'],
+                    });
+
+                    const delegateCredential = await wallet.invoke.issueCredential(
+                        unsignedDelegateCredential
+                    );
+
+                    const unsignedDidAuthVp = await wallet.invoke.newPresentation(
+                        delegateCredential
+                    );
+
+                    const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
+                        proofPurpose: 'authentication',
+                        proofFormat: 'jwt',
+                    })) as any as string;
+
+                    urlObj.searchParams.set('vp', vp);
+                }
+
+                window.open(urlObj.toString(), '_blank');
+                return;
+            }
+        }
+
+        // AI Tutor apps - open full connected view with topics
+        if ((listing.launch_type as string) === 'AI_TUTOR' && launchConfig.aiTutorUrl) {
+            newModal(
+                <AiTutorConnectedView
+                    listing={listing}
+                    launchConfig={{
+                        aiTutorUrl: launchConfig.aiTutorUrl,
+                        contractUri: launchConfig.contractUri,
+                    }}
+                />
+            );
+            return;
+        }
+
+        // Default launch behavior
+        if (listing.launch_type === 'EMBEDDED_IFRAME' && launchConfig.url) {
+            newModal(
+                <EmbedIframeModal
+                    embedUrl={launchConfig.url}
+                    appId={(listing as any).slug || listing.listing_id}
+                    appName={listing.display_name}
+                    launchConfig={launchConfig}
+                    isInstalled={isInstalled || !!installedAt}
+                />
+            );
+        } else if (listing.launch_type === 'DIRECT_LINK' && launchConfig.url) {
+            await openExternalLink(launchConfig.url);
+        } else if (listing.launch_type === 'SECOND_SCREEN' && launchConfig.url) {
+            window.open(launchConfig.url, '_blank');
+        } else {
+            // Fallback to opening detail modal if launch type is not configured
+            handleOpenDetail();
+        }
+    };
+
+    const handleLaunch = async () => {
+        // Hard block: min_age violation - show blocked modal
+        if (isHardBlocked) {
+            showAgeBlockedModal();
+            return;
+        }
+
+        await proceedWithLaunch();
+    };
+
+    return {
+        handleLaunch,
+        handleOpenDetail,
+        showAgeBlockedModal,
+        isHardBlocked,
+        launchConfig,
+        installedAt,
+    };
+};
+
+export default useAppLaunch;

--- a/apps/learn-card-app/src/pages/myApps/AppGrid.test.tsx
+++ b/apps/learn-card-app/src/pages/myApps/AppGrid.test.tsx
@@ -15,10 +15,10 @@ describe('AppGrid', () => {
         expect(screen.getByText('child-b')).toBeTruthy();
     });
 
-    it('uses a 3-column mobile / 4-column desktop grid', () => {
+    it('uses a 3-column phone / 4-column tablet-and-up grid', () => {
         const { container } = render(<AppGrid heading="More Apps">{null}</AppGrid>);
         const grid = container.querySelector('[data-testid="app-grid"]')!;
         expect(grid.className).toContain('grid-cols-3');
-        expect(grid.className).toContain('md:grid-cols-4');
+        expect(grid.className).toContain('sm:grid-cols-4');
     });
 });

--- a/apps/learn-card-app/src/pages/myApps/AppGrid.tsx
+++ b/apps/learn-card-app/src/pages/myApps/AppGrid.tsx
@@ -14,7 +14,7 @@ const AppGrid: React.FC<AppGridProps> = ({ heading, children }) => (
         )}
         <div
             data-testid="app-grid"
-            className="grid grid-cols-3 items-start justify-items-center gap-x-3 gap-y-5 md:grid-cols-4 md:gap-x-6 md:gap-y-8"
+            className="grid grid-cols-3 items-start justify-items-center gap-x-3 gap-y-5 sm:grid-cols-4 md:gap-x-6 md:gap-y-8"
         >
             {children}
         </div>

--- a/apps/learn-card-app/src/pages/myApps/AppGridTile.tsx
+++ b/apps/learn-card-app/src/pages/myApps/AppGridTile.tsx
@@ -39,7 +39,7 @@ const AppGridTile: React.FC<AppGridTileProps> = ({
                 />
             ) : (
                 <div
-                    className="flex aspect-square w-full max-w-[100px] items-center justify-center rounded-[19%] border border-[#FBFBFC] p-[18%] md:max-w-[160px]"
+                    className="flex aspect-square w-full max-w-[160px] items-center justify-center rounded-[19%] border border-[#FBFBFC] p-[18%]"
                     style={{
                         backgroundImage:
                             gradientFrom && gradientTo

--- a/apps/learn-card-app/src/pages/myApps/MoreAppTile.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MoreAppTile.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { AppStoreListing, InstalledApp } from '@learncard/types';
+
+import AppGridTile from './AppGridTile';
+import useAppLaunch from '../launchPad/useAppLaunch';
+
+type MoreAppTileProps = {
+    listing: AppStoreListing | InstalledApp;
+    /** True when this is one of the user's installed apps (tapping launches it);
+     *  false for suggested apps (tapping opens the store detail page). */
+    isInstalled: boolean;
+    onInstallSuccess?: () => void;
+};
+
+/**
+ * A "More Apps" grid tile. Installed apps launch on tap (mirrors the "Open"
+ * button in the browse list); suggested/not-installed apps open the app detail
+ * page so the user can install them first.
+ */
+const MoreAppTile: React.FC<MoreAppTileProps> = ({ listing, isInstalled, onInstallSuccess }) => {
+    const { handleLaunch, handleOpenDetail } = useAppLaunch({
+        listing,
+        isInstalled,
+        onInstallSuccess,
+    });
+
+    return (
+        <AppGridTile
+            title={listing.display_name}
+            icon={listing.icon_url}
+            onClick={isInstalled ? handleLaunch : handleOpenDetail}
+        />
+    );
+};
+
+export default MoreAppTile;

--- a/apps/learn-card-app/src/pages/myApps/MoreAppTile.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MoreAppTile.tsx
@@ -18,11 +18,15 @@ type MoreAppTileProps = {
  * page so the user can install them first.
  */
 const MoreAppTile: React.FC<MoreAppTileProps> = ({ listing, isInstalled, onInstallSuccess }) => {
-    const { handleLaunch, handleOpenDetail } = useAppLaunch({
+    const { handleLaunch, handleOpenDetail, isHardBlocked } = useAppLaunch({
         listing,
         isInstalled,
         onInstallSuccess,
     });
+
+    // Mirror AppStoreListItem: hide age-hard-blocked apps entirely instead of
+    // rendering a tile that only surfaces the block modal on tap.
+    if (isHardBlocked) return null;
 
     return (
         <AppGridTile

--- a/apps/learn-card-app/src/pages/myApps/MyAppsLanding.test.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MyAppsLanding.test.tsx
@@ -13,7 +13,9 @@ vi.mock('react-router-dom', async orig => {
 
 vi.mock('../../components/main-header/MainHeader', () => ({ default: () => null }));
 vi.mock('../../components/main-header/ProfileAlertsIsland', () => ({ default: () => null }));
-vi.mock('../launchPad/AppStoreDetailModal', () => ({ default: () => null }));
+// MoreAppTile pulls in the full app-launch/consent-flow chain; stub it out (the
+// landing test only cares about layout + shortcut wiring, not launch behavior).
+vi.mock('./MoreAppTile', () => ({ default: () => null }));
 vi.mock('./useMoreApps', () => ({
     default: () => ({ apps: [], isSuggested: true, isLoading: false }),
 }));
@@ -22,6 +24,7 @@ vi.mock('learn-card-base', () => ({
     useModal: () => ({ newModal: vi.fn(), closeModal: vi.fn() }),
     ModalTypes: { Cancel: 'Cancel', Right: 'Right', Center: 'Center', FullScreen: 'FullScreen' },
     useDeviceTypeByWidth: () => ({ isMobile: false }),
+    useFeatureConfig: () => ({}),
 }));
 
 import MyAppsLanding from './MyAppsLanding';

--- a/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { IonPage, IonContent } from '@ionic/react';
-import { useModal, ModalTypes, useDeviceTypeByWidth } from 'learn-card-base';
+import { useDeviceTypeByWidth } from 'learn-card-base';
 
 import Search from 'learn-card-base/svgs/Search';
 
 import MainHeader from '../../components/main-header/MainHeader';
 import ProfileAlertsIsland from '../../components/main-header/ProfileAlertsIsland';
-import AppStoreDetailModal from '../launchPad/AppStoreDetailModal';
 import AppGrid from './AppGrid';
 import AppGridTile from './AppGridTile';
+import MoreAppTile from './MoreAppTile';
 import {
     LEARNCARD_APP_SHORTCUTS,
     JOURNEYS_SHORTCUT,
@@ -35,8 +35,6 @@ const MOBILE_HEADER_STYLE: React.CSSProperties = {
 const MyAppsLanding: React.FC = () => {
     const history = useHistory();
     const { search } = useLocation();
-    // Initialize with a modal type so newModal renders (mirrors AppStoreListItem).
-    const { newModal } = useModal({ desktop: ModalTypes.Right, mobile: ModalTypes.Right });
     const { isMobile } = useDeviceTypeByWidth();
     const openBoost = useOpenBoostTemplateSelector();
     const { apps: moreApps, isSuggested, isLoading: isLoadingMore } = useMoreApps();
@@ -99,14 +97,7 @@ const MyAppsLanding: React.FC = () => {
     );
 
     const renderAppTile = (app: (typeof moreApps)[number]) => (
-        <AppGridTile
-            key={app.listing_id}
-            title={app.display_name}
-            icon={app.icon_url}
-            onClick={() =>
-                newModal(<AppStoreDetailModal listing={app} isInstalled={!isSuggested} />)
-            }
-        />
+        <MoreAppTile key={app.listing_id} listing={app} isInstalled={!isSuggested} />
     );
 
     const renderSkeletonTile = (key: string) => (


### PR DESCRIPTION
## Summary


BEFORE:

<img width="677" height="921" alt="Screenshot 2026-07-09 at 12 06 57 AM" src="https://github.com/user-attachments/assets/ac926b8d-ea09-4626-b322-12ed44f3e445" />


AFTER:

<img width="613" height="925" alt="Screenshot 2026-07-09 at 12 07 00 AM" src="https://github.com/user-attachments/assets/88ed9719-4600-4278-ad4f-d0960340bbb2" />


- **Fix tiny LearnCard app icons at tablet / in-between widths.** The launchpad grid stayed at 3 columns until `md` (768px) while every tile was capped at `max-w-[100px]`, so between ~400 and 767px the tiles sat tiny inside much wider grid columns and the icons looked lost. Cap the tile at `max-w-[160px]` at every width (not just desktop) and move the 3→4 column breakpoint from `md` down to `sm` (640px), so the original `p-[18%]` icon padding stays proportional across all viewports.
- **More Apps tiles now launch installed apps directly instead of always opening the info page.** Previously every tile in the More Apps section opened `AppStoreDetailModal`. Now installed apps launch on tap — mirroring the existing "Open" button on the browse list — and only not-installed / suggested apps still open the detail page (so the user can install first).
- **Refactor: extract shared launch flow into a `useAppLaunch` hook.** The launch logic (consent redirect + delegate VP, AI tutor, embedded iframe, direct / second-screen links, age hard-block, fallback) was already duplicated in `AppStoreListItem` and `AppStoreDetailModal`. Rather than add a third copy for the new `MoreAppTile`, extract the `AppStoreListItem` flavor into `useAppLaunch` and have both `AppStoreListItem` and `MoreAppTile` consume it.

## Test plan

- [ ] Desktop (≥992px, sidebar visible): LearnCard app tiles + icons look proportional and match the design.
- [ ] Tablet / in-between (~400–991px, no sidebar): LearnCard app icons are no longer tiny inside oversized tiles.
- [ ] Mobile (<400px): LearnCard tiles look the same as before this PR.
- [ ] Tap a LearnCard shortcut tile → navigates to that feature (`Skill Insights`, `Pathways`, etc.).
- [ ] Tap an installed app tile in **More Apps** → **launches the app** (opens the embed/redirect/etc, not the detail modal).
- [ ] Tap a not-installed / suggested app tile in **More Apps** → opens the app detail / install page.
- [ ] Age-restricted apps still show the hard-block modal on tap (unchanged behavior).
- [ ] Browse list ("Browse More +" → app store) is unchanged: Get / Install / Open buttons still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Extract app launch logic into reusable hook to fix tile icons and enable consistent launch behavior across app grid and store list.

Main changes:
- Created `useAppLaunch` hook encapsulating consent-flow, AI Tutor, iframe, and direct-link launch paths with age-gating
- Refactored `AppStoreListItem` to use new hook, removing 246 lines of embedded launch logic
- Updated `AppGrid` responsive breakpoints (3-col phone → 4-col tablet) and created `MoreAppTile` component using shared launch hook

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
