### PR TITLE
feat: Desktop AI Pathways

### DIFF
--- a/.changeset/fiery-pots-bow.md
+++ b/.changeset/fiery-pots-bow.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+feat: Desktop AI Pathways

--- a/apps/learn-card-app/src/pages/ai-pathways/AiPathways.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/AiPathways.tsx
@@ -39,30 +39,36 @@ const AiPathways: React.FC = () => {
                         hidePlusBtn={true}
                     />
                     <AiFeatureGate>
-                        <div className="flex items-center justify-center flex-col relative w-full pt-[50px] pb-[50px] gap-4">
-                            {isInitialPercentageAboveZero && <AiPathwaysWhatWouldYouLikeToDoCard />}
+                        <div className="relative w-full pt-[50px] pb-[50px] max-w-[1240px] mx-auto px-4 flex flex-col gap-6">
+                            <div className="flex flex-col desktop:flex-row desktop:items-start gap-6 w-full">
+                                <div className="flex flex-col gap-4 w-full desktop:w-[400px] desktop:shrink-0">
+                                    {isInitialPercentageAboveZero && (
+                                        <AiPathwaysWhatWouldYouLikeToDoCard />
+                                    )}
 
-                            <MySkillProfile className="px-4" />
+                                    <MySkillProfile className="w-full" />
 
-                            {!isInitialPercentageAboveZero && (
-                                <AiPathwaysWhatWouldYouLikeToDoCard />
-                            )}
+                                    {!isInitialPercentageAboveZero && (
+                                        <AiPathwaysWhatWouldYouLikeToDoCard />
+                                    )}
 
-                            <div className="w-full px-4 mx-auto max-w-[600px]">
-                                <GrowSkillsPathwaysHome />
+                                    {(isLoading || (careerKeywords && occupations)) && (
+                                        <AiPathwayCareers
+                                            careerKeywords={careerKeywords || []}
+                                            occupations={occupations || []}
+                                            isLoading={isLoading}
+                                        />
+                                    )}
+                                </div>
+
+                                <div className="flex flex-col gap-4 w-full min-w-0 desktop:flex-1">
+                                    <GrowSkillsPathwaysHome />
+                                </div>
                             </div>
-
-                            {(isLoading || (careerKeywords && occupations)) && (
-                                <AiPathwayCareers
-                                    careerKeywords={careerKeywords || []}
-                                    occupations={occupations || []}
-                                    isLoading={isLoading}
-                                />
-                            )}
 
                             <AiFeatureLinks
                                 features={['ai-sessions', 'skills-hub', 'ai-insights']}
-                                className="px-4 max-w-[600px]"
+                                className="w-full"
                             />
                         </div>
                     </AiFeatureGate>

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsAiSessionItem.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsAiSessionItem.tsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useModal } from 'learn-card-base';
 
-import { ChevronRight } from 'lucide-react';
 import GrowSkillsSkillChips from './GrowSkillsSkillChips';
 import { type GrowSkillsPathway } from './useGrowSkillsContent';
 import { AiSessionsIconWithShape } from 'learn-card-base/svgs/wallet/AiSessionsIcon';
@@ -83,7 +82,6 @@ const GrowSkillsAiSessionItem: React.FC<GrowSkillsAiSessionItemProps> = ({ data 
                             {title}
                         </h3>
                     </div>
-                    <ChevronRight className="w-[20px] h-[20px] text-grayscale-700 flex-shrink-0" />
                 </div>
 
                 <p className="text-[14px] text-grayscale-600 font-notoSans text-left">

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -1,5 +1,11 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperInstance } from 'swiper';
+
+import { useScreenWidth } from 'learn-card-base';
+import SlimCaretLeft from '../../components/svgs/SlimCaretLeft';
+import SlimCaretRight from '../../components/svgs/SlimCaretRight';
+
 import 'swiper/css';
 
 type GrowSkillsCarouselSectionProps<T> = {
@@ -11,7 +17,6 @@ type GrowSkillsCarouselSectionProps<T> = {
     viewAllLabel?: string;
     className?: string;
     slideClassName?: string;
-    maxGridItems?: number;
 };
 
 const GrowSkillsCarouselSection = <T,>({
@@ -23,38 +28,99 @@ const GrowSkillsCarouselSection = <T,>({
     viewAllLabel = 'View All',
     className = '',
     slideClassName = 'flex !h-auto overflow-visible',
-    maxGridItems = 2,
 }: GrowSkillsCarouselSectionProps<T>) => {
     const carouselItems = items ?? [];
 
-    if (carouselItems.length === 0) return null;
+    const width = useScreenWidth(true);
+    const swiperRef = useRef<SwiperInstance | null>(null);
+    const [atBeginning, setAtBeginning] = useState<boolean>(true);
+    const [atEnd, setAtEnd] = useState<boolean>(false);
 
-    const gridItems = carouselItems.slice(0, maxGridItems);
+    const showNavigation = width > 991;
+    const showHeaderNavigation = showNavigation && carouselItems.length > 1;
+
+    const handleSwiperUpdate = (swiper: SwiperInstance) => {
+        setAtBeginning(swiper.isBeginning);
+        setAtEnd(swiper.isEnd);
+    };
+
+    const handleSwiperInit = (swiper: SwiperInstance) => {
+        swiperRef.current = swiper;
+        // 'auto'-width slides aren't measured yet on first render, so isEnd can be
+        // wrong here — recompute after layout settles.
+        requestAnimationFrame(() => {
+            swiper.update();
+            handleSwiperUpdate(swiper);
+        });
+    };
+
+    if (carouselItems.length === 0) return null;
 
     return (
         <div className={`flex flex-col items-center gap-[10px] ${className}`.trim()}>
-            <div className="flex gap-[5px] w-full">
+            <div className="flex items-center gap-[5px] w-full">
                 <span className="text-[14px] font-poppins text-grayscale-800 font-bold leading-[130%]">
                     {title}
                 </span>
-                {onViewAll && (
-                    <button
-                        type="button"
-                        onClick={onViewAll}
-                        className="text-[14px] font-poppins text-indigo-500 font-bold leading-[130%] ml-auto transition-colors hover:text-grayscale-900"
-                    >
-                        {viewAllLabel}
-                    </button>
+
+                {(onViewAll || showHeaderNavigation) && (
+                    <div className="ml-auto flex items-center gap-[12px]">
+                        {onViewAll && (
+                            <button
+                                type="button"
+                                onClick={onViewAll}
+                                className="text-[14px] font-poppins text-indigo-500 font-bold leading-[130%] transition-colors hover:text-grayscale-900"
+                            >
+                                {viewAllLabel}
+                            </button>
+                        )}
+
+                        {showHeaderNavigation && (
+                            <div className="flex items-center gap-[6px]">
+                                <button
+                                    type="button"
+                                    aria-label="Previous"
+                                    disabled={atBeginning}
+                                    className="flex h-[30px] w-[30px] items-center justify-center text-grayscale-900 transition-colors hover:text-grayscale-700 disabled:text-grayscale-400 disabled:cursor-not-allowed"
+                                    onClick={() => swiperRef.current?.slidePrev()}
+                                >
+                                    <SlimCaretLeft className="h-[30px] w-[30px]" />
+                                </button>
+
+                                <button
+                                    type="button"
+                                    aria-label="Next"
+                                    disabled={atEnd}
+                                    className="flex h-[30px] w-[30px] items-center justify-center text-grayscale-900 transition-colors hover:text-grayscale-700 disabled:text-grayscale-400 disabled:cursor-not-allowed"
+                                    onClick={() => swiperRef.current?.slideNext()}
+                                >
+                                    <SlimCaretRight className="h-[30px] w-[30px]" />
+                                </button>
+                            </div>
+                        )}
+                    </div>
                 )}
             </div>
 
-            <div className="relative w-full overflow-visible desktop:hidden">
+            <div className="relative w-full overflow-visible">
                 <Swiper
+                    onSwiper={handleSwiperInit}
+                    onResize={handleSwiperUpdate}
+                    onSlideChange={handleSwiperUpdate}
+                    onReachBeginning={() => setAtBeginning(true)}
+                    onReachEnd={() => setAtEnd(true)}
+                    onFromEdge={() => {
+                        if (swiperRef.current) {
+                            setAtBeginning(swiperRef.current.isBeginning);
+                            setAtEnd(swiperRef.current.isEnd);
+                        }
+                    }}
                     spaceBetween={12}
                     slidesPerView={'auto'}
                     grabCursor={true}
                     preventClicks={true}
                     preventClicksPropagation={true}
+                    slidesPerGroupAuto
                     style={{ overflow: 'visible' }}
                 >
                     {carouselItems.map((item, index) => (
@@ -67,14 +133,6 @@ const GrowSkillsCarouselSection = <T,>({
                         </SwiperSlide>
                     ))}
                 </Swiper>
-            </div>
-
-            <div className="hidden desktop:grid grid-cols-2 items-start gap-4 w-full">
-                {gridItems.map((item, index) => (
-                    <div key={getItemKey?.(item, index) ?? index} className="w-full">
-                        {renderItem(item, index)}
-                    </div>
-                ))}
             </div>
         </div>
     );

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -49,6 +49,7 @@ const GrowSkillsCarouselSection = <T,>({
         // 'auto'-width slides aren't measured yet on first render, so isEnd can be
         // wrong here — recompute after layout settles.
         requestAnimationFrame(() => {
+            if (swiper.destroyed) return;
             swiper.update();
             handleSwiperUpdate(swiper);
         });

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -31,7 +31,7 @@ const GrowSkillsCarouselSection = <T,>({
 }: GrowSkillsCarouselSectionProps<T>) => {
     const carouselItems = items ?? [];
 
-    const width = useScreenWidth(true);
+    const width = useScreenWidth();
     const swiperRef = useRef<SwiperInstance | null>(null);
     const [atBeginning, setAtBeginning] = useState<boolean>(true);
     const [atEnd, setAtEnd] = useState<boolean>(false);

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -11,6 +11,7 @@ type GrowSkillsCarouselSectionProps<T> = {
     viewAllLabel?: string;
     className?: string;
     slideClassName?: string;
+    maxGridItems?: number;
 };
 
 const GrowSkillsCarouselSection = <T,>({
@@ -22,10 +23,13 @@ const GrowSkillsCarouselSection = <T,>({
     viewAllLabel = 'View All',
     className = '',
     slideClassName = 'flex !h-auto overflow-visible',
+    maxGridItems = 2,
 }: GrowSkillsCarouselSectionProps<T>) => {
     const carouselItems = items ?? [];
 
     if (carouselItems.length === 0) return null;
+
+    const gridItems = carouselItems.slice(0, maxGridItems);
 
     return (
         <div className={`flex flex-col items-center gap-[10px] ${className}`.trim()}>
@@ -44,7 +48,7 @@ const GrowSkillsCarouselSection = <T,>({
                 )}
             </div>
 
-            <div className="relative w-full overflow-visible">
+            <div className="relative w-full overflow-visible desktop:hidden">
                 <Swiper
                     spaceBetween={12}
                     slidesPerView={'auto'}
@@ -63,6 +67,14 @@ const GrowSkillsCarouselSection = <T,>({
                         </SwiperSlide>
                     ))}
                 </Swiper>
+            </div>
+
+            <div className="hidden desktop:grid grid-cols-2 gap-4 w-full">
+                {gridItems.map((item, index) => (
+                    <div key={getItemKey?.(item, index) ?? index} className="h-full w-full">
+                        {renderItem(item, index)}
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -69,9 +69,9 @@ const GrowSkillsCarouselSection = <T,>({
                 </Swiper>
             </div>
 
-            <div className="hidden desktop:grid grid-cols-2 gap-4 w-full">
+            <div className="hidden desktop:grid grid-cols-2 items-start gap-4 w-full">
                 {gridItems.map((item, index) => (
-                    <div key={getItemKey?.(item, index) ?? index} className="h-full w-full">
+                    <div key={getItemKey?.(item, index) ?? index} className="w-full">
                         {renderItem(item, index)}
                     </div>
                 ))}

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { CalendarClock, ChevronRight } from 'lucide-react';
+import { CalendarClock } from 'lucide-react';
 
 import careerOneStopLogo from '../../assets/images/career-one-stop-logo.png';
 import AiPathwaySchoolProgramDetails from './ai-pathway-courses/AiPathwaySchoolProgramDetails';
@@ -89,7 +89,6 @@ const GrowSkillsCourseItem: React.FC<GrowSkillsCourseItemProps> = ({ program }) 
                             {program?.ProgramName}
                         </h3>
                     </div>
-                    <ChevronRight className="w-[20px] h-[20px] text-grayscale-700 flex-shrink-0" />
                 </div>
 
                 <div className="flex gap-[10px]">

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
@@ -79,9 +79,9 @@ const GrowSkillsCourseItem: React.FC<GrowSkillsCourseItemProps> = ({ program }) 
             onPointerCancel={handlePointerUp}
             onClickCapture={handleClickCapture}
             onClick={openCourseDetailsModal}
-            className="w-full h-full flex flex-col rounded-[15px] bg-white shadow-bottom-4-4 overflow-hidden cursor-pointer border-b-[3px] border-emerald-500 text-left"
+            className="w-full flex flex-col rounded-[15px] bg-white shadow-bottom-4-4 overflow-hidden cursor-pointer border-b-[3px] border-emerald-500 text-left"
         >
-            <div className="px-[15px] py-[20px] flex flex-col gap-[5px] h-full">
+            <div className="px-[15px] py-[20px] flex flex-col gap-[5px]">
                 <div className="flex items-start gap-[10px]">
                     <ThickStudiesIconWithShape className="w-[35px] h-[35px] flex-shrink-0" />
                     <div className="flex-1 min-w-0">

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsPathwaysHome.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsPathwaysHome.tsx
@@ -35,7 +35,7 @@ const GrowSkillsPathwaysHome: React.FC<GrowSkillsPathwaysHomeProps> = ({}) => {
 
     return (
         <>
-            <div className="bg-grayscale-50 px-[15px] py-[20px] rounded-[15px] flex flex-col gap-[30px] w-full shadow-bottom-4-4 max-w-[568px] overflow-hidden">
+            <div className="bg-grayscale-50 px-[15px] py-[20px] rounded-[15px] flex flex-col gap-[30px] w-full shadow-bottom-4-4 max-w-full overflow-hidden">
                 <div className="flex flex-col gap-[5px]">
                     <div className="flex items-center gap-[10px] text-grayscale-900">
                         <SkillsIconWithShape className="w-[50px] h-[50px]" />
@@ -91,7 +91,7 @@ const GrowSkillsPathwaysHome: React.FC<GrowSkillsPathwaysHomeProps> = ({}) => {
             </div>
 
             {emptyPathways && (
-                <div className="flex items-center justify-center w-full rounded-[10px] max-w-[600px] mt-4">
+                <div className="flex items-center justify-center w-full rounded-[10px] max-w-full mt-4">
                     <AiPathwaysEmptyPlaceholder />
                 </div>
             )}

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsPathwaysHome.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsPathwaysHome.tsx
@@ -69,9 +69,9 @@ const GrowSkillsPathwaysHome: React.FC<GrowSkillsPathwaysHomeProps> = ({}) => {
                     onViewAll={() => openGrowSkillsModal('Media')}
                     renderItem={card =>
                         card.type === 'youtube-media' ? (
-                            <GrowSkillsYouTubeMediaItem video={card.video} className="h-full" />
+                            <GrowSkillsYouTubeMediaItem video={card.video} />
                         ) : (
-                            <GrowSkillsMediaItem occupation={card.occupation} className="h-full" />
+                            <GrowSkillsMediaItem occupation={card.occupation} />
                         )
                     }
                     getItemKey={card =>

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathway-careers/AiPathwayCareers.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathway-careers/AiPathwayCareers.tsx
@@ -41,11 +41,11 @@ const AiPathwayCareers: React.FC<{
 
     if (isLoading) {
         return (
-            <div className="w-full max-w-[600px] flex items-center justify-center flex-wrap text-center px-4">
+            <div className="w-full max-w-full flex items-center justify-center flex-wrap text-center">
                 <div className="w-full bg-white items-center justify-center flex flex-col shadow-bottom-2-4 p-[15px] rounded-[15px]">
                     {titleEl}
 
-                    <div className="w-full flex flex-col items-start justify-start mt-4 gap-4">
+                    <div className="w-full grid grid-cols-1 gap-4 mt-4">
                         {Array.from({ length: 3 }).map((_, index) => (
                             <AiPathwayCareerItemSkeletonLoader key={index} />
                         ))}
@@ -58,11 +58,11 @@ const AiPathwayCareers: React.FC<{
     if (!isLoading && (!careerKeywords?.length || !occupations?.length)) return null;
 
     return (
-        <div className="w-full max-w-[600px] flex items-center justify-center flex-wrap text-center px-4">
+        <div className="w-full max-w-full flex items-center justify-center flex-wrap text-center">
             <div className="w-full bg-white items-center justify-center flex flex-col shadow-bottom-2-4 p-[15px] rounded-[15px]">
                 {titleEl}
 
-                <div className="w-full flex flex-col items-start justify-start mt-4 gap-4">
+                <div className="w-full grid grid-cols-1 gap-4 mt-4">
                     {occupations?.map(occupation => (
                         <AiPathwayCareerItem key={occupation.OnetCode} occupation={occupation} />
                     ))}

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { Capacitor } from '@capacitor/core';
 
@@ -20,11 +20,21 @@ type MySkillProfileProps = {
 const isNativePlatform = Capacitor.isNativePlatform();
 
 const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
-    const { percentage, lastEditedDate } = useSkillProfileCompletion();
+    const { percentage, lastEditedDate, isFetched } = useSkillProfileCompletion();
     const { openSkillProfile } = useSkillProfileModal();
 
-    const [isExpanded, setIsExpanded] = useState(isNativePlatform && percentage === 0);
+    const [isExpanded, setIsExpanded] = useState(false);
     const [currentStep, setCurrentStep] = useState(1);
+
+    const hasAutoExpanded = useRef(false);
+
+    useEffect(() => {
+        if (!isNativePlatform || hasAutoExpanded.current) return;
+        if (isFetched && percentage === 0) {
+            hasAutoExpanded.current = true;
+            setIsExpanded(true);
+        }
+    }, [isFetched, percentage]);
 
     const formattedEditDate = lastEditedDate
         ? new Date(lastEditedDate).toLocaleDateString('en-US', {

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Capacitor } from '@capacitor/core';
+
 import { ProfilePicture } from 'learn-card-base';
 import X from 'src/components/svgs/X';
 import Pencil from 'src/components/svgs/Pencil';
@@ -9,14 +11,19 @@ import SkillProfileStep2 from './SkillProfileStep2';
 import SkillProfileStep3 from './SkillProfileStep3';
 import SkillProfileStep4 from './SkillProfileStep4';
 import SkillProfileStep5 from './SkillProfileStep5';
+import useSkillProfileModal from '../../dashboard/hooks/useSkillProfileModal';
 
 type MySkillProfileProps = {
     className?: string;
 };
 
+const isNativePlatform = Capacitor.isNativePlatform();
+
 const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
     const { percentage, lastEditedDate } = useSkillProfileCompletion();
-    const [isExpanded, setIsExpanded] = useState(percentage === 0);
+    const { openSkillProfile } = useSkillProfileModal();
+
+    const [isExpanded, setIsExpanded] = useState(isNativePlatform && percentage === 0);
     const [currentStep, setCurrentStep] = useState(1);
 
     const formattedEditDate = lastEditedDate
@@ -27,17 +34,19 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
           })
         : undefined;
 
-    const handleNext = () => {
-        setCurrentStep(currentStep + 1);
-    };
-
+    const handleNext = () => setCurrentStep(prev => prev + 1);
+    const handleBack = () => setCurrentStep(prev => prev - 1);
     const handleFinish = () => {
         setCurrentStep(1);
         setIsExpanded(false);
     };
 
-    const handleBack = () => {
-        setCurrentStep(currentStep - 1);
+    const handleEdit = () => {
+        if (isNativePlatform) {
+            setIsExpanded(true);
+        } else {
+            openSkillProfile();
+        }
     };
 
     const steps: Record<number, React.ReactNode> = {
@@ -67,13 +76,16 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
                                 </span>
                             )}
                         </h2>
-                        {isExpanded && (
+                        {isExpanded ? (
                             <button onClick={() => setIsExpanded(false)} className="ml-auto">
                                 <X className="h-[25px] w-[25px] text-grayscale-500" />
                             </button>
-                        )}
-                        {!isExpanded && (
-                            <button onClick={() => setIsExpanded(true)} className="ml-auto">
+                        ) : (
+                            <button
+                                onClick={handleEdit}
+                                className="ml-auto"
+                                aria-label="Edit skill profile"
+                            >
                                 <Pencil className="h-[25px] w-[25px] text-grayscale-500" />
                             </button>
                         )}
@@ -85,7 +97,7 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
                         isExpanded={isExpanded}
                     />
 
-                    {isExpanded && (
+                    {isExpanded ? (
                         <div className="flex items-center w-full">
                             <span className="text-grayscale-600 font-poppins font-[500] text-[14px] leading-[18px]">
                                 {currentStep} of 5
@@ -97,9 +109,7 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
                                 Skip
                             </button>
                         </div>
-                    )}
-
-                    {!isExpanded && (
+                    ) : (
                         <div className="flex items-center w-full">
                             <span className="text-grayscale-600 font-poppins font-[500] text-[14px] leading-[18px]">
                                 {percentage}% optimized
@@ -109,17 +119,19 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
                     )}
                 </div>
 
-                <div
-                    className={`grid w-full transition-[grid-template-rows] duration-300 ease-in-out ${
-                        isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-                    }`}
-                >
-                    <div className="overflow-hidden min-h-0">
-                        <div className="pt-[20px] border-t border-grayscale-200 w-full mt-[10px]">
-                            {steps[currentStep] ?? <div>Step {currentStep} content...</div>}
+                {isNativePlatform && (
+                    <div
+                        className={`grid w-full transition-[grid-template-rows] duration-300 ease-in-out ${
+                            isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                        }`}
+                    >
+                        <div className="overflow-hidden min-h-0">
+                            <div className="pt-[20px] border-t border-grayscale-200 w-full mt-[10px]">
+                                {steps[currentStep] ?? null}
+                            </div>
                         </div>
                     </div>
-                </div>
+                )}
             </div>
         </div>
     );

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
@@ -49,10 +49,8 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
     };
 
     return (
-        <div
-            className={`w-full max-w-[600px] flex items-center justify-center text-left ${className}`}
-        >
-            <div className="w-full max-w-[600px] bg-white items-center justify-center flex flex-col shadow-bottom-4-4 px-[15px] py-[18px] rounded-[15px]">
+        <div className={`w-full flex items-center justify-center text-left ${className}`}>
+            <div className="w-full bg-white items-center justify-center flex flex-col shadow-bottom-4-4 px-[15px] py-[18px] rounded-[15px]">
                 <div className="flex flex-col w-full gap-[10px]">
                     <div className="flex gap-[10px] items-center justify-start w-full">
                         <ProfilePicture

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileProgressBar.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileProgressBar.tsx
@@ -34,26 +34,47 @@ type SkillProfileProgressBarProps = {
 
 export const useSkillProfileCompletion = () => {
     // Step 1: Goals + Professional Title + Role Experience
-    const { data: goalsData, issuanceDate: goalsIssuanceDate } =
-        useVerifiableData<SkillProfileGoalsData>(SKILL_PROFILE_GOALS_KEY);
-    const { data: professionalTitleData, issuanceDate: professionalTitleIssuanceDate } =
-        useVerifiableData<SkillProfileProfessionalTitleData>(SKILL_PROFILE_PROFESSIONAL_TITLE_KEY);
-    const { data: roleExperienceData, issuanceDate: roleExperienceIssuanceDate } =
-        useVerifiableData<SkillProfileRoleExperienceData>(SKILL_PROFILE_ROLE_EXPERIENCE_KEY);
+    const {
+        data: goalsData,
+        issuanceDate: goalsIssuanceDate,
+        isFetched: goalsFetched,
+    } = useVerifiableData<SkillProfileGoalsData>(SKILL_PROFILE_GOALS_KEY);
+    const {
+        data: professionalTitleData,
+        issuanceDate: professionalTitleIssuanceDate,
+        isFetched: professionalTitleFetched,
+    } = useVerifiableData<SkillProfileProfessionalTitleData>(SKILL_PROFILE_PROFESSIONAL_TITLE_KEY);
+    const {
+        data: roleExperienceData,
+        issuanceDate: roleExperienceIssuanceDate,
+        isFetched: roleExperienceFetched,
+    } = useVerifiableData<SkillProfileRoleExperienceData>(SKILL_PROFILE_ROLE_EXPERIENCE_KEY);
 
     // Step 2: Work History
-    const { data: workHistoryData, issuanceDate: workHistoryIssuanceDate } =
-        useVerifiableData<SkillProfileWorkHistoryData>(SKILL_PROFILE_WORK_HISTORY_KEY);
+    const {
+        data: workHistoryData,
+        issuanceDate: workHistoryIssuanceDate,
+        isFetched: workHistoryFetched,
+    } = useVerifiableData<SkillProfileWorkHistoryData>(SKILL_PROFILE_WORK_HISTORY_KEY);
 
     // Step 3: Salary
-    const { data: salaryData, issuanceDate: salaryIssuanceDate } =
-        useVerifiableData<SkillProfileSalaryData>(SKILL_PROFILE_SALARY_KEY);
+    const {
+        data: salaryData,
+        issuanceDate: salaryIssuanceDate,
+        isFetched: salaryFetched,
+    } = useVerifiableData<SkillProfileSalaryData>(SKILL_PROFILE_SALARY_KEY);
 
     // Step 4: Work Life Balance + Job Stability
-    const { data: workLifeBalanceData, issuanceDate: workLifeBalanceIssuanceDate } =
-        useVerifiableData<SkillProfileWorkLifeBalanceData>(SKILL_PROFILE_WORK_LIFE_BALANCE_KEY);
-    const { data: jobStabilityData, issuanceDate: jobStabilityIssuanceDate } =
-        useVerifiableData<SkillProfileJobStabilityData>(SKILL_PROFILE_JOB_STABILITY_KEY);
+    const {
+        data: workLifeBalanceData,
+        issuanceDate: workLifeBalanceIssuanceDate,
+        isFetched: workLifeBalanceFetched,
+    } = useVerifiableData<SkillProfileWorkLifeBalanceData>(SKILL_PROFILE_WORK_LIFE_BALANCE_KEY);
+    const {
+        data: jobStabilityData,
+        issuanceDate: jobStabilityIssuanceDate,
+        isFetched: jobStabilityFetched,
+    } = useVerifiableData<SkillProfileJobStabilityData>(SKILL_PROFILE_JOB_STABILITY_KEY);
 
     // Step 5: Self-assigned skills
     const { data: sasBoostData } = useGetSelfAssignedSkillsBoost();
@@ -86,6 +107,18 @@ export const useSkillProfileCompletion = () => {
 
     const percentage = Math.round((completedCount / TOTAL_METRICS) * 100);
 
+    // Until this is true, `percentage` reads 0 because the async data hasn't
+    // loaded yet — not because the profile is empty. Auto-open-on-0% consumers
+    // must gate on this to avoid firing for users with complete profiles.
+    const isFetched =
+        goalsFetched &&
+        professionalTitleFetched &&
+        roleExperienceFetched &&
+        workHistoryFetched &&
+        salaryFetched &&
+        workLifeBalanceFetched &&
+        jobStabilityFetched;
+
     // Step completion for expanded view
     const step1Complete = hasGoals && hasTitle && hasExperience;
     const step2Complete = hasWorkHistory;
@@ -117,6 +150,7 @@ export const useSkillProfileCompletion = () => {
         totalMetrics: TOTAL_METRICS,
         stepCompletion: [step1Complete, step2Complete, step3Complete, step4Complete, step5Complete],
         lastEditedDate,
+        isFetched,
     };
 };
 


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

<img width="1918" height="977" alt="Screenshot 2026-07-09 at 6 22 16 PM" src="https://github.com/user-attachments/assets/19535e19-53e0-4e25-bf1d-e851270e751b" />

The AI Pathways page was built mobile-first and looked awkward on desktop: a narrow centered column floating in empty space, with horizontal drag-to-scroll carousels that are confusing with a mouse. This reworks it into a proper desktop layout that uses the wider screen, while leaving the mobile experience exactly as it was.

#### 🥴 TL; DR

On wide screens (≥992px), AI Pathways is now a two-column layout — a left rail (My Skill Profile + Explore Roles) and a right column (Grow Skills). Below 992px it stacks into the original single column and keeps the swipe carousels.

#### 💡 Feature Breakdown

- **Two-column desktop layout.** Left rail holds My Skill Profile and Explore Roles; the right column holds Grow Skills. Feature links sit full-width underneath. Stacks to one column on mobile. (`AiPathways.tsx`)
- **Grow Skills: carousel on mobile, grid on desktop.** Each section (Courses / AI Sessions / Media) shows a 2-up grid on desktop capped at 2 items, with "View All" for the rest. Mobile keeps the existing swipe carousel. (`GrowSkillsCarouselSection.tsx`)
- **Skill Profile editing.** On web, the pencil now opens the shared 640px side modal (the same one the Dashboard uses) instead of a cramped inline form. Native keeps the inline expand and still auto-opens for brand-new users (0% complete). (`MySkillProfile.tsx`)
- **Card fixes.** Course/media cards no longer stretch and leave a blank gap when they have no skills, and course cards no longer get vertically clipped inside the "View All" modal. (`GrowSkillsCourseItem.tsx`, `GrowSkillsPathwaysHome.tsx`)

Heads-up for reviewers: this app **overrides Tailwind's default breakpoints** — there is no `lg`/`xl`. Desktop styles use the app's custom `desktop:` breakpoint (992px). That's why the responsive classes here look unusual.

#### 🛠 Important tradeoffs made:

- On mobile, Explore Roles now appears above Grow Skills, since it moved into the left rail (feature links stay last).
- Desktop grid cards are natural height rather than stretched to equal heights, so a row can have slightly uneven bottoms. This is intentional — stretching was what caused the blank-space bug.

#### 🔍 Types of Changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (desktop layout)
-   [ ] Breaking change
-   [x] Chore (UI/layout refactor)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

On `/ai/pathways`:

**Desktop (browser window ≥992px wide)**
1. Page shows two columns: left rail (My Skill Profile, Explore Roles), right column (Grow Skills). Feature links span full width at the bottom.
2. Grow Skills sections show a 2-card grid (not a carousel). "View All" opens the full list, and course cards in that modal are fully visible (not clipped).
3. Cards without skills don't show a large empty gap at the bottom.
4. Click the pencil on My Skill Profile → the profile editor opens in a right-side modal.

**Narrow browser (<992px)**
- Everything collapses to a single column and Grow Skills uses the swipe carousel — same as before this PR.

**Native (iOS/Android)**
- My Skill Profile still expands inline (no modal). For a new user (0% complete), it auto-expands on load.

#### 📱 🖥 Which devices would you like help testing on?

Chromium / Safari (desktop + narrow), iOS Native, Android Native

#### 🧪 Code Coverage

No automated tests — this is a layout/UI change. Verified manually across desktop, narrow, and the View All modal.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor AI Pathways desktop layout to use responsive grid system with carousel navigation controls and improved mobile/desktop component positioning.

Main changes:
- Restructured AiPathways layout with max-width constraints removed, dual-column flex layout for desktop breakpoints, and conditional sidebar positioning
- Enhanced GrowSkillsCarouselSection with Swiper navigation buttons, header controls, and state management for carousel edge detection
- Updated MySkillProfile with native platform detection, auto-expansion logic on 0% completion, and isFetched flag for async data validation
- Removed fixed heights and max-width constraints from course/career item components and carousel slides for flexible responsive sizing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
