### PR TITLE
fix: eliminate loading-screen and login-form flashes during app boot (hard refresh + cold login)

### DIFF
--- a/.changeset/loud-lamps-shake.md
+++ b/.changeset/loud-lamps-shake.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: eliminate the loading-screen flash on hard refresh and cold login. The wallet now survives the auth coordinator re-initialization that follows Firebase session restore (instead of being torn down and rebuilt while flashing the loader over the rendered app), and the coordinator bridges the login provider swap with a transitional state so the login screen no longer flashes between loaders.

--- a/apps/learn-card-app/src/AppRouter.tsx
+++ b/apps/learn-card-app/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { SplashScreen } from '@capacitor/splash-screen';
@@ -352,6 +352,24 @@ const AppRouter: React.FC = () => {
             .then(m => m.prefetchRoutes({ aiEnabled: isAiEnabled }))
             .catch(() => undefined);
     }, [enablePrefetch, isAiEnabled]);
+
+    // Warm the landing chunks immediately — while the boot loader or login
+    // form is still up, before auth resolves. The post-login redirect
+    // (→ /dashboard) and the post-boot mount of the refreshed route would
+    // otherwise only START downloading their chunk after navigation, leaving
+    // a white Suspense gap between the loader and the app on a cold cache.
+    // The full prefetch above stays gated on login; this is just the entry
+    // routes: the default landing pages plus wherever the URL already points.
+    const initialPathRef = useRef(window.location.pathname);
+    useEffect(() => {
+        import('./Routes')
+            .then(m => {
+                void m.ROUTE_PRELOAD['/dashboard']?.();
+                void m.ROUTE_PRELOAD['/wallet']?.();
+                void m.ROUTE_PRELOAD[initialPathRef.current]?.();
+            })
+            .catch(() => undefined);
+    }, []);
 
     const showScanner = QRCodeScannerStore.useTracked.showScanner();
     useLaunchDarklyIdentify({ debug: false });

--- a/apps/learn-card-app/src/pages/login/LoginPage.tsx
+++ b/apps/learn-card-app/src/pages/login/LoginPage.tsx
@@ -62,6 +62,7 @@ import { useAppAuth } from '../../providers/AuthCoordinatorProvider';
 
 export const LoginContent: React.FC = () => {
     const { textLogo, brandMarkLight, fullLogoDark, desktopLoginBg } = useTenantBrandingAssets();
+    const { theme } = useTheme();
     const { newModal, closeModal } = useModal();
     const { state: coordinatorState } = useAppAuth();
     const isLoggedIn = useIsLoggedIn();
@@ -264,6 +265,33 @@ export const LoginContent: React.FC = () => {
         ],
         [appleLogin, googleLogin]
     );
+
+    // Redirect-pending gate: once the wallet is built and the user counts as
+    // logged in, the effect above will history.push away from /login — but
+    // only on the tick AFTER React has already painted this component,
+    // flashing the login form between the boot loader and the app. Bridge
+    // that gap with a loader-colored overlay instead. Intentionally NOT
+    // LoginLoadingPage (an IonPage): nesting a page inside this route
+    // triggers Ionic's page transition twice — same reasoning as
+    // RouteTransitionLoader. needs_setup is excluded so the form stays
+    // visible under the onboarding modal.
+    const redirectPending =
+        (isLoggedIn || !!currentUser) && coordinatorState.status !== 'needs_setup';
+
+    if (redirectPending) {
+        return (
+            <div
+                className="fixed inset-0 z-[1000] flex items-center justify-center"
+                style={{ backgroundColor: theme.colors.defaults.loaders?.[0] ?? '#8B5CF6' }}
+            >
+                <img
+                    src={textLogo}
+                    alt="Logo"
+                    className="max-w-[300px] max-h-[80px] object-contain"
+                />
+            </div>
+        );
+    }
 
     return (
         <div className="w-full h-full flex flex-col items-center justify-center p-0 m-0 px-[30px] overflow-y-auto  pt-[150px] pb-[100px] sm:pt-[0px] sm:pb-[0px] ">

--- a/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
+++ b/apps/learn-card-app/src/providers/AuthCoordinatorProvider.tsx
@@ -105,6 +105,7 @@ import {
 const WALLET_INIT_TIMEOUT_MS = 15000;
 
 import { auth } from '../firebase/firebase';
+import { mergeAuthUserIntoCurrentUser, shouldResetWalletOnStatus } from './authCoordinator.helpers';
 import {
     getAppBaseUrl,
     getFirebaseRedirectDomain,
@@ -1051,9 +1052,16 @@ const AuthSessionManager: React.FC<{
         walletUpgradeNonce,
     ]);
 
-    // --- Reset wallet when coordinator leaves 'ready' (e.g. on logout) ---
+    // --- Reset wallet when coordinator settles outside 'ready' (e.g. logout) ---
+    // Transitional statuses (authenticating / checking_key_status / deriving_key)
+    // are deliberately excluded: they occur while the coordinator re-initializes
+    // after the noOp → real authProvider swap that follows Firebase session
+    // restore on a hard refresh. The wallet — derived from the same cached
+    // private key — stays valid throughout, and tearing it down here used to
+    // flash the full-screen loader over the already-rendered app and rebuild an
+    // identical wallet.
     useEffect(() => {
-        if (coordinator.state.status !== 'ready' && wallet) {
+        if (shouldResetWalletOnStatus(coordinator.state.status) && wallet) {
             setWallet(null);
             setLcnProfile(null);
             setRecoveryMethodCount(null);
@@ -1062,6 +1070,61 @@ const AuthSessionManager: React.FC<{
             walletModeStore.set.mode(null);
         }
     }, [coordinator.state.status, wallet]);
+
+    // --- Backfill auth-session identity once the real provider lands ---
+    // On the private-key-first path the wallet is built before Firebase
+    // restores the session, so currentUser.uid/email/phoneNumber start empty.
+    // The coordinator re-init used to repopulate them by rebuilding the wallet;
+    // now that the wallet survives, patch the missing fields in place.
+    useEffect(() => {
+        if (coordinator.state.status !== 'ready' || !wallet) return;
+
+        const merged = mergeAuthUserIntoCurrentUser(
+            currentUserStore.get.currentUser(),
+            coordinator.state.authUser
+        );
+
+        if (merged) currentUserStore.set.currentUser(merged);
+    }, [coordinator.state, wallet]);
+
+    // --- Backfill recovery-method count for the same reason ---
+    // The wallet-build network tail (which normally loads it) is skipped on the
+    // pk-first path because no auth provider exists yet, and the wallet is no
+    // longer rebuilt when the provider arrives.
+    useEffect(() => {
+        if (
+            coordinator.state.status !== 'ready' ||
+            !wallet ||
+            !authProvider ||
+            recoveryMethodCount !== null ||
+            !keyDerivation.capabilities.recovery ||
+            !keyDerivation.getAvailableRecoveryMethods
+        )
+            return;
+
+        let cancelled = false;
+
+        void (async () => {
+            try {
+                const token = await authProvider.getIdToken();
+                const providerType = authProvider.getProviderType();
+                const methods = await keyDerivation.getAvailableRecoveryMethods!(
+                    token,
+                    providerType
+                );
+
+                if (!cancelled) {
+                    setRecoveryMethodCount(methods.filter(m => m.type !== 'email').length);
+                }
+            } catch {
+                // Non-critical — same best-effort semantics as the wallet-build tail
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [coordinator.state.status, wallet, authProvider, recoveryMethodCount, keyDerivation]);
 
     // --- Clear stale legacy stores when coordinator is idle ---
     // After a public-computer session, the tab close destroys the Firebase

--- a/apps/learn-card-app/src/providers/authCoordinator.helpers.test.ts
+++ b/apps/learn-card-app/src/providers/authCoordinator.helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import { shouldResetWalletOnStatus, mergeAuthUserIntoCurrentUser } from './authCoordinator.helpers';
+
+describe('shouldResetWalletOnStatus', () => {
+    it('keeps the wallet while the coordinator is in a transitional status', () => {
+        // These occur during the noOp → real authProvider re-init on hard
+        // refresh; resetting here flashes the loader over the rendered app.
+        expect(shouldResetWalletOnStatus('authenticating')).toBe(false);
+        expect(shouldResetWalletOnStatus('authenticated')).toBe(false);
+        expect(shouldResetWalletOnStatus('checking_key_status')).toBe(false);
+        expect(shouldResetWalletOnStatus('deriving_key')).toBe(false);
+    });
+
+    it('does not reset while ready', () => {
+        expect(shouldResetWalletOnStatus('ready')).toBe(false);
+    });
+
+    it('resets the wallet in settled non-ready statuses', () => {
+        expect(shouldResetWalletOnStatus('idle')).toBe(true);
+        expect(shouldResetWalletOnStatus('needs_setup')).toBe(true);
+        expect(shouldResetWalletOnStatus('needs_migration')).toBe(true);
+        expect(shouldResetWalletOnStatus('needs_recovery')).toBe(true);
+        expect(shouldResetWalletOnStatus('error')).toBe(true);
+    });
+});
+
+describe('mergeAuthUserIntoCurrentUser', () => {
+    const baseUser = {
+        uid: '',
+        email: '',
+        phoneNumber: '',
+        name: 'Keep Me',
+        privateKey: 'pk',
+    };
+
+    it('backfills uid/email/phone from the auth user when empty', () => {
+        const merged = mergeAuthUserIntoCurrentUser(baseUser, {
+            id: 'firebase-uid',
+            email: 'user@example.com',
+            phone: '+15551234567',
+        });
+
+        expect(merged).toEqual({
+            ...baseUser,
+            uid: 'firebase-uid',
+            email: 'user@example.com',
+            phoneNumber: '+15551234567',
+        });
+    });
+
+    it('preserves already-populated fields', () => {
+        const populated = { ...baseUser, uid: 'existing-uid', email: 'kept@example.com' };
+
+        const merged = mergeAuthUserIntoCurrentUser(populated, {
+            id: 'other-uid',
+            email: 'other@example.com',
+            phone: '+15550000000',
+        });
+
+        expect(merged).toEqual({ ...populated, phoneNumber: '+15550000000' });
+    });
+
+    it('returns null when nothing changes', () => {
+        const populated = {
+            ...baseUser,
+            uid: 'uid',
+            email: 'a@b.c',
+            phoneNumber: '+15551112222',
+        };
+
+        expect(mergeAuthUserIntoCurrentUser(populated, { id: 'uid', email: 'a@b.c' })).toBeNull();
+    });
+
+    it('returns null without a current user or auth user', () => {
+        expect(mergeAuthUserIntoCurrentUser(null, { id: 'uid' })).toBeNull();
+        expect(mergeAuthUserIntoCurrentUser(baseUser, null)).toBeNull();
+        expect(mergeAuthUserIntoCurrentUser(baseUser, undefined)).toBeNull();
+    });
+});

--- a/apps/learn-card-app/src/providers/authCoordinator.helpers.ts
+++ b/apps/learn-card-app/src/providers/authCoordinator.helpers.ts
@@ -1,0 +1,61 @@
+import type { UnifiedAuthState } from 'learn-card-base';
+
+type AuthStatus = UnifiedAuthState['status'];
+
+// Statuses the coordinator passes through while (re)initializing. The most
+// important case: on a hard refresh the private-key-first path reaches 'ready'
+// and builds the wallet BEFORE Firebase restores the session; when the real
+// authProvider then replaces the noOp stub, the base coordinator is recreated
+// and re-runs initialize(), briefly leaving 'ready' through these statuses.
+// The already-built wallet (derived from the same cached private key) remains
+// valid the whole time — tearing it down here is what used to flash the
+// full-screen loader over the already-rendered app.
+const TRANSITIONAL_AUTH_STATUSES: ReadonlySet<AuthStatus> = new Set<AuthStatus>([
+    'authenticating',
+    'authenticated',
+    'checking_key_status',
+    'deriving_key',
+]);
+
+/**
+ * Whether an existing wallet must be torn down when the coordinator is in the
+ * given status. Settled non-ready statuses (logout, setup, recovery,
+ * migration, error) reset the wallet; transitional statuses keep it so a
+ * background re-initialization never unmounts the running app.
+ */
+export const shouldResetWalletOnStatus = (status: AuthStatus): boolean =>
+    status !== 'ready' && !TRANSITIONAL_AUTH_STATUSES.has(status);
+
+/**
+ * Backfill auth-session identity into the stored current user.
+ *
+ * On a hard refresh the wallet is built via the private-key-first path before
+ * the Firebase session resolves, so currentUser.uid/email/phoneNumber start
+ * empty. Previously the post-restore coordinator re-init rebuilt the wallet
+ * (repopulating them as a side effect); now that the wallet survives, patch
+ * the missing fields in place instead.
+ *
+ * Returns the updated user, or null when there is nothing to change.
+ */
+export const mergeAuthUserIntoCurrentUser = <
+    T extends { uid: string; email: string; phoneNumber: string }
+>(
+    currentUser: T | null,
+    authUser: { id: string; email?: string; phone?: string } | null | undefined
+): T | null => {
+    if (!currentUser || !authUser?.id) return null;
+
+    const uid = currentUser.uid || authUser.id;
+    const email = currentUser.email || authUser.email || '';
+    const phoneNumber = currentUser.phoneNumber || authUser.phone || '';
+
+    if (
+        uid === currentUser.uid &&
+        email === currentUser.email &&
+        phoneNumber === currentUser.phoneNumber
+    ) {
+        return null;
+    }
+
+    return { ...currentUser, uid, email, phoneNumber };
+};

--- a/packages/learn-card-base/src/auth-coordinator/AuthCoordinatorProvider.tsx
+++ b/packages/learn-card-base/src/auth-coordinator/AuthCoordinatorProvider.tsx
@@ -176,6 +176,12 @@ export const AuthCoordinatorProvider: React.FC<AuthCoordinatorProviderProps> = (
     const [state, setState] = useState<UnifiedAuthState>({ status: 'idle' });
     const coordinatorRef = useRef<AuthCoordinator | null>(null);
 
+    // Mirror of `state` readable inside the (re)creation effect without adding
+    // `state` to its deps (which would recreate the coordinator on every
+    // state transition).
+    const stateRef = useRef(state);
+    stateRef.current = state;
+
     // Helper to determine event level from state
     const getStateEventLevel = useCallback((newState: UnifiedAuthState): DebugEventLevel => {
         if (newState.status === 'error') return 'error';
@@ -264,6 +270,16 @@ export const AuthCoordinatorProvider: React.FC<AuthCoordinatorProviderProps> = (
 
         coordinatorRef.current = coordinator;
 
+        // Bridge the async gap until initialize() emits its first state. When
+        // a real auth provider arrives while the previous coordinator instance
+        // had settled in 'idle' (interactive login, or Firebase restoring the
+        // session), initialize() awaits the cached-key read before any
+        // setState — leaving consumers on the stale 'idle' long enough to
+        // paint the logged-out UI between two loading screens.
+        if (authProvider && stateRef.current.status === 'idle') {
+            handleStateChange({ status: 'authenticating' });
+        }
+
         coordinator.initialize();
 
         return () => {
@@ -273,6 +289,7 @@ export const AuthCoordinatorProvider: React.FC<AuthCoordinatorProviderProps> = (
     }, [
         enabled,
         effectiveAuthProvider,
+        authProvider,
         keyDerivation,
         didFromPrivateKey,
         signDidAuthVp,

--- a/packages/learn-card-base/src/auth-coordinator/AuthCoordinatorProvider.tsx
+++ b/packages/learn-card-base/src/auth-coordinator/AuthCoordinatorProvider.tsx
@@ -276,6 +276,11 @@ export const AuthCoordinatorProvider: React.FC<AuthCoordinatorProviderProps> = (
         // session), initialize() awaits the cached-key read before any
         // setState — leaving consumers on the stale 'idle' long enough to
         // paint the logged-out UI between two loading screens.
+        //
+        // The condition is intentionally broad: ANY recreation of the
+        // coordinator from 'idle' with a real provider (not just the
+        // noOp→real swap) is about to re-run initialize(), and a loader is
+        // always a better paint for that window than the logged-out UI.
         if (authProvider && stateRef.current.status === 'idle') {
             handleStateChange({ status: 'authenticating' });
         }

--- a/packages/learn-card-base/src/auth-coordinator/__tests__/AuthCoordinatorProvider.test.tsx
+++ b/packages/learn-card-base/src/auth-coordinator/__tests__/AuthCoordinatorProvider.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Provider-level tests for the authProvider swap.
+ *
+ * On interactive login, authUser populates and the app swaps the noOp auth
+ * provider for the real one. The provider recreates the coordinator; until
+ * the new coordinator's async initialize() emits its first state, consumers
+ * used to see the stale settled state ('idle') for a paint — flashing the
+ * login screen between two loading screens. The provider must bridge that
+ * window synchronously with 'authenticating'.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { AuthCoordinatorProvider, useAuthCoordinator } from '../AuthCoordinatorProvider';
+
+import type { AuthProvider, KeyDerivationStrategy } from '../types';
+
+const createMockKeyDerivation = (): KeyDerivationStrategy =>
+    ({
+        name: 'mock',
+        capabilities: { recovery: false },
+        hasLocalKey: vi.fn().mockResolvedValue(false),
+        fetchServerKeyStatus: vi.fn().mockResolvedValue({
+            exists: false,
+            needsMigration: false,
+            recoveryMethods: [],
+        }),
+        deriveKey: vi.fn(),
+        setupKey: vi.fn(),
+        clearLocalKeys: vi.fn(),
+    } as unknown as KeyDerivationStrategy);
+
+const StatusProbe: React.FC = () => {
+    const { state } = useAuthCoordinator();
+    return <div data-testid="status">{state.status}</div>;
+};
+
+// Real cached-key reads hit async platform storage (IndexedDB / secure
+// storage) — a macrotask, not a microtask. That delay is the paint window
+// where stale settled state used to flash, so the mock must model it.
+const slowCachedKey = (value: string | null) => () =>
+    new Promise<string | null>(resolve => setTimeout(() => resolve(value), 20));
+
+describe('AuthCoordinatorProvider authProvider swap', () => {
+    it('bridges idle → real-provider swap with authenticating instead of a stale idle frame', async () => {
+        const keyDerivation = createMockKeyDerivation();
+
+        // didFromPrivateKey is always provided by the app, which routes
+        // initialize() through the private-key-first path: it awaits the slow
+        // cached-key read BEFORE emitting any state, leaving the stale settled
+        // state visible.
+        const { rerender } = render(
+            <AuthCoordinatorProvider
+                keyDerivation={keyDerivation}
+                authProvider={null}
+                getCachedPrivateKey={slowCachedKey(null)}
+                didFromPrivateKey={async () => 'did:key:z123'}
+            >
+                <StatusProbe />
+            </AuthCoordinatorProvider>
+        );
+
+        // noOp provider path settles in idle (no cached key, no session)
+        await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('idle'));
+
+        // Real provider arrives (login) — getCurrentUser never resolves so we
+        // can observe the bridge state before initialize() emits anything.
+        const pendingProvider: AuthProvider = {
+            getIdToken: vi.fn().mockResolvedValue('token'),
+            getCurrentUser: vi.fn().mockReturnValue(new Promise(() => {})),
+            getProviderType: vi.fn().mockReturnValue('firebase'),
+            signOut: vi.fn(),
+        };
+
+        rerender(
+            <AuthCoordinatorProvider
+                keyDerivation={keyDerivation}
+                authProvider={pendingProvider}
+                getCachedPrivateKey={slowCachedKey(null)}
+                didFromPrivateKey={async () => 'did:key:z123'}
+            >
+                <StatusProbe />
+            </AuthCoordinatorProvider>
+        );
+
+        // Synchronously after the swap commit, the state must already be
+        // transitional — never the stale 'idle' that renders the login page.
+        expect(screen.getByTestId('status').textContent).toBe('authenticating');
+    });
+
+    it('does not disturb a ready state when the provider swaps', async () => {
+        const keyDerivation = createMockKeyDerivation();
+
+        const { rerender } = render(
+            <AuthCoordinatorProvider
+                keyDerivation={keyDerivation}
+                authProvider={null}
+                getCachedPrivateKey={slowCachedKey('cached-private-key')}
+                didFromPrivateKey={async () => 'did:key:z123'}
+            >
+                <StatusProbe />
+            </AuthCoordinatorProvider>
+        );
+
+        // Private-key-first path reaches ready before any session restore
+        await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('ready'));
+
+        const pendingProvider: AuthProvider = {
+            getIdToken: vi.fn().mockResolvedValue('token'),
+            getCurrentUser: vi.fn().mockReturnValue(new Promise(() => {})),
+            getProviderType: vi.fn().mockReturnValue('firebase'),
+            signOut: vi.fn(),
+        };
+
+        rerender(
+            <AuthCoordinatorProvider
+                keyDerivation={keyDerivation}
+                authProvider={pendingProvider}
+                getCachedPrivateKey={slowCachedKey('cached-private-key')}
+                didFromPrivateKey={async () => 'did:key:z123'}
+            >
+                <StatusProbe />
+            </AuthCoordinatorProvider>
+        );
+
+        // The bridge only applies to the settled-idle case; a ready state must
+        // not be knocked back synchronously (the app keeps its wallet while the
+        // new coordinator re-derives in the background).
+        expect(screen.getByTestId('status').textContent).toBe('ready');
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Related to: LC-1959 (boot-performance follow-ups from the same trace analysis)

#### 📚 What is the context and goal of this PR?

<img width="728" height="562" alt="Screenshot 2026-07-10 at 3 08 00 AM" src="https://github.com/user-attachments/assets/8a75c840-e0fc-4be4-94bc-af902d8651ed" />

<img width="1001" height="776" alt="Screenshot 2026-07-10 at 2 46 20 AM" src="https://github.com/user-attachments/assets/dd812203-579d-4ffc-9424-fc2c71bb155e" />

Two related boot-sequence glitches, both diagnosed from DevTools performance-trace filmstrips:

**1. Hard refresh: loading screen → app for ~3 frames → loading screen again → app.**

Root cause: a race between two independent boot paths.

1. On refresh, the base `AuthCoordinator` initializes with the **noOp auth provider** and takes the private-key-first path. With a cached key it reaches `ready` and builds the wallet **before Firebase finishes restoring the session** → the app renders.
2. Firebase's session restore then populates `authUser`, the app-side `authProvider` memo returns a new identity, and the base provider **recreates the coordinator**, leaving `ready`.
3. Leaving `ready` reset the already-valid wallet to `null`, flipping `AppRouter`'s `initLoading` back on → second full-screen loader while an **identical wallet was rebuilt** (~1s of duplicated boot work: `user.getDids`, `profile.getProfile`, triple LaunchDarkly identify).

**2. Cold login: boot loader → login form flashes for ~100ms → app.** (Verified still present after fix 1 via a second trace.)

Root cause: when the wallet becomes ready, `AppRouter`'s loader drops while the router is still on `/login`. The redirect effect in `LoginContent` only runs on the tick *after* React paints, so the login form gets one committed paint between the loader and the app.

**3. Post-login/post-boot: ~900ms of white before the destination page paints.**

Root cause: the `/dashboard` chunk only starts downloading *after* `history.push`, so the route-level Suspense (200ms `DelayedFallback`, then `RouteTransitionLoader`) sits on a blank background while the chunk fetches on a cold cache.

#### 🥴 TL; RL:

Don't tear down a valid wallet just because the auth coordinator is re-initializing in the background, don't paint a stale `idle` frame during the login provider swap, and don't paint the login form while its own redirect effect is about to navigate away. No more flashes, and cold boot no longer builds the wallet twice.

#### 💡 Feature Breakdown

https://www.loom.com/share/ea2aa6442c434823a8d2014e3616648d

**`apps/learn-card-app` — providers/AuthCoordinatorProvider.tsx + new authCoordinator.helpers.ts:**
- The wallet-reset effect now only fires for **settled** non-ready statuses (`idle`, `needs_setup`, `needs_recovery`, `needs_migration`, `error`). Transitional statuses (`authenticating`, `authenticated`, `checking_key_status`, `deriving_key`) keep the wallet mounted, so the coordinator re-init after Firebase session restore is invisible.
- New backfill effects replace what the wallet rebuild used to do as a side effect: `currentUser.uid/email/phoneNumber` are patched in place once the real provider lands, and the recovery-method count is fetched (previously loaded in the wallet-build network tail, which the pk-first path skips).

**`apps/learn-card-app` — pages/login/LoginPage.tsx:**
- `LoginContent` renders a loader-colored overlay whenever a post-login redirect is pending (`isLoggedIn`/`currentUser` set and status ≠ `needs_setup`), bridging the one-paint gap before its redirect effect fires. The gate lives *inside* `LoginContent` so the redirect effect keeps running, and uses a plain `fixed` div rather than the `IonPage`-based loader per the documented `RouteTransitionLoader` rationale (a nested IonPage double-triggers Ionic's page transition).

**`apps/learn-card-app` — AppRouter.tsx (chunk warm-up):**
- AppRouter preloads the entry chunks (dashboard, wallet, and whatever route the URL already points at) as soon as it mounts, so the boot-loader and login-form phases double as chunk warm-up time and the post-navigation Suspense gap never fires on the landing routes. The full `ROUTE_PRELOAD` sweep stays gated on login as before.

**`packages/learn-card-base` — auth-coordinator/AuthCoordinatorProvider.tsx:**
- When a real auth provider arrives while the previous coordinator instance had settled in `idle` (interactive login), the provider now synchronously bridges to `authenticating` instead of leaving the stale `idle` state visible for the duration of `initialize()`'s first await (an async cached-key read) — this was the login-screen flash between two loading screens during cold login. The condition is intentionally broad (any re-init from `idle` with a real provider), documented inline.

#### 🛠 Important tradeoffs made:

- The wallet is intentionally kept through transitional statuses even though the coordinator hasn't confirmed the re-derived key yet. This is safe because the wallet and the re-derivation both come from the same cached private key; if re-init lands anywhere unexpected (`needs_migration`, `needs_recovery`, `error`, `idle`), the wallet still resets as before.
- The duplicate wallet build is eliminated as a side effect (the `walletInitRef` guard now survives the re-init), which also removes the duplicate LaunchDarkly/analytics identifies during boot.
- Public-computer mode parity (re review): `isPublicComputerMode()` makes `getCachedPrivateKey` return `null`, so that mode never takes the pk-first path — it always runs the full wallet build with the original network tail, including the `setShowRecoverySetup` prompt the backfill intentionally omits.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Log in on web, then **hard refresh** (Cmd+Shift+R). Before: purple loader → app flash → purple loader → app. After: a single loader, then the app stays. ✅ *Verified fixed by trace filmstrip on this branch.*
2. **Cold login**: log out, log back in. Before: the login form flashed for ~100ms between the boot loader and the app, followed by ~900ms of white while the dashboard chunk loaded. After: continuous loader from submit to app, with the dashboard painting immediately after the redirect (chunk pre-warmed).
3. **Account switch** (per review): log out of user A, log in as user B — the settled-status reset path must fully tear down A's wallet before B's builds.
4. Regression sweep: logout (should land on /login and clear the wallet), recovery flow (`needs_recovery` still resets the wallet + shows recovery UI), onboarding/new-user signup (login form must stay visible under the onboarding modal — `needs_setup` is excluded from the redirect gate), offline boot gate, and profile settings showing the correct email after a hard refresh (backfill path).
5. Optional: record a DevTools performance trace of the hard refresh — the launchpad should render once and `user.getDids`/`profile.getProfile` should run once, not twice.

#### 📱 🖥 Which devices would you like help testing on?

Chromium + Safari web most important (the flashes were diagnosed on web). A native smoke test (iOS/Android) is welcome since the Capacitor splash bridge reads the same states, though its logic is untouched.

#### 🧪 Code Coverage

- New unit tests for the app-side gate helpers (`shouldResetWalletOnStatus`, `mergeAuthUserIntoCurrentUser`).
- New provider-level tests in learn-card-base proving (a) the idle→real-provider swap bridges to `authenticating` instead of painting stale `idle`, and (b) a `ready` state is not disturbed synchronously by the swap.
- Full app unit suite: 1342 passed; the 2 failures (`OnboardingPrivacyDataStep`, `learnCardAppShortcuts`) are pre-existing on `main` (verified via stash).
- The flashes themselves aren't unit-testable end-to-end (paint-timing races across Firebase restore + secure-storage reads), hence the manual QA steps above.

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs**

-   [ ] Tutorial
-   [ ] How-To Guide
-   [ ] Reference
-   [ ] Concept
-   [ ] App Flows

**Internal/AI Docs**

-   [ ] AGENTS.md
-   [x] **Code comments/JSDoc** — the reset-gate semantics, the backfill effects, the login redirect gate, and the base-provider bridge are all documented inline where the races live

**Visual Documentation**

-   [ ] Mermaid diagram

#### 💭 Documentation Notes

Internal boot-sequencing fix; no API or user-facing flow changes. The inline comments explain the races so the gates aren't "simplified" away later.

# ✅ PR Checklist

-   [ ] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases (hard-refresh fix verified via trace; login-flash fix + regression sweep pending per QA steps)
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes (2 pre-existing failures on main excluded)
-   [x] I have completed the **Documentation Checklist** above
-   [x] I have considered **product analytics** (side benefit: removes duplicate boot-time analytics/LaunchDarkly identifies)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Eliminate UI flashes during app boot by preventing wallet destruction during coordinator re-initialization and bridging auth provider swaps with transitional states.

Main changes:
- Preserve wallet through transitional auth statuses and backfill missing identity fields post-Firebase session restore instead of rebuilding
- Add synchronous 'authenticating' state bridge when real auth provider arrives to prevent stale 'idle' login screen flash
- Preload landing route chunks (dashboard, wallet, current path) during boot before auth resolves to eliminate Suspense gaps

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


