### PR TITLE
chore: Update Claim Page Styles

### DIFF
--- a/.changeset/major-walls-doubt.md
+++ b/.changeset/major-walls-doubt.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+chore: Update Claim Page Styles

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -3,33 +3,12 @@ import moment from 'moment';
 import { useHistory, useLocation } from 'react-router-dom';
 import queryString from 'query-string';
 import { VC, VP } from '@learncard/types';
-import {
-    IonLoading,
-    IonContent,
-    IonPage,
-    IonRow,
-    IonFooter,
-    IonToolbar,
-    useIonModal,
-    IonButton,
-    IonButtons,
-    IonCol,
-    IonGrid,
-    IonHeader,
-    IonIcon,
-    IonMenuButton,
-    IonText,
-    IonTitle,
-    IonSpinner,
-} from '@ionic/react';
+import { IonContent, IonPage, useIonModal } from '@ionic/react';
 
 import { getLogger } from 'learn-card-base';
 const log = getLogger('claim-from-request');
 
 import ClaimBoostLoggedOutPrompt from 'learn-card-base/components/boost/claimBoostLoggedOutPrompt/ClaimBoostLoggedOutPrompt';
-import VCDisplayCardWrapper2 from 'learn-card-base/components/vcmodal/VCDisplayCardWrapper2';
-import FatArrow from 'learn-card-base/svgs/FatArrow';
-import X from 'learn-card-base/svgs/X';
 
 import {
     ProfilePicture,
@@ -64,13 +43,7 @@ import ExchangeInitiate from './ExchangeInitiate';
 import ExchangeDidAuth from './ExchangeDidAuth';
 import ExchangeLoading from './ExchangeLoading';
 
-import {
-    checkmarkCircleOutline,
-    closeCircleOutline,
-    homeOutline,
-    refreshOutline,
-} from 'ionicons/icons';
-import { AlertCircle, RefreshCw, Home, HelpCircle, MessageCircle, CheckCircle } from 'lucide-react';
+import { AlertCircle, RefreshCw, Home, CheckCircle } from 'lucide-react';
 import LoggedOutRequest from './LoggedOutRequest';
 import { getInfoFromCredential } from 'learn-card-base/components/CredentialBadge/CredentialVerificationDisplay';
 
@@ -203,7 +176,7 @@ const ClaimBoostBodyPreviewOverride: React.FC<{ boostVC: VC }> = ({ boostVC }) =
                                 customSize={500}
                             />
                         ) : (
-                            <div className="flex flex-row items-center justify-center h-full w-full overflow-hidden bg-gray-50 text-emerald-700 font-semibold text-xl">
+                            <div className="flex flex-row items-center justify-center h-full w-full overflow-hidden bg-grayscale-100 text-emerald-700 font-semibold text-xl">
                                 {getEmojiFromDidString(issuer)}
                             </div>
                         )}
@@ -346,44 +319,48 @@ const ExchangeErrorDisplay: React.FC<{
     const friendlyError = getFriendlyErrorInfo(rawErrorMessage);
 
     return (
-        <div className="min-h-full bg-gradient-to-br from-rose-50 via-white to-orange-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-3xl shadow-xl max-w-md w-full overflow-hidden">
+        <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+            <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
                 {/* Header with icon */}
-                <div className="bg-gradient-to-r from-rose-500 to-orange-500 px-6 py-8 text-center">
-                    <div className="w-20 h-20 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-4">
-                        <AlertCircle className="w-10 h-10 text-white" />
+                <div className="bg-white px-6 py-8 text-center border-b border-grayscale-200">
+                    <div className="w-16 h-16 bg-red-50 rounded-2xl flex items-center justify-center mx-auto mb-5">
+                        <AlertCircle className="w-8 h-8 text-red-500" />
                     </div>
 
-                    <h1 className="text-2xl font-bold text-white mb-2">{friendlyError.title}</h1>
+                    <h1 className="text-xl font-semibold text-grayscale-900 mb-2">
+                        {friendlyError.title}
+                    </h1>
 
-                    <p className="text-rose-100 text-sm">We couldn't complete your request</p>
+                    <p className="text-grayscale-500 text-sm">We couldn't complete your request</p>
                 </div>
 
                 {/* Content */}
                 <div className="p-6">
-                    <div className="space-y-4 mb-6">
-                        <p className="text-gray-600 text-center text-sm">
+                    <div className="space-y-5 mb-6">
+                        <p className="text-grayscale-600 text-center text-sm leading-relaxed">
                             {friendlyError.description}
                         </p>
 
                         {/* Suggestion box */}
-                        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
-                            <p className="text-xs font-medium text-amber-600 uppercase tracking-wide mb-2">
+                        <div className="bg-amber-50 border border-amber-100 rounded-2xl p-5">
+                            <p className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-2">
                                 What to do
                             </p>
 
-                            <p className="text-sm text-amber-800">{friendlyError.suggestion}</p>
+                            <p className="text-sm text-amber-800 leading-relaxed">
+                                {friendlyError.suggestion}
+                            </p>
                         </div>
 
                         {/* Technical details (collapsed by default feeling) */}
                         {errorData && rawErrorMessage !== friendlyError.description && (
                             <details className="group">
-                                <summary className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">
+                                <summary className="text-xs text-grayscale-400 cursor-pointer hover:text-grayscale-600 transition-colors">
                                     Show technical details
                                 </summary>
 
-                                <div className="mt-2 bg-gray-100 rounded-lg p-3">
-                                    <p className="text-xs text-gray-600 font-mono break-words">
+                                <div className="mt-3 bg-grayscale-100 rounded-xl p-4">
+                                    <p className="text-xs text-grayscale-600 font-mono break-words">
                                         {rawErrorMessage}
                                     </p>
                                 </div>
@@ -395,18 +372,18 @@ const ExchangeErrorDisplay: React.FC<{
                     <div className="space-y-3">
                         <button
                             onClick={() => onRetry()}
-                            className="w-full py-4 px-6 bg-gradient-to-r from-rose-500 to-orange-500 text-white font-semibold rounded-xl hover:from-rose-600 hover:to-orange-600 transition-all flex items-center justify-center gap-2 shadow-lg shadow-rose-500/25"
+                            className="w-full py-3 px-4 bg-grayscale-900 text-white font-medium text-sm rounded-[20px] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
                         >
-                            <RefreshCw className="w-5 h-5" />
-                            Try Again
+                            <RefreshCw className="w-4 h-4" />
+                            Try again
                         </button>
 
                         <button
                             onClick={onCancel}
-                            className="w-full py-3 px-6 text-gray-500 font-medium rounded-xl hover:bg-gray-100 transition-colors flex items-center justify-center gap-2"
+                            className="w-full py-3 px-4 text-sm text-grayscale-600 font-medium rounded-[20px] hover:text-grayscale-900 hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
                         >
                             <Home className="w-4 h-4" />
-                            Go Back Home
+                            Go back home
                         </button>
                     </div>
                 </div>
@@ -420,26 +397,28 @@ const ExchangeSuccessDisplay: React.FC<{
     description?: string;
     onDone: () => void;
 }> = ({
-    title = 'Shared Successfully',
+    title = 'Shared successfully',
     description = 'Your credentials were shared successfully.',
     onDone,
 }) => (
-    <div className="min-h-full bg-gradient-to-br from-emerald-50 via-white to-emerald-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-3xl shadow-xl max-w-md w-full overflow-hidden">
-            <div className="bg-gradient-to-r from-emerald-500 to-emerald-600 px-6 py-8 text-center">
-                <div className="w-20 h-20 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-4">
-                    <CheckCircle className="w-10 h-10 text-white" />
+    <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+        <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
+            <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 px-6 py-8 text-center">
+                <div className="w-16 h-16 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-5">
+                    <CheckCircle className="w-8 h-8 text-white" />
                 </div>
-                <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
-                <p className="text-emerald-100 text-sm">You're all set</p>
+                <h1 className="text-xl font-semibold text-white mb-2">{title}</h1>
+                <p className="text-emerald-50 text-sm">You're all set</p>
             </div>
             <div className="p-6">
-                <p className="text-grayscale-600 text-center text-sm mb-6">{description}</p>
+                <p className="text-grayscale-600 text-center text-sm leading-relaxed mb-6">
+                    {description}
+                </p>
                 <button
                     onClick={onDone}
-                    className="w-full py-4 px-6 bg-grayscale-900 text-white font-semibold rounded-[20px] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                    className="w-full py-3 px-4 bg-grayscale-900 text-white font-medium text-sm rounded-[20px] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
                 >
-                    <Home className="w-5 h-5" />
+                    <Home className="w-4 h-4" />
                     Done
                 </button>
             </div>

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { VC, VP } from '@learncard/types';
 import { IonContent, IonPage, IonFooter, IonToolbar, IonRow, IonLoading } from '@ionic/react';
-import { Gift, Check, X as XIcon, Loader2, AlertCircle, Home, HelpCircle } from 'lucide-react';
+import { Gift, Check, X as XIcon, AlertCircle, Home, HelpCircle } from 'lucide-react';
 
 import { getLogger } from 'learn-card-base';
 const log = getLogger('exchange-accept-credentials');
@@ -211,21 +211,21 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
     };
 
     const renderMultipleCredentials = () => (
-        <div className="min-h-full bg-gradient-to-br from-emerald-50 via-white to-cyan-50 pb-[120px]">
-            <div className="max-w-4xl mx-auto px-4 py-6">
+        <div className="min-h-full bg-grayscale-100 pb-[120px] font-poppins">
+            <div className="max-w-4xl mx-auto px-4 py-6 animate-fade-in-up">
                 {/* Header */}
                 <div className="text-center mb-6">
-                    <div className="w-16 h-16 bg-gradient-to-r from-emerald-500 to-cyan-500 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-lg shadow-emerald-500/25">
-                        <Gift className="w-8 h-8 text-white" />
+                    <div className="w-16 h-16 bg-white rounded-2xl flex items-center justify-center mx-auto mb-5 shadow-sm border border-grayscale-200">
+                        <Gift className="w-8 h-8 text-emerald-600" />
                     </div>
 
-                    <h1 className="text-2xl font-bold text-gray-900 mb-2">
-                        {credentials.length} Credentials Ready to Claim
+                    <h1 className="text-xl font-semibold text-grayscale-900 mb-2">
+                        {credentials.length} credentials ready to claim
                     </h1>
 
-                    <p className="text-gray-600 text-sm max-w-md mx-auto">
+                    <p className="text-grayscale-600 text-sm max-w-md mx-auto leading-relaxed">
                         Tap each credential to select or deselect it. Only selected credentials will
-                        be added to your wallet.
+                        be added to your account.
                     </p>
                 </div>
 
@@ -254,35 +254,35 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                 </div>
 
                 {/* Summary footer */}
-                <div className="mt-6 p-4 bg-white rounded-xl border border-gray-200 shadow-sm">
+                <div className="mt-6 p-5 bg-white rounded-[20px] border border-grayscale-200 shadow-sm">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-3">
                             <div
                                 className={`w-10 h-10 rounded-full flex items-center justify-center ${
                                     selectedCredentials.length > 0
-                                        ? 'bg-emerald-100'
-                                        : 'bg-gray-100'
+                                        ? 'bg-emerald-50'
+                                        : 'bg-grayscale-100'
                                 }`}
                             >
                                 <Check
                                     className={`w-5 h-5 ${
                                         selectedCredentials.length > 0
                                             ? 'text-emerald-600'
-                                            : 'text-gray-400'
+                                            : 'text-grayscale-400'
                                     }`}
                                 />
                             </div>
 
                             <div>
-                                <p className="font-medium text-gray-900">
+                                <p className="font-medium text-grayscale-900 text-sm">
                                     {selectedCredentials.length} of {credentials.length} credential
                                     {credentials.length !== 1 ? 's' : ''} selected
                                 </p>
 
-                                <p className="text-sm text-gray-500">
+                                <p className="text-sm text-grayscale-500">
                                     {selectedCredentials.length === 0
                                         ? 'Select at least one to continue'
-                                        : 'These will be added to your wallet'}
+                                        : 'These will be added to your account'}
                                 </p>
                             </div>
                         </div>
@@ -296,11 +296,11 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                                     setSelectedIndices(new Set(credentials.map((_, i) => i)));
                                 }
                             }}
-                            className="text-sm text-cyan-600 hover:text-cyan-700 font-medium"
+                            className="text-sm text-emerald-600 hover:text-emerald-700 font-medium transition-colors"
                         >
                             {selectedCredentials.length === credentials.length
-                                ? 'Deselect All'
-                                : 'Select All'}
+                                ? 'Deselect all'
+                                : 'Select all'}
                         </button>
                     </div>
                 </div>
@@ -312,32 +312,32 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         return (
             <IonPage>
                 <IonContent fullscreen className="ion-padding">
-                    <div className="min-h-full bg-gradient-to-br from-amber-50 via-white to-orange-50 flex items-center justify-center p-4">
-                        <div className="bg-white rounded-3xl shadow-xl max-w-md w-full overflow-hidden">
+                    <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+                        <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
                             {/* Header with icon */}
-                            <div className="bg-gradient-to-r from-amber-500 to-orange-500 px-6 py-8 text-center">
-                                <div className="w-20 h-20 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-4">
-                                    <AlertCircle className="w-10 h-10 text-white" />
+                            <div className="bg-white px-6 py-8 text-center border-b border-grayscale-200">
+                                <div className="w-16 h-16 bg-amber-50 rounded-2xl flex items-center justify-center mx-auto mb-5">
+                                    <AlertCircle className="w-8 h-8 text-amber-500" />
                                 </div>
 
-                                <h1 className="text-2xl font-bold text-white mb-2">
-                                    No Credentials Found
+                                <h1 className="text-xl font-semibold text-grayscale-900 mb-2">
+                                    No credentials found
                                 </h1>
 
-                                <p className="text-amber-100 text-sm">
+                                <p className="text-grayscale-500 text-sm">
                                     This link doesn't contain any credentials
                                 </p>
                             </div>
 
                             {/* Content */}
                             <div className="p-6">
-                                <div className="space-y-4 mb-6">
-                                    <p className="text-gray-600 text-center text-sm">
+                                <div className="space-y-5 mb-6">
+                                    <p className="text-grayscale-600 text-center text-sm leading-relaxed">
                                         The credential link you followed doesn't have any
                                         credentials to claim. This could happen if:
                                     </p>
 
-                                    <ul className="text-sm text-gray-500 space-y-2 pl-4">
+                                    <ul className="text-sm text-grayscale-600 space-y-2 pl-4">
                                         <li className="flex items-start gap-2">
                                             <span className="text-amber-500 mt-0.5">•</span>
                                             The credential has already been claimed
@@ -348,17 +348,17 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                                         </li>
                                         <li className="flex items-start gap-2">
                                             <span className="text-amber-500 mt-0.5">•</span>
-                                            The issuer removed the credential
+                                            The sender removed the credential
                                         </li>
                                     </ul>
 
                                     {/* Suggestion box */}
-                                    <div className="bg-cyan-50 border border-cyan-200 rounded-xl p-4">
-                                        <p className="text-xs font-medium text-cyan-600 uppercase tracking-wide mb-2">
+                                    <div className="bg-amber-50 border border-amber-100 rounded-2xl p-5">
+                                        <p className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-2">
                                             What to do
                                         </p>
 
-                                        <p className="text-sm text-cyan-800">
+                                        <p className="text-sm text-amber-800 leading-relaxed">
                                             Contact the person or organization that sent you this
                                             link to request a new one.
                                         </p>
@@ -369,20 +369,20 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                                 <div className="space-y-3">
                                     <button
                                         onClick={() => history.push('/')}
-                                        className="w-full py-4 px-6 bg-gradient-to-r from-cyan-500 to-blue-500 text-white font-semibold rounded-xl hover:from-cyan-600 hover:to-blue-600 transition-all flex items-center justify-center gap-2 shadow-lg shadow-cyan-500/25"
+                                        className="w-full py-3 px-4 bg-grayscale-900 text-white font-medium text-sm rounded-[20px] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
                                     >
-                                        <Home className="w-5 h-5" />
-                                        Go to Home
+                                        <Home className="w-4 h-4" />
+                                        Go to home
                                     </button>
 
                                     <button
                                         onClick={() =>
                                             window.open('mailto:support@learncard.com', '_blank')
                                         }
-                                        className="w-full py-3 px-6 text-gray-500 font-medium rounded-xl hover:bg-gray-100 transition-colors flex items-center justify-center gap-2"
+                                        className="w-full py-3 px-4 text-sm text-grayscale-600 font-medium rounded-[20px] hover:text-grayscale-900 hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
                                     >
                                         <HelpCircle className="w-4 h-4" />
-                                        Contact Support
+                                        Contact support
                                     </button>
                                 </div>
                             </div>
@@ -407,15 +407,15 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                     <IonRow className="relative z-10 w-full flex flex-nowrap justify-center items-center gap-4">
                         <button
                             onClick={() => history.push('/')} // Or some other cancel action
-                            className="w-[50px] h-[50px] min-h-[50px] min-w-[50px] bg-white rounded-full flex items-center justify-center shadow-3xl"
+                            className="w-[50px] h-[50px] min-h-[50px] min-w-[50px] bg-white rounded-full flex items-center justify-center shadow-lg border border-grayscale-200 hover:bg-grayscale-10 transition-colors"
                         >
-                            <X className="text-black w-[30px]" />
+                            <XIcon className="text-grayscale-600 w-6 h-6" />
                         </button>
 
                         <button
                             onClick={handleClaim}
                             disabled={claiming || isClaimed}
-                            className={`flex items-center justify-center bg-${primaryColor} text-white py-2 mr-3 font-bold text-2xl tracking-wider rounded-[40px] shadow-2xl w-[200px] max-w-[320px] ml-2 normal font-poppins`}
+                            className={`flex items-center justify-center bg-${primaryColor} text-white py-3 px-4 font-medium text-sm rounded-[20px] shadow-lg w-[200px] max-w-[320px] ml-2 font-poppins hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed`}
                         >
                             {isClaimed ? 'Claimed' : 'Accept'}
                         </button>

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeDidAuth.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeDidAuth.tsx
@@ -4,7 +4,7 @@ import { VP } from '@learncard/types';
 import { useWallet, useIsLoggedIn } from 'learn-card-base';
 import { useHistory } from 'react-router-dom';
 import { VCAPIRequestStrategy } from './ClaimFromRequest';
-import { Gift, Shield, ChevronRight, X, Loader2, CheckCircle, Info } from 'lucide-react';
+import { Gift, Shield, CheckCircle, Info } from 'lucide-react';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('exchange-did-auth');
 
@@ -72,89 +72,93 @@ const ExchangeDidAuth: React.FC<ExchangeDidAuthProps> = ({
     return (
         <IonPage>
             <IonContent fullscreen>
-                <div className="min-h-full bg-gradient-to-br from-emerald-50 via-white to-cyan-50 flex items-center justify-center p-4">
-                    <div className="bg-white rounded-3xl shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin">
+                <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+                    <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
                         {/* Header with icon */}
-                        <div className="bg-gradient-to-r from-emerald-500 to-cyan-500 px-6 py-8 text-center">
-                            <div className="w-20 h-20 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-4">
-                                <Gift className="w-10 h-10 text-white" />
+                        <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 px-6 py-8 text-center">
+                            <div className="w-16 h-16 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-5">
+                                <Gift className="w-8 h-8 text-white" />
                             </div>
 
-                            <h1 className="text-2xl font-bold text-white mb-2">
-                                You've Been Sent a Credential!
+                            <h1 className="text-xl font-semibold text-white mb-2">
+                                You've been sent a credential
                             </h1>
 
-                            <p className="text-emerald-100 text-sm">
-                                Someone wants to issue you a verifiable credential
+                            <p className="text-emerald-50 text-sm">
+                                Confirm your identity to receive it
                             </p>
                         </div>
 
                         {/* Content */}
                         <div className="p-6">
-                            <div className="space-y-4 mb-6">
-                                <h2 className="text-lg font-semibold text-gray-900 text-center">
-                                    Ready to claim it?
-                                </h2>
+                            <div className="space-y-5 mb-6">
+                                <div className="space-y-1">
+                                    <h2 className="text-lg font-semibold text-grayscale-900 text-center">
+                                        Ready to claim it?
+                                    </h2>
 
-                                <p className="text-gray-600 text-center text-sm">
-                                    To receive this credential, you'll need to confirm your
-                                    identity. This lets the issuer securely deliver it to your
-                                    wallet.
-                                </p>
+                                    <p className="text-grayscale-600 text-center text-sm leading-relaxed">
+                                        To receive this credential, you'll need to confirm your
+                                        identity. This lets the sender securely deliver it to your
+                                        account.
+                                    </p>
+                                </div>
 
                                 {/* What happens section */}
-                                <div className="bg-gray-50 rounded-xl p-4 space-y-3">
-                                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                                <div className="bg-grayscale-10 rounded-2xl p-5 space-y-4 border border-grayscale-200">
+                                    <p className="text-xs font-medium text-grayscale-700 uppercase tracking-wide">
                                         What happens when you continue:
                                     </p>
 
                                     <div className="flex items-start gap-3">
-                                        <div className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
+                                        <div className="w-6 h-6 bg-emerald-50 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
                                             <CheckCircle className="w-4 h-4 text-emerald-600" />
                                         </div>
 
-                                        <p className="text-sm text-gray-700">
-                                            Your wallet confirms your identity to the issuer
+                                        <p className="text-sm text-grayscale-800 leading-relaxed">
+                                            We confirm it's really you
                                         </p>
                                     </div>
 
                                     <div className="flex items-start gap-3">
-                                        <div className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
+                                        <div className="w-6 h-6 bg-emerald-50 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
                                             <CheckCircle className="w-4 h-4 text-emerald-600" />
                                         </div>
 
-                                        <p className="text-sm text-gray-700">
-                                            The credential is securely delivered to your wallet
+                                        <p className="text-sm text-grayscale-800 leading-relaxed">
+                                            Your credential arrives safely
                                         </p>
                                     </div>
 
                                     <div className="flex items-start gap-3">
-                                        <div className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
+                                        <div className="w-6 h-6 bg-emerald-50 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
                                             <CheckCircle className="w-4 h-4 text-emerald-600" />
                                         </div>
 
-                                        <p className="text-sm text-gray-700">
-                                            You own and control this credential forever
+                                        <p className="text-sm text-grayscale-800 leading-relaxed">
+                                            It's yours to keep, forever
                                         </p>
                                     </div>
                                 </div>
 
                                 {/* Privacy note */}
-                                <div className="flex items-start gap-2 text-xs text-gray-500">
-                                    <Shield className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                                <div className="flex items-start gap-2.5 text-xs text-grayscale-500">
+                                    <Shield className="w-4 h-4 flex-shrink-0 mt-0.5 text-grayscale-400" />
 
-                                    <p>
-                                        Your identity is only shared with the issuer to complete
-                                        this exchange. You're always in control of your data.
+                                    <p className="leading-relaxed">
+                                        Your identity is only shared to complete this exchange.
+                                        You're always in control of your data.
                                     </p>
                                 </div>
                             </div>
 
                             {/* Error message */}
                             {error && (
-                                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl flex items-center gap-2 text-red-700 text-sm">
-                                    <Info className="w-4 h-4 flex-shrink-0" />
-                                    {error}
+                                <div className="mb-5 p-3 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-2.5">
+                                    <Info className="text-red-400 w-5 h-5 mt-0.5 shrink-0" />
+                                    <span className="text-sm text-red-700 leading-relaxed">
+                                        {error}
+                                    </span>
                                 </div>
                             )}
 
@@ -163,27 +167,23 @@ const ExchangeDidAuth: React.FC<ExchangeDidAuthProps> = ({
                                 <button
                                     onClick={handleAccept}
                                     disabled={isLoading}
-                                    className="w-full py-4 px-6 bg-gradient-to-r from-emerald-500 to-cyan-500 text-white font-semibold rounded-xl hover:from-emerald-600 hover:to-cyan-600 transition-all flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed shadow-lg shadow-emerald-500/25"
+                                    className="w-full py-3 px-4 bg-emerald-600 text-white font-medium text-sm rounded-[20px] hover:bg-emerald-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
                                 >
                                     {isLoading ? (
                                         <>
-                                            <Loader2 className="w-5 h-5 animate-spin" />
+                                            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
                                             Connecting...
                                         </>
                                     ) : (
-                                        <>
-                                            Claim My Credential
-                                            <ChevronRight className="w-5 h-5" />
-                                        </>
+                                        <>Claim my credential</>
                                     )}
                                 </button>
 
                                 <button
                                     onClick={handleDecline}
                                     disabled={isLoading}
-                                    className="w-full py-3 px-6 text-gray-500 font-medium rounded-xl hover:bg-gray-100 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+                                    className="w-full py-3 px-4 text-sm text-grayscale-600 font-medium rounded-[20px] hover:text-grayscale-900 hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
                                 >
-                                    <X className="w-4 h-4" />
                                     No thanks, take me home
                                 </button>
                             </div>

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeInitiate.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeInitiate.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IonContent, IonPage, IonButton } from '@ionic/react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Gift } from 'lucide-react';
 
 interface ExchangeInitiateProps {
     onStart: () => void;
@@ -8,15 +9,44 @@ interface ExchangeInitiateProps {
 const ExchangeInitiate: React.FC<ExchangeInitiateProps> = ({ onStart }) => {
     return (
         <IonPage>
-            <IonContent fullscreen className="ion-padding">
-                <div className="flex flex-col items-center justify-center h-full">
-                    <h1 className="text-2xl font-bold text-center mb-4">
-                        You've been sent a request
-                    </h1>
-                    <p className="text-center mb-8">
-                        Click the button below to begin the exchange process.
-                    </p>
-                    <IonButton onClick={onStart}>Begin</IonButton>
+            <IonContent fullscreen>
+                <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+                    <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
+                        {/* Header with icon */}
+                        <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 px-6 py-8 text-center">
+                            <div className="w-16 h-16 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-5">
+                                <Gift className="w-8 h-8 text-white" />
+                            </div>
+
+                            <h1 className="text-xl font-semibold text-white mb-2">
+                                You've been sent a request
+                            </h1>
+
+                            <p className="text-emerald-50 text-sm">
+                                A credential exchange is ready
+                            </p>
+                        </div>
+
+                        {/* Content */}
+                        <div className="p-6">
+                            <div className="space-y-5 mb-6">
+                                <p className="text-grayscale-600 text-center text-sm leading-relaxed">
+                                    Click the button below to begin the exchange process and see
+                                    what was sent to you.
+                                </p>
+                            </div>
+
+                            {/* Action buttons */}
+                            <div className="space-y-3">
+                                <button
+                                    onClick={onStart}
+                                    className="w-full py-3 px-4 bg-emerald-600 text-white font-medium text-sm rounded-[20px] hover:bg-emerald-700 transition-colors flex items-center justify-center gap-2"
+                                >
+                                    Begin
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </IonContent>
         </IonPage>

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeLoading.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeLoading.tsx
@@ -4,18 +4,9 @@ const ExchangeLoading = () => {
     return (
         <IonPage>
             <IonContent fullscreen>
-                <div
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        height: '100%',
-                        textAlign: 'center',
-                    }}
-                >
-                    <IonSpinner name="crescent" />
-                    <p style={{ marginTop: '1rem' }}>Loading...</p>
+                <div className="min-h-full bg-grayscale-100 flex flex-col items-center justify-center p-4 font-poppins">
+                    <IonSpinner name="crescent" className="text-emerald-600 w-8 h-8 mb-4" />
+                    <p className="text-sm text-grayscale-600 font-medium">Loading...</p>
                 </div>
             </IonContent>
         </IonPage>

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeRedirect.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeRedirect.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IonContent, IonPage, IonButton } from '@ionic/react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Home } from 'lucide-react';
 
 interface ExchangeRedirectProps {
     redirectUrl: string; // Contains the redirectUrl from the server
@@ -14,17 +15,42 @@ const ExchangeRedirect: React.FC<ExchangeRedirectProps> = ({ redirectUrl }) => {
 
     return (
         <IonPage>
-            <IonContent fullscreen className="ion-padding">
-                <div className="flex flex-col items-center justify-center h-full">
-                    <h1 className="text-2xl font-bold text-center mb-4">
-                        Redirect Required
-                    </h1>
-                    <p className="text-center mb-8">
-                        To continue, you need to complete a step on an external website.
-                    </p>
-                    <IonButton onClick={handleRedirect} disabled={!redirectUrl}>
-                        Continue
-                    </IonButton>
+            <IonContent fullscreen>
+                <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+                    <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
+                        {/* Header with icon */}
+                        <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 px-6 py-8 text-center">
+                            <div className="w-16 h-16 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-5">
+                                <Home className="w-8 h-8 text-white" />
+                            </div>
+
+                            <h1 className="text-xl font-semibold text-white mb-2">
+                                Redirect required
+                            </h1>
+
+                            <p className="text-emerald-50 text-sm">Complete the next step</p>
+                        </div>
+
+                        {/* Content */}
+                        <div className="p-6">
+                            <div className="space-y-5 mb-6">
+                                <p className="text-grayscale-600 text-center text-sm leading-relaxed">
+                                    To continue, you need to complete a step on an external website.
+                                </p>
+                            </div>
+
+                            {/* Action buttons */}
+                            <div className="space-y-3">
+                                <button
+                                    onClick={handleRedirect}
+                                    disabled={!redirectUrl}
+                                    className="w-full py-3 px-4 bg-emerald-600 text-white font-medium text-sm rounded-[20px] hover:bg-emerald-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    Continue
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </IonContent>
         </IonPage>

--- a/apps/learn-card-app/src/pages/claim-from-request/InteractWithWallet.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/InteractWithWallet.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState } from 'react';
-import { IonList, IonItem } from '@ionic/react';
+import { IonList } from '@ionic/react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useModal, ModalTypes } from 'learn-card-base';
 import { useBrandingConfig } from 'learn-card-base/config/TenantConfigProvider';
 import { useTenantBrandingAssets } from '../../config/brandingAssets';
 import { getAppBaseUrl, getResolvedTenantConfig } from '../../config/bootstrapTenantConfig';
 import CaretDown from 'learn-card-base/svgs/CaretDown';
+import { AlertCircle } from 'lucide-react';
 
 // Simple wallet option type
 interface WalletOption {
@@ -52,9 +53,9 @@ const InteractWithWallet: React.FC<{
     }, [vcRequestUrl]);
 
     const headingText = useMemo(() => {
-        if (workflowId === 'claim') return 'You Have a Credential to Claim';
-        if (workflowId === 'verify') return 'Present Your Credentials';
-        return 'Continue in Your Wallet';
+        if (workflowId === 'claim') return 'You have a credential to claim';
+        if (workflowId === 'verify') return 'Present your credentials';
+        return 'Continue in your wallet';
     }, [workflowId]);
 
     const subheadingText = useMemo(() => {
@@ -66,7 +67,7 @@ const InteractWithWallet: React.FC<{
     }, [workflowId]);
 
     const buttonText = useMemo(() => {
-        if (workflowId === 'claim') return 'Claim with Wallet';
+        if (workflowId === 'claim') return 'Claim in LearnCard';
         if (workflowId === 'verify') return 'Verify with Wallet';
         return 'Open in Wallet';
     }, [workflowId]);
@@ -93,8 +94,7 @@ const InteractWithWallet: React.FC<{
         const lcwWallet: WalletOption = {
             name: 'Learner Credential Wallet',
 
-            urlTemplate: url =>
-                `https://lcw.app/request?vc_request_url=${encodeURIComponent(url)}`,
+            urlTemplate: url => `https://lcw.app/request?vc_request_url=${encodeURIComponent(url)}`,
         };
 
         if (isLearnCardTenant) return [learnCardWallet, lcwWallet];
@@ -131,28 +131,43 @@ const InteractWithWallet: React.FC<{
 
     if (!vcRequestUrl) {
         return (
-            <div className="w-full h-full flex items-center justify-center p-6">
-                <div className="max-w-md w-full bg-white rounded-2xl shadow-lg p-6 text-center">
-                    <h2 className="text-xl font-semibold mb-2">Invalid request link</h2>
-                    <p className="text-gray-600">Missing or invalid vc_request_url.</p>
+            <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+                <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
+                    <div className="bg-white px-6 py-8 text-center border-b border-grayscale-200">
+                        <div className="w-16 h-16 bg-red-50 rounded-2xl flex items-center justify-center mx-auto mb-5">
+                            <AlertCircle className="w-8 h-8 text-red-500" />
+                        </div>
+                        <h1 className="text-xl font-semibold text-grayscale-900 mb-2">
+                            Invalid request link
+                        </h1>
+                        <p className="text-grayscale-500 text-sm">
+                            Missing or invalid vc_request_url.
+                        </p>
+                    </div>
                 </div>
             </div>
         );
     }
 
     return (
-        <div className="w-full h-full flex justify-center  p-3">
-            <div className="max-w-lg w-full bg-white">
-                <div className="flex flex-col items-center text-center">
-                    <div className="mb-4 mt-[20px]">
-                        <img src={brandMark} alt="Brand mark" className="rounded-2xl h-16 w-16" />
+        <div className="min-h-full bg-grayscale-100 flex items-center justify-center p-4 font-poppins">
+            <div className="bg-white rounded-[20px] shadow-xl max-w-md w-full overflow-hidden safe-area-top-margin animate-fade-in-up">
+                <div className="p-6 flex flex-col items-center text-center">
+                    <div className="mb-5 mt-2">
+                        <img
+                            src={brandMark}
+                            alt="Brand mark"
+                            className="rounded-2xl h-16 w-16 shadow-sm border border-grayscale-200"
+                        />
                     </div>
 
-                    <h1 className="text-2xl font-bold mb-2">{headingText}</h1>
-                    <p className="text-gray-600 mb-6">{subheadingText}</p>
+                    <h1 className="text-xl font-semibold text-grayscale-900 mb-2">{headingText}</h1>
+                    <p className="text-grayscale-600 text-sm leading-relaxed mb-6">
+                        {subheadingText}
+                    </p>
 
-                    <div className="mb-6 p-4 border rounded-lg inline-block bg-white">
-                        <div className="w-[220px] h-[220px]">
+                    <div className="mb-6 p-4 bg-grayscale-10 border border-grayscale-200 rounded-2xl inline-block">
+                        <div className="w-[200px] h-[200px] bg-white p-2 rounded-xl">
                             <QRCodeSVG
                                 value={deeplink}
                                 className="w-full h-full"
@@ -161,27 +176,25 @@ const InteractWithWallet: React.FC<{
                         </div>
                     </div>
 
-                    <div className="mb-4 w-full">
-                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <div className="mb-6 w-full text-left">
+                        <label className="block text-xs font-medium text-grayscale-700 uppercase tracking-wide mb-2">
                             Open with:
                         </label>
-                        <div className="flex items-center gap-3">
-                            <InteractSelector
-                                wallets={wallets}
-                                selectedIndex={selectedIndex}
-                                setSelectedIndex={setSelectedIndex}
-                            />
-                        </div>
+                        <InteractSelector
+                            wallets={wallets}
+                            selectedIndex={selectedIndex}
+                            setSelectedIndex={setSelectedIndex}
+                        />
                     </div>
 
                     <a
                         href={deeplink}
-                        className="block w-full bg-blue-600 text-white font-bold py-3 px-4 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-300"
+                        className="w-full py-3 px-4 bg-emerald-600 text-white font-medium text-sm rounded-[20px] hover:bg-emerald-700 transition-colors flex items-center justify-center gap-2"
                     >
                         {buttonText}
                     </a>
 
-                    <p className="mt-6 text-sm text-gray-500">
+                    <p className="mt-5 text-xs text-grayscale-500">
                         Scan the QR code or tap the button above.
                     </p>
                 </div>
@@ -202,9 +215,9 @@ const InteractSelectorOptions: React.FC<{
         mobile: ModalTypes.Cancel,
     });
     return (
-        <div className="p-6">
-            <p>Select a wallet:</p>
-            <IonList className="mb-6 w-full h-full">
+        <div className="p-6 font-poppins">
+            <p className="text-lg font-semibold text-grayscale-900 mb-4">Select a wallet</p>
+            <IonList className="w-full h-full bg-transparent">
                 {wallets.map((wallet, idx) => {
                     const isSelected = idx === selectedIndex;
                     return (
@@ -214,18 +227,18 @@ const InteractSelectorOptions: React.FC<{
                                 closeModal();
                                 setSelectedIndex(idx);
                             }}
-                            className={`w-full rounded-full pl-[10px] pr-4 py-[6px] flex items-center justify-between  mt-4 mb-4 cursor-pointer ${
+                            className={`w-full rounded-[20px] p-3 flex items-center justify-between mb-3 cursor-pointer transition-colors border ${
                                 isSelected
-                                    ? 'bg-indigo-50 border-indigo-50 bg-indigo-50'
-                                    : 'bg-white'
+                                    ? 'bg-grayscale-10 border-grayscale-300'
+                                    : 'bg-white border-transparent hover:bg-grayscale-10'
                             }`}
                         >
                             <div className="flex items-center justify-start">
-                                <div className="w-[40px] bg-indigo-100 h-[40px] rounded-full  mr-2 overflow-hidden  cursor-pointer">
+                                <div className="w-10 h-10 bg-grayscale-100 rounded-2xl mr-3 overflow-hidden flex items-center justify-center">
                                     {wallet.icon}
                                 </div>
                                 <div className="flex flex-col items-start justify-center">
-                                    <h4 className="text-grayscale-800 text-left text-[17px]">
+                                    <h4 className="text-grayscale-900 font-medium text-sm">
                                         {wallet.name}
                                     </h4>
                                 </div>
@@ -258,19 +271,19 @@ const InteractSelector: React.FC<{
                     />
                 );
             }}
-            className="w-full rounded-full pl-[2px] pr-4 py-[6px] flex items-center justify-between border-[1px] border-solid border-grayscale-100 bg-grayscale-100 mt-4 mb-4"
+            className="w-full rounded-[20px] p-2 flex items-center justify-between border border-grayscale-200 bg-grayscale-10 hover:bg-grayscale-100 transition-colors"
         >
             <div className="flex items-center justify-start">
-                <div className="w-[40px] h-[40px] rounded-full bg-indigo-100 ml-[8px] mr-2 overflow-hidden">
+                <div className="w-10 h-10 rounded-2xl bg-grayscale-100 mr-3 overflow-hidden flex items-center justify-center">
                     {wallets[selectedIndex]?.icon}
                 </div>
                 <div className="flex flex-col items-start justify-center">
-                    <h4 className="text-grayscale-800 text-left text-[17px] line-clamp-1">
+                    <h4 className="text-grayscale-900 font-medium text-sm line-clamp-1">
                         {wallets[selectedIndex]?.name}
                     </h4>
                 </div>
             </div>
-            <CaretDown className="w-[20px] h-[20px] text-grayscale-800" />
+            <CaretDown className="w-5 h-5 text-grayscale-500 mr-2" />
         </button>
     );
 };


### PR DESCRIPTION
# Overview

## Before:
<img width="505" height="789" alt="Screenshot 2026-07-10 at 12 00 11 PM" src="https://github.com/user-attachments/assets/075818f0-54ca-420d-8780-8f4811025869" />

<img width="481" height="604" alt="Screenshot 2026-07-10 at 12 00 36 PM" src="https://github.com/user-attachments/assets/a5b9de41-3e51-4169-ad07-6a45c74eaa35" />


## After:

<img width="511" height="767" alt="Screenshot 2026-07-10 at 11 59 36 AM" src="https://github.com/user-attachments/assets/ed256a46-63f4-4b27-8c2a-deed4137be4a" />

<img width="564" height="659" alt="Screenshot 2026-07-10 at 11 59 52 AM" src="https://github.com/user-attachments/assets/f1d8a52e-66fa-4adc-a553-5a15f3e2c327" />

<img width="511" height="385" alt="Screenshot 2026-07-10 at 12 02 33 PM" src="https://github.com/user-attachments/assets/f899468d-c990-476d-aef3-1003923db76b" />



## What

Restyles the "claim a credential from a request" flow so every screen shares one look, instead of each step having its own colors and shapes.

Before, the flow was a bit of a design island: cyan/blue/rose/orange gradients, mismatched button shapes, generic Tailwind grays, and one screen even used indigo (which we reserve for Pathways). This aligns all of it to the app's design guidelines — grayscale/emerald/amber/red tokens, Poppins, pill buttons, and consistent cards.

## Why

A user going through claim → accept → success (or an error/redirect) would see the styling jump around between steps. This makes the whole journey feel like one cohesive, polished flow.

## What changed

Purely presentational. No logic, handlers, state machine, tracking, or wallet/QR behavior was touched.

- `ExchangeDidAuth.tsx` — the main "you've been sent a credential" screen: on-system card, emerald header, pill buttons, standard error banner. Copy de-jargoned ("wallet" → "account", "issuer" → "sender") and tightened.
- `ClaimFromRequest.tsx` — the error and success screens (rendered inline here) rebuilt to match; dropped rose/orange gradients.
- `ExchangeAcceptCredentials.tsx` — multi-credential grid, empty state, and footer buttons restyled. The Accept button keeps its tenant theme color but uses the standard pill shape now.
- `ExchangeInitiate.tsx` / `ExchangeRedirect.tsx` — were bare button screens, now proper on-system cards.
- `InteractWithWallet.tsx` — QR + wallet-picker screen restyled; removed indigo (reserved for Pathways v2).
- `ExchangeLoading.tsx` — inline-styled spinner replaced with on-system markup.

## Types of Changes

- [x] Chore (styling / UI polish, no behavior change)

# Testing

## How to QA

Open a credential claim/request link while logged in and walk the flow. The exchange can land on different steps depending on the request, so check whichever you can trigger:

1. Claim screen (`ExchangeDidAuth`) — confirm identity → claim the credential.
2. Accept screen — single credential, and multi-credential (select/deselect, select-all).
3. Empty state — a link with no credentials to claim.
4. Error state — e.g. an expired/invalid link.
5. Success and redirect screens.

For each, confirm: colors match the rest of the app (no stray cyan/blue/rose/orange/indigo), buttons are pill-shaped, text is readable, and buttons still do what they did before.

## Devices

Chromium primary; worth a glance on iOS/Android since this is a wallet flow.

## Code Coverage

No new tests — visual-only change, existing behavior unchanged.

# Documentation

No docs needed — no API or user-flow behavior changed, only styling.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor claim page UI components with consistent design system styling, replacing Ionic components and gradient backgrounds with standardized Tailwind classes and lucide-react icons.

Main changes:
- Replaced Ionic UI components (IonButton, IonLoading, etc.) with custom styled button elements using unified Tailwind classes and color palette (grayscale-*, emerald-*)
- Migrated icon libraries from ionicons to lucide-react (AlertCircle, RefreshCw, Home, CheckCircle, Gift, Shield) across multiple exchange flow pages
- Updated modal dialogs with consistent styling: simplified rounded corners ([20px] from [3xl]), reduced gradient backgrounds to solid grayscale, standardized spacing and typography

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
