### PR TITLE
fix: refresh claim-credential view + land on credential's category page

### DIFF
--- a/.changeset/wise-ducks-cheer.md
+++ b/.changeset/wise-ducks-cheer.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: refresh claim-credential view + land on credential's category page

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -58,6 +58,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { publishWalletEvent } from '../pathways/events/walletEventBus';
 import { CATEGORY_TO_ROUTE } from '../../helpers/categoryRoutes';
+import { ROUTE_PRELOAD } from '../../Routes';
 
 import ExchangePresentationRequest from './ExchangePresentationRequest';
 import ExchangeRedirect from './ExchangeRedirect';
@@ -480,6 +481,29 @@ const ClaimFromRequest: React.FC = () => {
 
     const { presentToast } = useToast();
 
+    // Resolve the wallet category route for a just-claimed credential (e.g.
+    // "/achievements", "/socialBadges"). Falls back to the passport ("/home")
+    // when the category can't be resolved.
+    const resolvePostClaimRoute = (claimedCredential?: VC): string => {
+        if (!claimedCredential) return '/home';
+        try {
+            const category = getDefaultCategoryForCredential(claimedCredential);
+            return CATEGORY_TO_ROUTE[category as CredentialCategoryEnum] ?? '/home';
+        } catch (err) {
+            log.warn('Failed to resolve post-claim category route', err);
+            return '/home';
+        }
+    };
+
+    // Warm the destination category chunk ahead of navigation. The credential
+    // itself is already inserted optimistically into the category list cache by
+    // storeAndAddVCToWallet, so warming the lazy route chunk while the user is
+    // still on the accept screen makes the post-claim hop feel instant (no
+    // Suspense fallback flash). Fire-and-forget.
+    const warmPostClaimRoute = (claimedCredential?: VC): void => {
+        void ROUTE_PRELOAD[resolvePostClaimRoute(claimedCredential)]?.();
+    };
+
     const handleRedirectTo = () => {
         const redirectTo = `/request?vc_request_url=${vc_request_url}`;
         redirectStore.set.lcnRedirect(redirectTo);
@@ -543,7 +567,7 @@ const ClaimFromRequest: React.FC = () => {
                     case 'DIDAuth':
                     default:
                         if (credentialClaimCount && credentialClaimCount > 0) {
-                            handleAfterCredentialClaim();
+                            void handleAfterCredentialClaim();
                             setExchangeState({ state: ExchangeState.Finished });
                             return;
                         } else {
@@ -556,6 +580,9 @@ const ClaimFromRequest: React.FC = () => {
                 // Remember the (first) credential being claimed for post-claim routing.
                 const vpCreds = data?.verifiableCredential;
                 claimedCredentialRef.current = Array.isArray(vpCreds) ? vpCreds[0] : vpCreds;
+                // Warm the destination category chunk while the user reviews the
+                // card so the post-claim navigation is instant.
+                warmPostClaimRoute(claimedCredentialRef.current);
                 setExchangeState({ state: ExchangeState.AcceptCredentials, data, strategy });
                 // Server sent a redirect URL
             } else if (type === RequestResponseDataType.RedirectUrl) {
@@ -594,25 +621,26 @@ const ClaimFromRequest: React.FC = () => {
         }
     }, [isLoggedIn]);
 
-    // Resolve the wallet category route for a just-claimed credential (e.g.
-    // "/achievements", "/socialBadges"). Falls back to the passport ("/home")
-    // when the category can't be resolved.
-    const resolvePostClaimRoute = (claimedCredential?: VC): string => {
-        if (!claimedCredential) return '/home';
-        try {
-            const category = getDefaultCategoryForCredential(claimedCredential);
-            return CATEGORY_TO_ROUTE[category as CredentialCategoryEnum] ?? '/home';
-        } catch (err) {
-            log.warn('Failed to resolve post-claim category route', err);
-            return '/home';
-        }
-    };
-
-    const handleAfterCredentialClaim = (claimedCredential?: VC) => {
+    const handleAfterCredentialClaim = async (claimedCredential?: VC) => {
         setExchangeState({ state: ExchangeState.Finished });
+
         // Land the user on the specific wallet category page of the credential
         // they just claimed (not the generic passport) so they see it in context.
-        history?.push(resolvePostClaimRoute(claimedCredential ?? claimedCredentialRef.current));
+        const route = resolvePostClaimRoute(claimedCredential ?? claimedCredentialRef.current);
+
+        // Await the destination chunk before navigating so the current view stays
+        // mounted (no Suspense fallback). warmPostClaimRoute already kicked this
+        // off when the accept screen appeared, so this usually resolves instantly;
+        // cap the wait so a stalled fetch can't block navigation.
+        const preload = ROUTE_PRELOAD[route];
+        if (preload) {
+            await Promise.race([
+                preload(),
+                new Promise<void>(resolve => setTimeout(resolve, 4000)),
+            ]).catch(() => undefined);
+        }
+
+        history?.push(route);
     };
 
     const handleClaimCredential = async () => {
@@ -662,7 +690,7 @@ const ClaimFromRequest: React.FC = () => {
             }
 
             setClaimingCredential(false);
-            handleAfterCredentialClaim(credential);
+            void handleAfterCredentialClaim(credential);
 
             presentToast(`Successfully claimed Credential!`, {
                 type: ToastTypeEnum.Success,
@@ -678,7 +706,7 @@ const ClaimFromRequest: React.FC = () => {
                     hasDismissButton: true,
                 });
 
-                handleAfterCredentialClaim(credential);
+                void handleAfterCredentialClaim(credential);
             } else {
                 presentToast(`Oops, we couldn't claim the credential.`, {
                     type: ToastTypeEnum.Error,

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import moment from 'moment';
 import { useHistory, useLocation } from 'react-router-dom';
 import queryString from 'query-string';
@@ -41,6 +41,7 @@ import {
     useCurrentUser,
     useToast,
     ToastTypeEnum,
+    CredentialCategoryEnum,
 } from 'learn-card-base';
 import { useQueryClient } from '@tanstack/react-query';
 import useRegistry from 'learn-card-base/hooks/useRegistry';
@@ -56,6 +57,7 @@ import { getEmojiFromDidString, getUserHandleFromDid } from 'learn-card-base/hel
 import { v4 as uuidv4 } from 'uuid';
 
 import { publishWalletEvent } from '../pathways/events/walletEventBus';
+import { CATEGORY_TO_ROUTE } from '../../helpers/categoryRoutes';
 
 import ExchangePresentationRequest from './ExchangePresentationRequest';
 import ExchangeRedirect from './ExchangeRedirect';
@@ -458,6 +460,11 @@ const ClaimFromRequest: React.FC = () => {
         state: ExchangeState.Loading,
     });
 
+    // The credential the user is claiming, captured so that after the exchange
+    // completes we can drop them on that credential's wallet category page
+    // (e.g. /achievements) instead of the generic passport (all categories).
+    const claimedCredentialRef = useRef<VC | undefined>(undefined);
+
     const { track } = useAnalytics();
 
     const queryClient = useQueryClient();
@@ -546,6 +553,9 @@ const ClaimFromRequest: React.FC = () => {
 
                 // Server sent a Verifiable Presentation, usually containing a verifiableCredential object
             } else if (type === RequestResponseDataType.VerifiablePresentation) {
+                // Remember the (first) credential being claimed for post-claim routing.
+                const vpCreds = data?.verifiableCredential;
+                claimedCredentialRef.current = Array.isArray(vpCreds) ? vpCreds[0] : vpCreds;
                 setExchangeState({ state: ExchangeState.AcceptCredentials, data, strategy });
                 // Server sent a redirect URL
             } else if (type === RequestResponseDataType.RedirectUrl) {
@@ -584,10 +594,25 @@ const ClaimFromRequest: React.FC = () => {
         }
     }, [isLoggedIn]);
 
-    const handleAfterCredentialClaim = () => {
-        // Navigate to home after claiming
+    // Resolve the wallet category route for a just-claimed credential (e.g.
+    // "/achievements", "/socialBadges"). Falls back to the passport ("/home")
+    // when the category can't be resolved.
+    const resolvePostClaimRoute = (claimedCredential?: VC): string => {
+        if (!claimedCredential) return '/home';
+        try {
+            const category = getDefaultCategoryForCredential(claimedCredential);
+            return CATEGORY_TO_ROUTE[category as CredentialCategoryEnum] ?? '/home';
+        } catch (err) {
+            log.warn('Failed to resolve post-claim category route', err);
+            return '/home';
+        }
+    };
+
+    const handleAfterCredentialClaim = (claimedCredential?: VC) => {
         setExchangeState({ state: ExchangeState.Finished });
-        history?.push('/home');
+        // Land the user on the specific wallet category page of the credential
+        // they just claimed (not the generic passport) so they see it in context.
+        history?.push(resolvePostClaimRoute(claimedCredential ?? claimedCredentialRef.current));
     };
 
     const handleClaimCredential = async () => {
@@ -637,7 +662,7 @@ const ClaimFromRequest: React.FC = () => {
             }
 
             setClaimingCredential(false);
-            handleAfterCredentialClaim();
+            handleAfterCredentialClaim(credential);
 
             presentToast(`Successfully claimed Credential!`, {
                 type: ToastTypeEnum.Success,
@@ -653,7 +678,7 @@ const ClaimFromRequest: React.FC = () => {
                     hasDismissButton: true,
                 });
 
-                handleAfterCredentialClaim();
+                handleAfterCredentialClaim(credential);
             } else {
                 presentToast(`Oops, we couldn't claim the credential.`, {
                     type: ToastTypeEnum.Error,

--- a/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ClaimFromRequest.tsx
@@ -567,8 +567,8 @@ const ClaimFromRequest: React.FC = () => {
                     case 'DIDAuth':
                     default:
                         if (credentialClaimCount && credentialClaimCount > 0) {
+                            // handleAfterCredentialClaim sets ExchangeState.Finished itself.
                             void handleAfterCredentialClaim();
-                            setExchangeState({ state: ExchangeState.Finished });
                             return;
                         } else {
                             setExchangeState({ state: ExchangeState.DidAuth, data, strategy });

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -198,15 +198,6 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         }
     };
 
-    // The claim view intentionally does NOT paint the credential's wallpaper
-    // photo behind the card — matching the credential detail view, which shows
-    // a plain dimmed backdrop rather than a full-bleed image. We use the app's
-    // canonical dark dim color (`#353E64`) so the card stays legible.
-    const CLAIM_BACKDROP_COLOR = '#353E64';
-    const getSingleCredentialBackgroundStyles = (): React.CSSProperties => ({
-        backgroundColor: CLAIM_BACKDROP_COLOR,
-    });
-
     // Mobile "Details" side panel — parity with ClaimBoost's footer.
     const openSingleCredentialDetails = (credential: VC) => {
         newModal(
@@ -437,10 +428,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
             <IonPage>
                 <IonLoading isOpen={claiming} message={'Claiming Credential(s)...'} />
                 <div className="flex h-full bg-grayscale-100">
-                    <section
-                        style={getSingleCredentialBackgroundStyles()}
-                        className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0"
-                    >
+                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-100">
                         <section
                             className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
                                 Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -198,48 +198,14 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         }
     };
 
-    // Themed background derived from the credential's display appearance —
-    // mirrors ClaimBoost so the claim view reads as a full credential view
-    // (wallpaper / brand color / fade / tile) rather than a bare gray card.
-    const getSingleCredentialBackgroundStyles = (credential: VC): React.CSSProperties => {
-        const appearance = credential?.display;
-        const wallpaperImage = appearance?.backgroundImage;
-        const wallpaperBackgroundColor = appearance?.backgroundColor;
-        const isWallpaperFaded = appearance?.fadeBackgroundImage;
-        const isWallpaperTiled = appearance?.repeatBackgroundImage;
-
-        let backgroundStyles: React.CSSProperties = {
-            backgroundPosition: 'center',
-            backgroundAttachment: 'fixed',
-            backgroundSize: 'cover',
-            backgroundImage: wallpaperImage ? `url(${wallpaperImage})` : undefined,
-            backgroundRepeat: 'no-repeat',
-        };
-
-        if (isWallpaperFaded && wallpaperImage) {
-            const overlay = wallpaperBackgroundColor
-                ? `${wallpaperBackgroundColor}80`
-                : '#353E6480';
-            backgroundStyles = {
-                ...backgroundStyles,
-                backgroundImage: `linear-gradient(${overlay}, ${overlay}), url(${wallpaperImage})`,
-            };
-        }
-
-        if (isWallpaperTiled && wallpaperImage) {
-            backgroundStyles = {
-                ...backgroundStyles,
-                backgroundRepeat: 'repeat',
-                backgroundSize: 'auto',
-            };
-        }
-
-        if (!isWallpaperFaded && wallpaperBackgroundColor) {
-            backgroundStyles.backgroundColor = wallpaperBackgroundColor;
-        }
-
-        return backgroundStyles;
-    };
+    // The claim view intentionally does NOT paint the credential's wallpaper
+    // photo behind the card — matching the credential detail view, which shows
+    // a plain dimmed backdrop rather than a full-bleed image. We use the app's
+    // canonical dark dim color (`#353E64`) so the card stays legible.
+    const CLAIM_BACKDROP_COLOR = '#353E64';
+    const getSingleCredentialBackgroundStyles = (): React.CSSProperties => ({
+        backgroundColor: CLAIM_BACKDROP_COLOR,
+    });
 
     // Mobile "Details" side panel — parity with ClaimBoost's footer.
     const openSingleCredentialDetails = (credential: VC) => {
@@ -472,7 +438,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                 <IonLoading isOpen={claiming} message={'Claiming Credential(s)...'} />
                 <div className="flex h-full bg-grayscale-100">
                     <section
-                        style={getSingleCredentialBackgroundStyles(credential)}
+                        style={getSingleCredentialBackgroundStyles()}
                         className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0"
                     >
                         <section

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -53,7 +53,6 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
     onAccept,
     strategy,
 }) => {
-    const [isFront, setIsFront] = useState(true);
     const [claiming, setClaiming] = useState(false);
     const [isClaimed, setIsClaimed] = useState(false);
 
@@ -227,8 +226,12 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                 checkProof={false}
                 hideNavButtons
                 hideFrontFaceDetails={false}
-                isFrontOverride={isFront}
-                setIsFrontOverride={setIsFront}
+                // Disable the click-to-flip: the back face is superseded by the
+                // Details overlay. Passing a no-op setter (and omitting
+                // isFrontOverride) keeps the card fixed on its front face, the
+                // same way the read-only detail views (BoostPreview/ClaimBoost)
+                // suppress the flip.
+                setIsFrontOverride={() => {}}
             />
         );
     };

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -227,12 +227,25 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         }
     };
 
+    // getDefaultCategoryForCredential can throw on malformed credentials, so
+    // resolve defensively for the detail views (categoryType is optional on
+    // both BoostDetailsSideMenu and BoostDetailsSideBar). Mirrors the guarded
+    // resolution used for post-claim routing in ClaimFromRequest.
+    const resolveDetailsCategoryType = (cred: VC): CredentialCategoryEnum | undefined => {
+        try {
+            return getDefaultCategoryForCredential(cred) as CredentialCategoryEnum;
+        } catch (err) {
+            log.warn('Failed to resolve credential category for details view', err);
+            return undefined;
+        }
+    };
+
     // Mobile "Details" side panel — parity with ClaimBoost's footer.
     const openSingleCredentialDetails = (credential: VC) => {
         newModal(
             <BoostDetailsSideMenu
                 credential={credential}
-                categoryType={getDefaultCategoryForCredential(credential) as CredentialCategoryEnum}
+                categoryType={resolveDetailsCategoryType(credential)}
                 verificationItems={verificationItems}
                 renderMethodCredential={credential}
             />,
@@ -492,11 +505,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                     {!isMobile && (
                         <BoostDetailsSideBar
                             credential={credential}
-                            categoryType={
-                                getDefaultCategoryForCredential(
-                                    credential
-                                ) as CredentialCategoryEnum
-                            }
+                            categoryType={resolveDetailsCategoryType(credential)}
                             verificationItems={verificationItems}
                             renderMethodCredential={credential}
                         />

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -11,6 +11,7 @@ const log = getLogger('exchange-accept-credentials');
 import VCDisplayCardWrapper2 from 'learn-card-base/components/vcmodal/VCDisplayCardWrapper2';
 import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFooter';
 import BoostDetailsSideMenu from '../../components/boost/boostCMS/BoostPreview/BoostDetailsSideMenu';
+import BoostDetailsSideBar from '../../components/boost/boostCMS/BoostPreview/BoostDetailsSideBar';
 
 import {
     useWallet,
@@ -455,6 +456,22 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                             useFullCloseButton={!isMobile}
                         />
                     </footer>
+
+                    {/* On desktop the Details footer button is hidden; show the
+                        persistent Details/Endorsements sidebar instead, matching
+                        the credential detail view (ClaimBoost/BoostPreview). */}
+                    {!isMobile && (
+                        <BoostDetailsSideBar
+                            credential={credential}
+                            categoryType={
+                                getDefaultCategoryForCredential(
+                                    credential
+                                ) as CredentialCategoryEnum
+                            }
+                            verificationItems={[] as VerificationItem[]}
+                            renderMethodCredential={credential}
+                        />
+                    )}
                 </div>
             </IonPage>
         );

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -1,16 +1,27 @@
 import React, { useState, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
-import { VC, VP } from '@learncard/types';
-import { IonContent, IonPage, IonFooter, IonToolbar, IonRow, IonLoading } from '@ionic/react';
-import { Gift, Check, X as XIcon, Loader2, AlertCircle, Home, HelpCircle } from 'lucide-react';
+import { Capacitor } from '@capacitor/core';
+import { VC, VP, VerificationItem } from '@learncard/types';
+import { IonContent, IonPage, IonFooter, IonLoading } from '@ionic/react';
+import { Gift, Check, AlertCircle, Home, HelpCircle } from 'lucide-react';
 
 import { getLogger } from 'learn-card-base';
 const log = getLogger('exchange-accept-credentials');
 
 import VCDisplayCardWrapper2 from 'learn-card-base/components/vcmodal/VCDisplayCardWrapper2';
-import X from 'learn-card-base/svgs/X';
+import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFooter';
+import BoostDetailsSideMenu from '../../components/boost/boostCMS/BoostPreview/BoostDetailsSideMenu';
 
-import { useWallet, useToast, ToastTypeEnum, BoostPageViewMode } from 'learn-card-base';
+import {
+    useWallet,
+    useToast,
+    ToastTypeEnum,
+    BoostPageViewMode,
+    useModal,
+    ModalTypes,
+    useDeviceTypeByWidth,
+    CredentialCategoryEnum,
+} from 'learn-card-base';
 import {
     useAnalytics,
     AnalyticsEvents,
@@ -31,8 +42,6 @@ import { publishWalletEvent } from '../pathways/events/walletEventBus';
 
 import { VCAPIRequestStrategy } from './ClaimFromRequest';
 
-import useTheme from '../../theme/hooks/useTheme';
-
 interface ExchangeAcceptCredentialsProps {
     verifiablePresentation: VP; // Contains the verifiablePresentation from the server
     onAccept: (body: any, credentialClaimCount: number) => void; // Callback to continue the exchange
@@ -44,9 +53,6 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
     onAccept,
     strategy,
 }) => {
-    const { colors } = useTheme();
-    const primaryColor = colors?.defaults?.primaryColor;
-
     const [isFront, setIsFront] = useState(true);
     const [claiming, setClaiming] = useState(false);
     const [isClaimed, setIsClaimed] = useState(false);
@@ -83,6 +89,8 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
     const { storeAndAddVCToWallet } = useWallet();
     const { track } = useAnalytics();
     const { capture, snapshotRef } = useProfileSnapshotCapture();
+    const { newModal } = useModal();
+    const { isMobile } = useDeviceTypeByWidth();
     const flowStartedAt = useRef(Date.now());
 
     const handleClaim = async () => {
@@ -190,23 +198,81 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         }
     };
 
-    const renderSingleCredential = () => {
-        const credential = credentials[0];
+    // Themed background derived from the credential's display appearance —
+    // mirrors ClaimBoost so the claim view reads as a full credential view
+    // (wallpaper / brand color / fade / tile) rather than a bare gray card.
+    const getSingleCredentialBackgroundStyles = (credential: VC): React.CSSProperties => {
+        const appearance = credential?.display;
+        const wallpaperImage = appearance?.backgroundImage;
+        const wallpaperBackgroundColor = appearance?.backgroundColor;
+        const isWallpaperFaded = appearance?.fadeBackgroundImage;
+        const isWallpaperTiled = appearance?.repeatBackgroundImage;
+
+        let backgroundStyles: React.CSSProperties = {
+            backgroundPosition: 'center',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundImage: wallpaperImage ? `url(${wallpaperImage})` : undefined,
+            backgroundRepeat: 'no-repeat',
+        };
+
+        if (isWallpaperFaded && wallpaperImage) {
+            const overlay = wallpaperBackgroundColor
+                ? `${wallpaperBackgroundColor}80`
+                : '#353E6480';
+            backgroundStyles = {
+                ...backgroundStyles,
+                backgroundImage: `linear-gradient(${overlay}, ${overlay}), url(${wallpaperImage})`,
+            };
+        }
+
+        if (isWallpaperTiled && wallpaperImage) {
+            backgroundStyles = {
+                ...backgroundStyles,
+                backgroundRepeat: 'repeat',
+                backgroundSize: 'auto',
+            };
+        }
+
+        if (!isWallpaperFaded && wallpaperBackgroundColor) {
+            backgroundStyles.backgroundColor = wallpaperBackgroundColor;
+        }
+
+        return backgroundStyles;
+    };
+
+    // Mobile "Details" side panel — parity with ClaimBoost's footer.
+    const openSingleCredentialDetails = (credential: VC) => {
+        newModal(
+            <BoostDetailsSideMenu
+                credential={credential}
+                categoryType={getDefaultCategoryForCredential(credential) as CredentialCategoryEnum}
+                verificationItems={[] as VerificationItem[]}
+                renderMethodCredential={credential}
+            />,
+            {
+                className: '!bg-transparent',
+                hideButton: true,
+            },
+            { desktop: ModalTypes.Right, mobile: ModalTypes.Right }
+        );
+    };
+
+    const renderSingleCredentialCard = (credential: VC) => {
         const name = credential.name || 'Credential';
 
         return (
-            <div className="px-[40px] pb-[100px] vc-preview-modal-safe-area h-full overflow-y-auto">
-                <section className="w-full flex justify-center py-16">
-                    <VCDisplayCardWrapper2
-                        overrideCardTitle={name}
-                        credential={credential}
-                        checkProof={false}
-                        hideNavButtons
-                        isFrontOverride={isFront}
-                        setIsFrontOverride={setIsFront}
-                    />
-                </section>
-            </div>
+            <VCDisplayCardWrapper2
+                useCurrentUserName
+                credential={credential}
+                overrideCardTitle={name}
+                customFooterComponent={<div />}
+                checkProof={false}
+                hideNavButtons
+                hideFrontFaceDetails={false}
+                isFrontOverride={isFront}
+                setIsFrontOverride={setIsFront}
+            />
         );
     };
 
@@ -393,34 +459,68 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
         );
     }
 
+    const claimBtnText = isClaimed ? 'Claimed' : claiming ? 'Loading...' : 'Accept';
+
+    // Single-credential claim — full credential view, matching ClaimBoost:
+    // themed background, edge-to-edge scroll area (no phantom padding / inset
+    // scrollbar), and the shared frosted BoostFooter (Close / Details / Accept).
+    if (credentials.length === 1) {
+        const credential = credentials[0];
+
+        return (
+            <IonPage>
+                <IonLoading isOpen={claiming} message={'Claiming Credential(s)...'} />
+                <div className="flex h-full bg-grayscale-100">
+                    <section
+                        style={getSingleCredentialBackgroundStyles(credential)}
+                        className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0"
+                    >
+                        <section
+                            className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
+                                Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'
+                            }`}
+                        >
+                            <div className="pb-4 vc-preview-modal-safe-area h-full w-full">
+                                {renderSingleCredentialCard(credential)}
+                            </div>
+                        </section>
+                    </section>
+
+                    <footer className="w-full flex justify-center items-center ion-no-border absolute bottom-0 z-10">
+                        <BoostFooter
+                            handleClose={() => history.push('/')}
+                            handleDetails={
+                                isMobile ? () => openSingleCredentialDetails(credential) : undefined
+                            }
+                            handleClaim={handleClaim}
+                            claimBtnText={claimBtnText}
+                            disableClaimButton={claiming || isClaimed}
+                            useFullCloseButton={!isMobile}
+                        />
+                    </footer>
+                </div>
+            </IonPage>
+        );
+    }
+
+    // Multiple-credential claim — grid selection view (unchanged).
     return (
         <IonPage>
             <IonLoading isOpen={claiming} message={'Claiming Credential(s)...'} />
             <IonContent fullscreen color="grayscale-100" className="ion-padding">
-                {credentials.length === 1 ? renderSingleCredential() : renderMultipleCredentials()}
+                {renderMultipleCredentials()}
             </IonContent>
             <IonFooter
                 mode="ios"
-                className="w-full flex justify-center items-center p-[15px] ion-no-border absolute bottom-0"
+                className="w-full flex justify-center items-center ion-no-border absolute bottom-0"
             >
-                <IonToolbar color="transparent" mode="ios">
-                    <IonRow className="relative z-10 w-full flex flex-nowrap justify-center items-center gap-4">
-                        <button
-                            onClick={() => history.push('/')} // Or some other cancel action
-                            className="w-[50px] h-[50px] min-h-[50px] min-w-[50px] bg-white rounded-full flex items-center justify-center shadow-3xl"
-                        >
-                            <X className="text-black w-[30px]" />
-                        </button>
-
-                        <button
-                            onClick={handleClaim}
-                            disabled={claiming || isClaimed}
-                            className={`flex items-center justify-center bg-${primaryColor} text-white py-2 mr-3 font-bold text-2xl tracking-wider rounded-[40px] shadow-2xl w-[200px] max-w-[320px] ml-2 normal font-poppins`}
-                        >
-                            {isClaimed ? 'Claimed' : 'Accept'}
-                        </button>
-                    </IonRow>
-                </IonToolbar>
+                <BoostFooter
+                    handleClose={() => history.push('/')}
+                    handleClaim={handleClaim}
+                    claimBtnText={claimBtnText}
+                    disableClaimButton={claiming || isClaimed}
+                    useFullCloseButton={false}
+                />
             </IonFooter>
         </IonPage>
     );

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
 import { VC, VP, VerificationItem } from '@learncard/types';
+import { prettifyVerificationItems } from 'learn-card-base/helpers/verificationPrettifier';
 import { IonContent, IonPage, IonFooter, IonLoading } from '@ionic/react';
 import { Gift, Check, AlertCircle, Home, HelpCircle } from 'lucide-react';
 
@@ -86,12 +87,40 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
 
     const history = useHistory();
     const { presentToast } = useToast();
-    const { storeAndAddVCToWallet } = useWallet();
+    const { storeAndAddVCToWallet, initWallet } = useWallet();
     const { track } = useAnalytics();
     const { capture, snapshotRef } = useProfileSnapshotCapture();
     const { newModal } = useModal();
     const { isMobile } = useDeviceTypeByWidth();
     const flowStartedAt = useRef(Date.now());
+
+    // Verify the (single) credential so the Details panel/sidebar shows real
+    // Proof / Status / Expiration rows. Always run — the verification block is
+    // shown on both mobile (Details modal) and desktop (persistent sidebar).
+    const [verificationItems, setVerificationItems] = useState<VerificationItem[]>([]);
+    useEffect(() => {
+        const cred = credentials[0];
+        if (!cred) return;
+
+        let cancelled = false;
+        (async () => {
+            try {
+                const wallet = await initWallet();
+                const verifications = await wallet?.invoke?.verifyCredential(cred, {}, true);
+                if (!cancelled) {
+                    setVerificationItems(prettifyVerificationItems(verifications ?? []));
+                }
+            } catch (err) {
+                log.warn('Failed to verify claim credential', err);
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+        // `credentials` is captured once from the VP at mount and never changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleClaim = async () => {
         if (selectedCredentials.length === 0) {
@@ -204,7 +233,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
             <BoostDetailsSideMenu
                 credential={credential}
                 categoryType={getDefaultCategoryForCredential(credential) as CredentialCategoryEnum}
-                verificationItems={[] as VerificationItem[]}
+                verificationItems={verificationItems}
                 renderMethodCredential={credential}
             />,
             {
@@ -468,7 +497,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                                     credential
                                 ) as CredentialCategoryEnum
                             }
-                            verificationItems={[] as VerificationItem[]}
+                            verificationItems={verificationItems}
                             renderMethodCredential={credential}
                         />
                     )}


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!-- No linked Jira ticket — surfaced during Bug Fest UI review. Add one if desired. -->

#### 📚 What is the context and goal of this PR?

The "claim a credential" view reached via a claim link (`/interactions/claim/…` → `/request` → `ClaimFromRequest` → `ExchangeAcceptCredentials`) looked out of step with the rest of the app's full-credential views and had a couple of concrete bugs. This brings the single-credential claim view in line with the `ClaimBoost` full-credential view and fixes where the user lands after claiming.

#### 🥴 TL; RL:

Claim view had phantom L/R padding (card too thin, scrollbar inset from the edge) and dropped you on the passport after claiming. Now it matches the ClaimBoost look and lands you on the claimed credential's category page.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

SEE LOOM



https://github.com/user-attachments/assets/23a17a22-0c70-45e8-b6df-07666c0e60c8





https://www.loom.com/share/1c923b54180c4370a1c3c551ffb38372



BEFORE:
<img width="509" height="804" alt="Screenshot 2026-07-10 at 1 04 35 PM" src="https://github.com/user-attachments/assets/75943632-b923-4a94-ac25-0a0150f6eb84" />

AFTER:
<img width="567" height="820" alt="Screenshot 2026-07-10 at 1 04 43 PM" src="https://github.com/user-attachments/assets/90c13dd4-3d21-422f-ac9b-b724b04cb40a" />


<img width="1409" height="870" alt="Screenshot 2026-07-10 at 1 41 23 PM" src="https://github.com/user-attachments/assets/4fd617f4-34e5-46ab-9e28-0a474e1a08dd" />


**1. Padding / scrollbar fix + design refresh (single-credential path)**
- Removed the double padding: previously an `ion-padding` `IonContent` nested inside a `px-[40px]` div (~56px per side). The scroll container's inner padding also pushed the scrollbar in from the true edge.
- Rebuilt the single-credential view to mirror `ClaimBoost`:
  - Edge-to-edge scroll area: `px-6` + `disable-scrollbars` + `[&::part(scroll)]:px-0` + `safe-area-top-margin` — card regains full width, no inset scrollbar.
  - Swapped the bare floating X + pill for the shared frosted **`BoostFooter`** (Close / Details / Accept). Details opens `BoostDetailsSideMenu` on mobile.
- Multi-credential + empty states untouched (multi got the same `BoostFooter` for consistency).

**2. Post-claim navigation**
- `handleAfterCredentialClaim` now routes to the claimed credential's wallet category page via `CATEGORY_TO_ROUTE[getDefaultCategoryForCredential(cred)]`, falling back to `/home` (passport) when unresolvable. The claimed credential is captured in a ref when entering the accept state.

#### 🛠 Important tradeoffs made:

- Reused `ClaimBoost`'s existing layout + `BoostFooter` + `BoostDetailsSideMenu` rather than extracting a shared full-credential display component. A unified display component across every full-credential view is the cleaner long-term fix but was intentionally left out of scope here to keep the change focused and low-risk.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
<!-- Note: the pre-existing follow-up of extracting one shared full-credential display component remains worth doing, but is not introduced by this PR. -->

# Testing

#### 🔬 How Can Someone QA This?

1. Open a credential claim link (`/interactions/claim/<token>?iuv=1`) while logged in.
2. Confirm the claim view: card fills the width (no phantom L/R padding), no visible/inset scrollbar, themed background matches the credential, and the footer is the frosted Close / Details / Accept bar.
3. Tap **Details** (mobile) → the credential detail side panel opens.
4. Tap **Accept** → after claiming you land on that credential's category page (e.g. `/socialBadges`, `/achievements`), not the passport.
5. Sanity check a multi-credential claim link still shows the selection grid and claims correctly.

#### 📱 🖥 Which devices would you like help testing on?

iOS Native / Android Native / Chromium

#### 🧪 Code Coverage

No new automated tests — UI composition of existing, production-proven components (`ClaimBoost` layout, `BoostFooter`, `BoostDetailsSideMenu`) plus a small navigation helper. Verified via typecheck (no new errors in the changed files) and lint. Manual E2E QA steps above.

# Documentation

#### 📝 Documentation Checklist

_No doc changes — internal app UI fix, no API/SDK surface change._

#### 💭 Documentation Notes

App UI/UX fix only; no user-facing docs, API, or config changes.

# ✅ PR Checklist

-   [ ] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (existing `CLAIM_BOOST` / `PROFILE_ITEM_ADDED` events preserved)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable credential claiming to route users to the claimed credential's category-specific page with preloaded chunks for instant navigation and improved post-claim UX.

Main changes:
- Added credential category routing logic with `CATEGORY_TO_ROUTE` mapping and chunk preloading via `ROUTE_PRELOAD` to enable instant navigation after claiming
- Enhanced `handleAfterCredentialClaim` to accept credential parameter, resolve destination route defensively, and await chunk preload with 4-second timeout
- Refactored `ExchangeAcceptCredentials` single-credential view to use `BoostFooter` component with Details panel/sidebar and credential verification display

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
