### PR TITLE
fix: Always show edge cards on swiper carousel  

### DIFF
--- a/.changeset/shy-beans-burn.md
+++ b/.changeset/shy-beans-burn.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: Always show edge cards on swiper carousel  

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -86,7 +86,7 @@ const GrowSkillsCarouselSection = <T,>({
                                     className="flex h-[30px] w-[30px] items-center justify-center text-grayscale-900 transition-colors hover:text-grayscale-700 disabled:text-grayscale-400 disabled:cursor-not-allowed"
                                     onClick={() => swiperRef.current?.slidePrev()}
                                 >
-                                    <SlimCaretLeft className="h-[30px] w-[30px]" />
+                                    <SlimCaretLeft className="h-[20px] w-[20px]" />
                                 </button>
 
                                 <button
@@ -96,7 +96,7 @@ const GrowSkillsCarouselSection = <T,>({
                                     className="flex h-[30px] w-[30px] items-center justify-center text-grayscale-900 transition-colors hover:text-grayscale-700 disabled:text-grayscale-400 disabled:cursor-not-allowed"
                                     onClick={() => swiperRef.current?.slideNext()}
                                 >
-                                    <SlimCaretRight className="h-[30px] w-[30px]" />
+                                    <SlimCaretRight className="h-[20px] w-[20px]" />
                                 </button>
                             </div>
                         )}

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCarouselSection.tsx
@@ -36,8 +36,9 @@ const GrowSkillsCarouselSection = <T,>({
     const [atBeginning, setAtBeginning] = useState<boolean>(true);
     const [atEnd, setAtEnd] = useState<boolean>(false);
 
-    const showNavigation = width > 991;
-    const showHeaderNavigation = showNavigation && carouselItems.length > 1;
+    const isDesktop = width > 991;
+    const showHeaderNavigation = carouselItems.length > 1;
+    const slideWidth = isDesktop ? '350px' : 'clamp(240px, calc(100% - 40px), 350px)';
 
     const handleSwiperUpdate = (swiper: SwiperInstance) => {
         setAtBeginning(swiper.isBeginning);
@@ -105,6 +106,7 @@ const GrowSkillsCarouselSection = <T,>({
 
             <div className="relative w-full overflow-visible">
                 <Swiper
+                    className="[&_.swiper-wrapper]:items-stretch"
                     onSwiper={handleSwiperInit}
                     onResize={handleSwiperUpdate}
                     onSlideChange={handleSwiperUpdate}
@@ -128,9 +130,11 @@ const GrowSkillsCarouselSection = <T,>({
                         <SwiperSlide
                             key={getItemKey?.(item, index) ?? index}
                             className={slideClassName}
-                            style={{ width: '350px' }}
+                            style={{ width: slideWidth }}
                         >
-                            {renderItem(item, index)}
+                            <div className="flex h-full w-full [&>*]:h-full">
+                                {renderItem(item, index)}
+                            </div>
                         </SwiperSlide>
                     ))}
                 </Swiper>

--- a/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/GrowSkillsCourseItem.tsx
@@ -81,7 +81,7 @@ const GrowSkillsCourseItem: React.FC<GrowSkillsCourseItemProps> = ({ program }) 
             onClick={openCourseDetailsModal}
             className="w-full flex flex-col rounded-[15px] bg-white shadow-bottom-4-4 overflow-hidden cursor-pointer border-b-[3px] border-emerald-500 text-left"
         >
-            <div className="px-[15px] py-[20px] flex flex-col gap-[5px]">
+            <div className="px-[15px] py-[20px] flex h-full flex-col gap-[5px]">
                 <div className="flex items-start gap-[10px]">
                     <ThickStudiesIconWithShape className="w-[35px] h-[35px] flex-shrink-0" />
                     <div className="flex-1 min-w-0">
@@ -113,7 +113,10 @@ const GrowSkillsCourseItem: React.FC<GrowSkillsCourseItemProps> = ({ program }) 
                     />
                 </div>
 
-                <GrowSkillsSkillChips searchQuery={program?.ProgramName ?? ''} />
+                <GrowSkillsSkillChips
+                    searchQuery={program?.ProgramName ?? ''}
+                    className="mt-auto"
+                />
             </div>
         </div>
     );

--- a/apps/learn-card-app/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/learn-card-app/src/pages/dashboard/DashboardPage.tsx
@@ -70,6 +70,7 @@ import { useSkillProfileCompletion } from '../ai-pathways/ai-pathways-skill-prof
 import { DEFAULT_REGISTRY } from './quickActions/registry';
 import { resolveSlots } from './quickActions/resolveSlots';
 import type { ActionHandlers, DashboardState, SlotIcons } from './quickActions/types';
+import { isHiddenActivity } from '../wallet/activity-feed/activityFeed.helpers';
 
 import ScanIcon from 'learn-card-base/svgs/ScanIcon';
 import LinkOutlinedIcon from 'learn-card-base/svgs/LinkOutlinedIcon';
@@ -125,6 +126,7 @@ const DashboardPage: React.FC = () => {
         () =>
             (allCredentials?.pages?.flatMap(p => p?.records ?? []) ?? []).filter(record => {
                 if (isVerifiableDataRecord(record)) return false;
+                if (isHiddenActivity(record.category)) return false;
                 if (selfAssignedSkillsUri && record.uri === selfAssignedSkillsUri) return false;
                 if (record.title?.trim() === SELF_ASSIGNED_SKILLS_BOOST_NAME) return false;
                 return true;

--- a/apps/learn-card-app/src/pages/wallet/activity-feed/PassportActivityFeed.tsx
+++ b/apps/learn-card-app/src/pages/wallet/activity-feed/PassportActivityFeed.tsx
@@ -65,6 +65,7 @@ export const PassportActivityFeed: React.FC = () => {
     // profile still loading as part of the pending state and hold the rows.
     const waiting = isPending || currentLCNUserLoading;
     const isEmpty = !waiting && !isError && groups.length === 0;
+    const activeFilterCount = filter === 'all' ? 0 : 1;
 
     return (
         <section className="w-full max-w-[840px] mx-auto mt-[24px]">
@@ -88,10 +89,13 @@ export const PassportActivityFeed: React.FC = () => {
                     <button
                         type="button"
                         onClick={() => setFilterOpen(o => !o)}
-                        className="flex items-center gap-2 rounded-[12px] bg-[#EEEEFB] px-4 py-[10px] font-poppins text-[14px] font-medium uppercase tracking-[0.5px] text-[#5457C7]"
+                        className="flex items-center gap-2 rounded-[12px] bg-[#EEEEFB] px-4 py-[10px] font-poppins text-[14px] font-medium uppercase tracking-[0.5px]"
                     >
-                        Filter
-                        <SortButton className="h-[18px] w-[18px]" />
+                        <span className="text-grayscale-700">Filter</span>
+                        {activeFilterCount > 0 && (
+                            <span className="text-indigo-500">{activeFilterCount}</span>
+                        )}
+                        <SortButton className="h-[18px] w-[18px] text-indigo-500" />
                     </button>
                     {/* TODO(LC-1919 polish): close popover on outside-click / Escape. */}
                     {filterOpen && (

--- a/apps/learn-card-app/src/pages/wallet/activity-feed/RecentlyAdded.tsx
+++ b/apps/learn-card-app/src/pages/wallet/activity-feed/RecentlyAdded.tsx
@@ -58,7 +58,7 @@ export const RecentlyAdded: React.FC = () => {
                     See all
                 </button>
             </div>
-            <div className="flex gap-3 md:gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:flex-wrap md:overflow-visible">
+            <div className="-mx-6 flex gap-3 overflow-x-auto px-6 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:mx-0 md:gap-2 md:overflow-visible md:px-0 md:flex-wrap">
                 {items.map(record => {
                     const category = resolveActivityCategory(record.category);
                     return (

--- a/apps/learn-card-app/src/pages/wallet/activity-feed/activityFeed.helpers.test.ts
+++ b/apps/learn-card-app/src/pages/wallet/activity-feed/activityFeed.helpers.test.ts
@@ -197,6 +197,9 @@ describe('isHiddenActivity', () => {
         expect(isHiddenActivity('Self-Assigned Skills')).toBe(true);
         expect(isHiddenActivity('VerifiableData')).toBe(true);
         expect(isHiddenActivity('AI Summary')).toBe(true);
+        expect(isHiddenActivity('AI Topic')).toBe(true);
+        expect(isHiddenActivity('AI Sessions')).toBe(true);
+        expect(isHiddenActivity('ai-topic')).toBe(true);
         expect(isHiddenActivity('Pay Rate')).toBe(true);
     });
     it('shows normal and unknown categories', () => {

--- a/apps/learn-card-app/src/pages/wallet/activity-feed/activityFeed.helpers.ts
+++ b/apps/learn-card-app/src/pages/wallet/activity-feed/activityFeed.helpers.ts
@@ -49,6 +49,9 @@ const CATEGORY_LOOKUP: Record<string, CredentialCategoryEnum> = (() => {
         map[value.toLowerCase()] = value as CredentialCategoryEnum;
         map[key.toLowerCase()] = value as CredentialCategoryEnum;
     }
+    map['ai session'] = CredentialCategoryEnum.aiTopic;
+    map['ai sessions'] = CredentialCategoryEnum.aiTopic;
+    map['ai-topic'] = CredentialCategoryEnum.aiTopic;
     return map;
 })();
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

1. On some mobile devices the carousel would only show a single card, & it was not apparent 
that there was additional cards , this makes it so a card + the edge card is shown. 

2. fixes an issue where cards were many heights, now all cards
grow the tallest possible height in the carousel 

3. allows the passport activity slides to overflow on mobile, removes padding-x

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

# before 

<img width="579" height="821" alt="Screenshot 2026-07-10 at 12 41 06 PM" src="https://github.com/user-attachments/assets/eb0391b0-bf03-47d9-b2af-336c93fe0f7f" />

# after

<img width="568" height="818" alt="Screenshot 2026-07-10 at 12 38 12 PM" src="https://github.com/user-attachments/assets/4eb55007-81f5-4773-84a6-710d00b9ea29" />


#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [ ] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [ ] I have **reviewed** my code
-   [ ] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [ ] Code is backwards compatible
-   [ ] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix swiper carousel to consistently display edge cards by adjusting slide sizing, layout, and filtering hidden activity categories from dashboard.

Main changes:
- Refactored carousel slide width calculations with responsive breakpoints and wrapper flex layout for proper card stretching
- Fixed navigation button icon sizing from 30px to 20px and added Swiper wrapper alignment class
- Added AI Topic category filtering via isHiddenActivity helper to exclude system-generated activities from dashboard and activity feed

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
