### PR TITLE
feat: Rich Tags

### DIFF
--- a/.changeset/good-poems-grin.md
+++ b/.changeset/good-poems-grin.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"scoutpass-app": patch
+---
+
+feat: Rich Tags

--- a/apps/learn-card-app/src/Routes.tsx
+++ b/apps/learn-card-app/src/Routes.tsx
@@ -47,6 +47,7 @@ const AddressBook = lazyWithRetry(() => import('./pages/addressBook/AddressBook'
 const BoostCMS = lazyWithRetry(() => import('./components/boost/boostCMS/BoostCMS'));
 const UpdateBoostCMS = lazyWithRetry(() => import('./components/boost/boostCMS/UpdateBoostCMS'));
 const IssueCredentialPage = lazyWithRetry(() => import('./pages/issue/IssueCredentialPage'));
+const BoostAFriendPage = lazyWithRetry(() => import('./pages/boostAFriend/BoostAFriendPage'));
 const SkillsPage = lazyWithRetry(() => import('./pages/skills/SkillsPage'));
 const AiInsights = lazyWithRetry(() => import('./pages/ai-insights/AiInsights'));
 const PrivacySettingsPage = lazyWithRetry(
@@ -317,6 +318,7 @@ export const Routes: React.FC = () => {
                         <PrivateRoute exact path="/boost" component={BoostCMS} />
                         <PrivateRoute exact path="/boost/update" component={UpdateBoostCMS} />
                         <PrivateRoute exact path="/issue" component={IssueCredentialPage} />
+                        <PrivateRoute exact path="/boost-a-friend" component={BoostAFriendPage} />
                         <PrivateRoute exact path="/test" component={VprQueryByExample} />
                         <SentryRoute exact path="/wallet-worker" component={WalletServiceWorker} />
                         <PrivateRoute exact path="/store" component={CredentialStorage} />
@@ -504,6 +506,7 @@ export const ROUTE_PRELOAD: Record<string, () => Promise<void>> = {
     // Mobile navbar / wallet header.
     '/boost': () => BoostCMS.preload(),
     '/issue': () => IssueCredentialPage.preload(),
+    '/boost-a-friend': () => BoostAFriendPage.preload(),
     // Other commonly side-menu-linked routes.
     '/privacy-and-data': () => PrivacySettingsPage.preload(),
     '/resume-builder': () => ResumeBuilderPage.preload(),

--- a/apps/learn-card-app/src/components/boost/boost-earned-card/BoostEarnedCard.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-earned-card/BoostEarnedCard.tsx
@@ -475,6 +475,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                     relativeDate={relativeDate}
                     compact={compact}
                     isCLR={isClrCredential}
+                    trustedVerifierOnly
                 />
             </ErrorBoundary>
         );
@@ -548,6 +549,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                         relativeDate={relativeDate}
                         compact={compact}
                         isCLR={isClrCredential}
+                        trustedVerifierOnly
                     />
                 </IonCol>
             </ErrorBoundary>
@@ -662,6 +664,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                     relativeDate={relativeDate}
                     compact={compact}
                     isCLR={isClrCredential}
+                    trustedVerifierOnly
                 />
             </IonCol>
         </ErrorBoundary>

--- a/apps/learn-card-app/src/components/boost/boost-earned-card/BoostEarnedCard.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-earned-card/BoostEarnedCard.tsx
@@ -162,6 +162,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
         idAccentColor,
         backgroundImage,
         backgroundColor,
+        accentColor,
 
         loading: vcInfoLoading,
     } = useGetVCInfo(cred, categoryType);
@@ -444,6 +445,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                                 showBackgroundImage
                                 backgroundImage={backgroundImage}
                                 backgroundColor={backgroundColor}
+                                accentColor={accentColor}
                                 badgeContainerCustomClass="mt-[0px] mb-[8px]"
                                 badgeCircleCustomClass={`!w-[116px] h-[116px] mt-1 ${
                                     isAwardDisplay ? 'mt-[17px]' : 'shadow-3xl'
@@ -517,6 +519,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                                     showBackgroundImage
                                     backgroundImage={backgroundImage}
                                     backgroundColor={backgroundColor}
+                                    accentColor={accentColor}
                                     badgeContainerCustomClass="mt-[0px] mb-[8px]"
                                     badgeCircleCustomClass={`!w-[116px] h-[116px] mt-1 ${
                                         isAwardDisplay ? 'mt-[17px]' : 'shadow-3xl'
@@ -619,6 +622,7 @@ export const BoostEarnedCard: React.FC<BoostEarnedCardProps> = ({
                                 showBackgroundImage
                                 backgroundImage={backgroundImage}
                                 backgroundColor={backgroundColor}
+                                accentColor={accentColor}
                                 badgeContainerCustomClass="mt-[0px] mb-[8px]"
                                 badgeCircleCustomClass={`!w-[116px] h-[116px] mt-1 ${
                                     isAwardDisplay ? 'mt-[17px] mb-[-22px]' : 'shadow-3xl'

--- a/apps/learn-card-app/src/components/boost/boost-options/boostOptions.ts
+++ b/apps/learn-card-app/src/components/boost/boost-options/boostOptions.ts
@@ -298,7 +298,7 @@ export const CATEGORY_TO_SUBCATEGORY_LIST: {
         //     type: AchievementTypes.Award,
         // },
         // {
-        //     title: 'Online Badge',
+        //     title: 'Badge',
         //     type: AchievementTypes.Badge,
         // },
         // {

--- a/apps/learn-card-app/src/components/boost/boost-template/LearnCardTemplateListItem.tsx
+++ b/apps/learn-card-app/src/components/boost/boost-template/LearnCardTemplateListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BoostUserTypeEnum, CredentialCategory, categoryMetadata, useModal } from 'learn-card-base';
 import { useHistory } from 'react-router-dom';
-import { useLCAStylesPackRegistry } from 'learn-card-base/hooks/useRegistry';
+import { useStylePackRegistry } from '../../../registries/useStylePackRegistry';
 import { getDefaultAchievementTypeImage } from '../boostHelpers';
 import { getAchievementTypeDisplayText } from 'learn-card-base/helpers/credentialHelpers';
 import CredentialGeneralPlus from '../../svgs/CredentialGeneralPlus';
@@ -28,8 +28,7 @@ const LearnCardTemplateListItem: React.FC<LearnCardTemplateListItemProps> = ({
         link = `${baseLink}&otherUserProfileId=${userToBoostProfileId}`;
     }
 
-    const { data: boostAppearanceBadgeList, isLoading: stylePackLoading } =
-        useLCAStylesPackRegistry();
+    const { data: boostAppearanceBadgeList, isLoading: stylePackLoading } = useStylePackRegistry();
 
     const badgeThumbnail = getDefaultAchievementTypeImage(
         categoryType,

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
@@ -11,6 +11,7 @@ import BoostDetailsSideMenu from './BoostDetailsSideMenu';
 import VerifiedChildCLRFooter from './VerifiedChildCLRFooter';
 import EndorsementBadge from '../../../boost-endorsements/EndorsementBadge';
 import VCDisplayCardWrapper2 from 'learn-card-base/components/vcmodal/VCDisplayCardWrapper2';
+import BoostMediaPreview from './BoostMediaPreview';
 import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFooter';
 import ClrTranscriptFullPage from '../../../clr-transcript/surfaces/ClrTranscriptFullPage';
 import {

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
@@ -210,6 +210,10 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
         displayType === DisplayTypeEnum.ID ||
         credential?.display?.displayType === 'id' ||
         categoryType === 'ID';
+    const isMedia =
+        !isClrCredential &&
+        !isClrChildCredential &&
+        (displayType === DisplayTypeEnum.Media || credential?.display?.displayType === 'media');
     const isIssuerViewSelected =
         enableRenderMethod &&
         Boolean(renderMethod) &&
@@ -231,6 +235,19 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
     );
     const clrEvidence = clrModel ? getDownloadableEvidence(clrModel.evidence) : [];
     const hasClrEvidence = clrEvidence.length > 0;
+
+    if (isMedia) {
+        return (
+            <BoostMediaPreview
+                credential={credential}
+                openDetailsSideModal={openDetailsSideModal}
+                handleShareBoost={handleShareBoost}
+                onDotsClick={onDotsClick}
+                verifications={verifications}
+                handleCloseModal={handleCloseModal}
+            />
+        );
+    }
 
     const credentialDisplay = (
         <VCDisplayCardWrapper2

--- a/apps/learn-card-app/src/components/debug/ThemeDebugTab.tsx
+++ b/apps/learn-card-app/src/components/debug/ThemeDebugTab.tsx
@@ -1,13 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import {
-    Palette,
-    Layout,
-    Image,
-    Navigation,
-    Copy,
-    Check,
-    Tag,
-} from 'lucide-react';
+import { Palette, Layout, Image, Navigation, Copy, Check, Tag } from 'lucide-react';
 
 import { useTenantConfig } from 'learn-card-base/config/TenantConfigProvider';
 
@@ -46,8 +38,7 @@ const ColorSwatch: React.FC<{ label: string; color: string }> = ({ label, color 
 // Theme Debug Tab
 // ---------------------------------------------------------------------------
 
-const isThemeEvent = (e: ConfigDebugEvent): boolean =>
-    e.type.startsWith('theme:');
+const isThemeEvent = (e: ConfigDebugEvent): boolean => e.type.startsWith('theme:');
 
 export const ThemeDebugTab: React.FC = () => {
     const config = useTenantConfig();
@@ -60,7 +51,7 @@ export const ThemeDebugTab: React.FC = () => {
     );
 
     useEffect(() => {
-        const unsubscribe = subscribeToConfigDebugEvents((event) => {
+        const unsubscribe = subscribeToConfigDebugEvents(event => {
             if (event.id === 'clear') {
                 setEvents([]);
             } else if (isThemeEvent(event)) {
@@ -153,7 +144,9 @@ export const ThemeDebugTab: React.FC = () => {
         try {
             await navigator.clipboard.writeText(JSON.stringify(theme, null, 2));
             setCopied('theme-json', theme);
-        } catch { /* ignore */ }
+        } catch {
+            /* ignore */
+        }
     }, [theme, setCopied]);
 
     return (
@@ -170,10 +163,37 @@ export const ThemeDebugTab: React.FC = () => {
                 </div>
 
                 <KVRow label="Theme ID" value={theme.id} copied={copied} onCopy={setCopied} />
-                <KVRow label="Display Name" value={theme.displayName} mono={false} copied={copied} onCopy={setCopied} />
-                <KVRow label="Internal Name" value={theme.name} copied={copied} onCopy={setCopied} />
-                <KVRow label="Default View Mode" value={theme.defaults.viewMode} copied={copied} onCopy={setCopied} />
-                <KVRow label="Theme Switching" value={switchingEnabled} copied={copied} onCopy={setCopied} />
+                <KVRow
+                    label="Display Name"
+                    value={theme.displayName}
+                    mono={false}
+                    copied={copied}
+                    onCopy={setCopied}
+                />
+                <KVRow
+                    label="Internal Name"
+                    value={theme.name}
+                    copied={copied}
+                    onCopy={setCopied}
+                />
+                <KVRow
+                    label="Passport View Mode"
+                    value={theme.defaults.passportViewMode}
+                    copied={copied}
+                    onCopy={setCopied}
+                />
+                <KVRow
+                    label="Credential View Mode"
+                    value={theme.defaults.credentialViewMode}
+                    copied={copied}
+                    onCopy={setCopied}
+                />
+                <KVRow
+                    label="Theme Switching"
+                    value={switchingEnabled}
+                    copied={copied}
+                    onCopy={setCopied}
+                />
             </div>
 
             {/* ── Registered & Allowed Themes ── */}
@@ -186,35 +206,56 @@ export const ThemeDebugTab: React.FC = () => {
                     </span>
                 }
             >
-                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">Registered Themes</p>
+                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">
+                    Registered Themes
+                </p>
 
-                {registeredThemes.map((id) => {
+                {registeredThemes.map(id => {
                     const isActive = id === activeThemeId;
                     const isAllowed = allowedThemes.includes(id);
                     const t = loadThemeSchema(id);
 
                     return (
-                        <div key={id} className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40">
+                        <div
+                            key={id}
+                            className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40"
+                        >
                             <div className="flex items-center gap-1.5">
-                                <div className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-purple-400' : 'bg-gray-600'}`} />
-                                <span className={isActive ? 'text-purple-400 font-semibold' : 'text-gray-400'}>{t.displayName}</span>
+                                <div
+                                    className={`w-1.5 h-1.5 rounded-full ${
+                                        isActive ? 'bg-purple-400' : 'bg-gray-600'
+                                    }`}
+                                />
+                                <span
+                                    className={
+                                        isActive ? 'text-purple-400 font-semibold' : 'text-gray-400'
+                                    }
+                                >
+                                    {t.displayName}
+                                </span>
                                 <span className="text-gray-600 font-mono text-[8px]">({id})</span>
                             </div>
 
                             <div className="flex items-center gap-1">
                                 {isActive && (
-                                    <span className="text-[8px] px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium">active</span>
+                                    <span className="text-[8px] px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium">
+                                        active
+                                    </span>
                                 )}
 
                                 {!isAllowed && (
-                                    <span className="text-[8px] px-1 py-0.5 rounded bg-red-500/20 text-red-400 font-medium">not allowed</span>
+                                    <span className="text-[8px] px-1 py-0.5 rounded bg-red-500/20 text-red-400 font-medium">
+                                        not allowed
+                                    </span>
                                 )}
                             </div>
                         </div>
                     );
                 })}
 
-                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2.5 mb-1">Tenant Allowed</p>
+                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2.5 mb-1">
+                    Tenant Allowed
+                </p>
 
                 <div className="text-[10px] text-gray-400">
                     {allowedThemes.join(', ') || '(none specified — all allowed)'}
@@ -231,8 +272,11 @@ export const ThemeDebugTab: React.FC = () => {
                     </span>
                 }
             >
-                {theme.categories.map((cat) => (
-                    <div key={cat.categoryId} className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40">
+                {theme.categories.map(cat => (
+                    <div
+                        key={cat.categoryId}
+                        className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40"
+                    >
                         <span className="text-gray-400">{cat.labels.plural}</span>
                         <span className="text-gray-600 font-mono text-[9px]">{cat.categoryId}</span>
                     </div>
@@ -240,13 +284,12 @@ export const ThemeDebugTab: React.FC = () => {
             </Section>
 
             {/* ── Color Palette ── */}
-            <Section
-                title="Color Palette"
-                icon={<Palette className="w-3 h-3 text-gray-500" />}
-            >
+            <Section title="Color Palette" icon={<Palette className="w-3 h-3 text-gray-500" />}>
                 {launchPadColors && (
                     <>
-                        <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">Launch Pad</p>
+                        <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">
+                            Launch Pad
+                        </p>
 
                         {Object.entries(launchPadColors).map(([key, color]) => (
                             <ColorSwatch key={key} label={key} color={color} />
@@ -256,14 +299,20 @@ export const ThemeDebugTab: React.FC = () => {
 
                 {categoryColorEntries.map(({ category, colors }) => (
                     <React.Fragment key={category}>
-                        <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2 mb-1">{category}</p>
+                        <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2 mb-1">
+                            {category}
+                        </p>
 
-                        {Object.entries(colors).slice(0, 4).map(([key, color]) => (
-                            <ColorSwatch key={key} label={key} color={color} />
-                        ))}
+                        {Object.entries(colors)
+                            .slice(0, 4)
+                            .map(([key, color]) => (
+                                <ColorSwatch key={key} label={key} color={color} />
+                            ))}
 
                         {Object.keys(colors).length > 4 && (
-                            <span className="text-[8px] text-gray-600">+{Object.keys(colors).length - 4} more</span>
+                            <span className="text-[8px] text-gray-600">
+                                +{Object.keys(colors).length - 4} more
+                            </span>
                         )}
                     </React.Fragment>
                 ))}
@@ -282,7 +331,9 @@ export const ThemeDebugTab: React.FC = () => {
                 >
                     {iconPaletteEntries.map(({ key, palette }) => (
                         <React.Fragment key={key}>
-                            <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">{key}</p>
+                            <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">
+                                {key}
+                            </p>
 
                             {Object.entries(palette).map(([pKey, pVal]) => (
                                 <ColorSwatch key={pKey} label={pKey} color={pVal} />
@@ -293,23 +344,31 @@ export const ThemeDebugTab: React.FC = () => {
             )}
 
             {/* ── Navigation ── */}
-            <Section
-                title="Navigation"
-                icon={<Navigation className="w-3 h-3 text-gray-500" />}
-            >
-                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">Navbar ({theme.navbar.length})</p>
+            <Section title="Navigation" icon={<Navigation className="w-3 h-3 text-gray-500" />}>
+                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1 mb-1">
+                    Navbar ({theme.navbar.length})
+                </p>
 
-                {theme.navbar.map((link) => (
-                    <div key={link.id} className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40">
+                {theme.navbar.map(link => (
+                    <div
+                        key={link.id}
+                        className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40"
+                    >
                         <span className="text-gray-400">{link.label}</span>
                         <span className="text-gray-600 font-mono text-[9px]">{link.path}</span>
                     </div>
                 ))}
 
-                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2.5 mb-1">Side Menu ({theme.sideMenuRootLinks.length + theme.sideMenuSecondaryLinks.length})</p>
+                <p className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-2.5 mb-1">
+                    Side Menu (
+                    {theme.sideMenuRootLinks.length + theme.sideMenuSecondaryLinks.length})
+                </p>
 
-                {theme.sideMenuRootLinks.map((link) => (
-                    <div key={link.id} className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40">
+                {theme.sideMenuRootLinks.map(link => (
+                    <div
+                        key={link.id}
+                        className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40"
+                    >
                         <span className="text-gray-400">{link.label}</span>
                         <span className="text-gray-600 font-mono text-[9px]">{link.path}</span>
                     </div>
@@ -319,10 +378,15 @@ export const ThemeDebugTab: React.FC = () => {
                     <>
                         <p className="text-[8px] text-gray-600 mt-1.5 mb-0.5">Secondary</p>
 
-                        {theme.sideMenuSecondaryLinks.map((link) => (
-                            <div key={link.id} className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40">
+                        {theme.sideMenuSecondaryLinks.map(link => (
+                            <div
+                                key={link.id}
+                                className="flex items-center justify-between text-[10px] py-[3px] border-t border-gray-700/40"
+                            >
                                 <span className="text-gray-400">{link.label}</span>
-                                <span className="text-gray-600 font-mono text-[9px]">{link.path}</span>
+                                <span className="text-gray-600 font-mono text-[9px]">
+                                    {link.path}
+                                </span>
                             </div>
                         ))}
                     </>
@@ -336,7 +400,14 @@ export const ThemeDebugTab: React.FC = () => {
                     icon={<Layout className="w-3 h-3 text-gray-500" />}
                 >
                     {Object.entries(theme.styles).map(([key, val]) => (
-                        <KVRow key={key} label={key} value={typeof val === 'object' ? JSON.stringify(val) : String(val)} mono={false} copied={copied} onCopy={setCopied} />
+                        <KVRow
+                            key={key}
+                            label={key}
+                            value={typeof val === 'object' ? JSON.stringify(val) : String(val)}
+                            mono={false}
+                            copied={copied}
+                            onCopy={setCopied}
+                        />
                     ))}
                 </Section>
             )}
@@ -363,13 +434,18 @@ export const ThemeDebugTab: React.FC = () => {
 
                     <div className="flex items-center gap-1">
                         <button
-                            onClick={(e) => { e.stopPropagation(); handleCopyThemeJson(); }}
+                            onClick={e => {
+                                e.stopPropagation();
+                                handleCopyThemeJson();
+                            }}
                             className="p-1 rounded hover:bg-gray-600 transition-colors"
                             title="Copy full theme JSON"
                         >
-                            {copied === 'theme-json'
-                                ? <Check className="w-3 h-3 text-emerald-400" />
-                                : <Copy className="w-3 h-3 text-gray-500" />}
+                            {copied === 'theme-json' ? (
+                                <Check className="w-3 h-3 text-emerald-400" />
+                            ) : (
+                                <Copy className="w-3 h-3 text-gray-500" />
+                            )}
                         </button>
                     </div>
                 </button>

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useMemo, useRef } from 'react';
 import { useHistory } from 'react-router';
 import { IonPage, IonContent } from '@ionic/react';
+import { Capacitor } from '@capacitor/core';
+import { Filesystem, Directory } from '@capacitor/filesystem';
+import { Media } from '@capacitor-community/media';
 import { ArrowLeft, Copy, Check, Share, Download, Loader2 } from 'lucide-react';
 import { QRCodeSVG, QRCodeCanvas } from 'qrcode.react';
 import {
@@ -10,6 +13,7 @@ import {
     useToast,
     ToastTypeEnum,
     walletSubtypeToDefaultImageSrc,
+    getLogger,
 } from 'learn-card-base';
 import { WalletCategoryTypes } from 'learn-card-base/components/IssueVC/types';
 
@@ -37,6 +41,23 @@ import BoostEarnedCard from '../../components/boost/boost-earned-card/BoostEarne
 import { BoostCategoryOptionsEnum, BoostPageViewMode } from 'learn-card-base';
 
 type Step = 'pick' | 'personalize' | 'send' | 'celebrate';
+
+const log = getLogger('boost-a-friend-page');
+
+const QR_ALBUM_NAME = 'LearnCard';
+
+const ensureQrAlbumExists = async (): Promise<string | undefined> => {
+    if (Capacitor.getPlatform() !== 'android') return undefined;
+
+    let { albums } = await Media.getAlbums();
+    let album = albums.find(a => a.name === QR_ALBUM_NAME);
+    if (album?.identifier) return album.identifier;
+
+    await Media.createAlbum({ name: QR_ALBUM_NAME });
+    ({ albums } = await Media.getAlbums());
+    album = albums.find(a => a.name === QR_ALBUM_NAME);
+    return album?.identifier;
+};
 
 const BoostAFriendPage: React.FC = () => {
     const history = useHistory();
@@ -204,17 +225,44 @@ const BoostAFriendPage: React.FC = () => {
         }
     };
 
-    const handleDownloadQR = () => {
+    const handleDownloadQR = async () => {
         if (!qrCanvasRef.current) return;
         try {
             const dataUrl = qrCanvasRef.current.toDataURL('image/png');
-            const link = document.createElement('a');
-            link.download = 'badge-qr.png';
-            link.href = dataUrl;
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-        } catch {
+
+            if (!Capacitor.isNativePlatform()) {
+                const link = document.createElement('a');
+                link.download = 'badge-qr.png';
+                link.href = dataUrl;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                return;
+            }
+
+            const base64 = dataUrl.split(',')[1];
+            const fileName = `qrcode_${Date.now()}.png`;
+
+            const savedFile = await Filesystem.writeFile({
+                path: fileName,
+                data: base64,
+                directory: Directory.Documents,
+            });
+
+            const albumIdentifier = await ensureQrAlbumExists();
+
+            await Media.savePhoto({
+                path: savedFile.uri,
+                fileName,
+                ...(albumIdentifier ? { albumIdentifier } : {}),
+            });
+
+            presentToast('QR code saved to Photos.', {
+                type: ToastTypeEnum.Success,
+                hasDismissButton: true,
+            });
+        } catch (err) {
+            log.error('boost-a-friend.qr_download_failed', err);
             presentToast('Failed to download QR code.', {
                 type: ToastTypeEnum.Error,
                 hasDismissButton: true,

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -50,7 +50,7 @@ const BoostAFriendPage: React.FC = () => {
     const [claimLink, setClaimLink] = useState<string | null>(null);
 
     const handleSelectBadge = (badge: BadgePreset, color: string) => {
-        const { backgroundColor } = resolveBadgeStyle(badge, stylePacks, categoryFallback);
+        const { backgroundColor } = resolveBadgeStyle(badge, stylePacks);
         setSelectedBadge(badge);
         setVibeColor(backgroundColor || color);
         setStep('personalize');
@@ -100,14 +100,14 @@ const BoostAFriendPage: React.FC = () => {
                 await getRegisteredSigningAuthority(wallet);
             }
 
-            const { imageUrl } = resolveBadgeStyle(selectedBadge, stylePacks, categoryFallback);
+            const { imageUrl } = resolveBadgeStyle(selectedBadge, stylePacks);
 
             const template = buildBoostFriendTemplate({
                 title: selectedBadge.title,
                 description: `A social badge for being a ${selectedBadge.title}`,
                 note,
                 vibeColor,
-                imageUrl,
+                imageUrl: imageUrl || categoryFallback,
             });
 
             const result = await issueViaBoost(wallet, template, {
@@ -172,22 +172,23 @@ const BoostAFriendPage: React.FC = () => {
         <IonPage className="bg-white">
             <MainHeader showBackButton customClassName="bg-white" />
             <IonContent>
-                <div className="min-h-full font-poppins relative overflow-hidden">
-                    <div
-                        className="absolute inset-0 pointer-events-none transition-colors duration-700 ease-in-out opacity-20"
-                        style={{
-                            background: `radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 70%)`,
-                        }}
-                    />
+                <div className="min-h-full font-poppins relative">
+                    <div className="absolute inset-0 pointer-events-none overflow-hidden">
+                        <div
+                            className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-20"
+                            style={{
+                                background: `radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 70%)`,
+                            }}
+                        />
+                    </div>
 
-                    <div className="max-w-xl mx-auto h-full flex flex-col px-4 sm:px-6 py-6 relative z-10">
+                    <div className="max-w-xl mx-auto h-full flex flex-col px-4 sm:px-6 py-4 relative z-10">
                         {step === 'pick' && (
                             <BadgePicker
                                 onSelect={handleSelectBadge}
                                 onBack={() => history.goBack()}
                                 stylePacks={stylePacks}
                                 badgeGroups={badgeGroups}
-                                categoryFallback={categoryFallback}
                             />
                         )}
 
@@ -201,7 +202,6 @@ const BoostAFriendPage: React.FC = () => {
                                 onNext={() => setStep('send')}
                                 onBack={() => setStep('pick')}
                                 stylePacks={stylePacks}
-                                categoryFallback={categoryFallback}
                             />
                         )}
 

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -17,7 +17,12 @@ import { BadgePicker } from './components/BadgePicker';
 import { BadgePersonalize } from './components/BadgePersonalize';
 import { BoostRecipientPicker } from './components/BoostRecipientPicker';
 import { Confetti } from '../issue/components/Confetti';
-import { RecipientMode, Recipient, LinkOptions } from '../issue/components/recipientTypes';
+import {
+    RecipientMode,
+    Recipient,
+    LinkOptions,
+    summarizeRecipients,
+} from '../issue/components/recipientTypes';
 import { issueViaBoost } from '../../components/simple-send/simpleSend.helpers';
 import {
     buildBoostFriendTemplate,
@@ -31,14 +36,6 @@ import BoostEarnedCard from '../../components/boost/boost-earned-card/BoostEarne
 import { BoostCategoryOptionsEnum, BoostPageViewMode } from 'learn-card-base';
 
 type Step = 'pick' | 'personalize' | 'send' | 'celebrate';
-
-const formatRecipients = (recs: Recipient[]) => {
-    if (recs.length === 0) return '';
-    const names = recs.map(r => (r.kind === 'profile' ? r.displayName : r.email));
-    if (names.length === 1) return names[0];
-    if (names.length === 2) return `${names[0]} and ${names[1]}`;
-    return `${names[0]}, ${names[1]} +${names.length - 2}`;
-};
 
 const BoostAFriendPage: React.FC = () => {
     const history = useHistory();
@@ -334,7 +331,7 @@ const BoostAFriendPage: React.FC = () => {
                                     </div>
                                 </div>
 
-                                <div className="flex-1 min-h-0 flex flex-col pb-20">
+                                <div className="flex-1 min-h-0 flex flex-col">
                                     <div className="max-w-sm mx-auto w-full flex-1 flex flex-col min-h-0">
                                         <BoostRecipientPicker
                                             mode={recipientMode}
@@ -355,7 +352,7 @@ const BoostAFriendPage: React.FC = () => {
                                     </div>
                                 </div>
 
-                                <div className="pt-4 mt-auto">
+                                <div className="pt-4 mt-auto pb-[env(safe-area-inset-bottom,0px)]">
                                     <button
                                         type="button"
                                         onClick={handleIssue}
@@ -385,101 +382,112 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'celebrate' && claimLink && (
-                            <div className="relative w-full max-w-[860px] mx-auto my-auto animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] desktop:grid desktop:grid-cols-2 desktop:gap-10 desktop:items-center">
-                                <Confetti />
+                            <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hide">
+                                <div className="relative w-full max-w-[860px] mx-auto min-h-full flex flex-col justify-center animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] pb-[calc(env(safe-area-inset-bottom)+1.5rem)] desktop:grid desktop:grid-cols-2 desktop:gap-10 desktop:items-center">
+                                    <Confetti />
 
-                                <div className="text-center space-y-6 mb-8 desktop:mb-0">
-                                    {celebrateCard && (
-                                        <div className="flex justify-center">
-                                            <div className="w-[160px] sm:w-[200px]">
-                                                {celebrateCard}
+                                    <div className="text-center space-y-6 mb-8 desktop:mb-0">
+                                        {celebrateCard && (
+                                            <div className="flex justify-center">
+                                                <div className="w-[160px] sm:w-[200px]">
+                                                    {celebrateCard}
+                                                </div>
                                             </div>
-                                        </div>
-                                    )}
-                                    <div className="animate-fade-in-up">
-                                        <h1 className="text-xl font-semibold text-grayscale-900 mb-1">
-                                            Link ready!
-                                        </h1>
-                                        <p className="text-sm text-grayscale-600 leading-relaxed">
-                                            Anyone with this link or QR code can claim it.
-                                        </p>
-                                    </div>
-                                </div>
-
-                                <div className="animate-fade-in-up space-y-6 text-center max-w-[420px] mx-auto w-full">
-                                    <div className="bg-white p-6 rounded-[20px] shadow-sm border border-grayscale-200 flex flex-col items-center gap-4">
-                                        <div className="w-48 h-48 relative">
-                                            <QRCodeSVG
-                                                className="w-full h-full"
-                                                value={claimLink}
-                                                bgColor="transparent"
-                                            />
-                                            <div className="hidden">
-                                                <QRCodeCanvas
-                                                    value={claimLink}
-                                                    size={1024}
-                                                    bgColor="#ffffff"
-                                                    fgColor="#000000"
-                                                    level="H"
-                                                    includeMargin={true}
-                                                    ref={qrCanvasRef}
-                                                />
-                                            </div>
-                                        </div>
-
-                                        <div className="w-full bg-grayscale-10 p-3 rounded-xl border border-grayscale-200 text-center">
-                                            <p
-                                                className="text-xs text-grayscale-600 font-mono truncate"
-                                                title={claimLink}
-                                            >
-                                                {truncateLink(claimLink)}
+                                        )}
+                                        <div className="animate-fade-in-up">
+                                            <h1 className="text-xl font-semibold text-grayscale-900 mb-1">
+                                                Link ready!
+                                            </h1>
+                                            <p className="text-sm text-grayscale-600 leading-relaxed">
+                                                Anyone with this link or QR code can claim it.
                                             </p>
                                         </div>
                                     </div>
 
-                                    <div className="space-y-3">
-                                        <button
-                                            type="button"
-                                            onClick={handleCopyLink}
-                                            className="w-full py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
-                                        >
-                                            {copied ? (
-                                                <Check className="w-4 h-4 text-emerald-500" />
-                                            ) : (
-                                                <Copy className="w-4 h-4" />
-                                            )}
-                                            {copied ? 'Copied' : 'Copy link'}
-                                        </button>
-                                        <div className="flex gap-3">
-                                            {typeof navigator !== 'undefined' &&
-                                                navigator.share && (
-                                                    <button
-                                                        type="button"
-                                                        onClick={handleShareLink}
-                                                        className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
-                                                    >
-                                                        <Share className="w-4 h-4" />
-                                                        Share
-                                                    </button>
-                                                )}
+                                    <div className="animate-fade-in-up space-y-6 text-center max-w-[420px] mx-auto w-full">
+                                        <div className="bg-white p-6 rounded-[20px] shadow-sm border border-grayscale-200 flex flex-col items-center gap-4">
+                                            <div className="w-48 h-48 relative">
+                                                <QRCodeSVG
+                                                    className="w-full h-full"
+                                                    value={claimLink}
+                                                    bgColor="transparent"
+                                                />
+                                                <div className="hidden">
+                                                    <QRCodeCanvas
+                                                        value={claimLink}
+                                                        size={1024}
+                                                        bgColor="#ffffff"
+                                                        fgColor="#000000"
+                                                        level="H"
+                                                        includeMargin={true}
+                                                        ref={qrCanvasRef}
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            <div className="w-full bg-grayscale-10 p-3 rounded-xl border border-grayscale-200 text-center">
+                                                <p
+                                                    className="text-xs text-grayscale-600 font-mono truncate"
+                                                    title={claimLink}
+                                                >
+                                                    {truncateLink(claimLink)}
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <div className="space-y-3">
                                             <button
                                                 type="button"
-                                                onClick={handleDownloadQR}
-                                                className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                                onClick={handleCopyLink}
+                                                className="w-full py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
                                             >
-                                                <Download className="w-4 h-4" />
-                                                Download QR
+                                                {copied ? (
+                                                    <Check className="w-4 h-4 text-emerald-500" />
+                                                ) : (
+                                                    <Copy className="w-4 h-4" />
+                                                )}
+                                                {copied ? 'Copied' : 'Copy link'}
+                                            </button>
+                                            <div className="flex gap-3">
+                                                {typeof navigator !== 'undefined' &&
+                                                    navigator.share && (
+                                                        <button
+                                                            type="button"
+                                                            onClick={handleShareLink}
+                                                            className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                                        >
+                                                            <Share className="w-4 h-4" />
+                                                            Share
+                                                        </button>
+                                                    )}
+                                                <button
+                                                    type="button"
+                                                    onClick={handleDownloadQR}
+                                                    className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                                >
+                                                    <Download className="w-4 h-4" />
+                                                    Download QR
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                        <div className="space-y-2">
+                                            <button
+                                                type="button"
+                                                onClick={handleBoostAnother}
+                                                className="w-full text-sm text-grayscale-600 hover:text-grayscale-900 transition-colors"
+                                            >
+                                                Boost Another
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => history.push('/wallet')}
+                                                className="w-full text-sm text-grayscale-500 hover:text-grayscale-900 transition-colors"
+                                            >
+                                                Done
                                             </button>
                                         </div>
                                     </div>
-
-                                    <button
-                                        type="button"
-                                        onClick={handleBoostAnother}
-                                        className="w-full text-sm text-grayscale-600 hover:text-grayscale-900 transition-colors"
-                                    >
-                                        Boost Another
-                                    </button>
                                 </div>
                             </div>
                         )}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -325,7 +325,7 @@ const BoostAFriendPage: React.FC = () => {
                             <div className="max-w-xl mx-auto w-full flex flex-col h-full text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] overflow-y-auto scrollbar-hide">
                                 <Confetti />
 
-                                <div className="my-auto w-full py-6 space-y-8">
+                                <div className="flex-1 min-h-0 flex flex-col items-center justify-center w-full py-6 space-y-8">
                                     <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto">
                                         {selectedBadge && (
                                             <div className="w-[160px] sm:w-[200px] mb-6">
@@ -409,7 +409,7 @@ const BoostAFriendPage: React.FC = () => {
                                     </div>
                                 </div>
 
-                                <div className="w-full max-w-sm mx-auto space-y-3 mt-auto pt-6">
+                                <div className="w-full max-w-sm mx-auto space-y-3 shrink-0 pt-6">
                                     <button
                                         type="button"
                                         onClick={handleBoostAnother}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -169,8 +169,8 @@ const BoostAFriendPage: React.FC = () => {
 
     return (
         <IonPage className="bg-white">
-            <IonContent>
-                <div className="min-h-full font-poppins relative">
+            <IonContent scrollY={false}>
+                <div className="h-full font-poppins relative">
                     <div className="absolute inset-0 pointer-events-none overflow-hidden">
                         <div
                             className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-25"

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -471,20 +471,20 @@ const BoostAFriendPage: React.FC = () => {
                                             </div>
                                         </div>
 
-                                        <div className="space-y-2">
-                                            <button
-                                                type="button"
-                                                onClick={handleBoostAnother}
-                                                className="w-full text-sm text-grayscale-600 hover:text-grayscale-900 transition-colors"
-                                            >
-                                                Boost Another
-                                            </button>
+                                        <div className="space-y-3 pt-5 border-t border-grayscale-200">
                                             <button
                                                 type="button"
                                                 onClick={() => history.push('/wallet')}
-                                                className="w-full text-sm text-grayscale-500 hover:text-grayscale-900 transition-colors"
+                                                className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
                                             >
                                                 Done
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={handleBoostAnother}
+                                                className="w-full py-3.5 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-base hover:bg-grayscale-10 transition-colors"
+                                            >
+                                                Boost Another
                                             </button>
                                         </div>
                                     </div>

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -24,6 +24,7 @@ import {
     summarizeRecipients,
 } from '../issue/components/recipientTypes';
 import { issueViaBoost } from '../../components/simple-send/simpleSend.helpers';
+import { getFriendlyIssueError, withTransientRetry } from '../issue/issueErrors';
 import {
     buildBoostFriendTemplate,
     BadgePreset,
@@ -39,7 +40,7 @@ type Step = 'pick' | 'personalize' | 'send' | 'celebrate';
 
 const BoostAFriendPage: React.FC = () => {
     const history = useHistory();
-    const { initWallet } = useWallet();
+    const { initWallet, addVCtoWallet } = useWallet();
     const { currentLCNUser } = useGetCurrentLCNUser();
     const { getRegisteredSigningAuthorities, getRegisteredSigningAuthority } =
         useSigningAuthority();
@@ -56,6 +57,7 @@ const BoostAFriendPage: React.FC = () => {
     const [note, setNote] = useState('');
     const [criteria, setCriteria] = useState('');
     const [description, setDescription] = useState('');
+    const [customImageUrl, setCustomImageUrl] = useState('');
 
     const [recipientMode, setRecipientMode] = useState<RecipientMode>('people');
     const [recipients, setRecipients] = useState<Recipient[]>([]);
@@ -80,6 +82,7 @@ const BoostAFriendPage: React.FC = () => {
         setDescription(presetDescription ?? '');
         setNote('');
         setCriteria(presetCriteria ?? '');
+        setCustomImageUrl('');
         setStep('personalize');
     };
 
@@ -128,6 +131,7 @@ const BoostAFriendPage: React.FC = () => {
             }
 
             const { imageUrl } = resolveBadgeStyle(selectedBadge, stylePacks);
+            const badgeImageUrl = customImageUrl.trim() || imageUrl;
 
             const template = buildBoostFriendTemplate({
                 title: title.trim(),
@@ -135,16 +139,27 @@ const BoostAFriendPage: React.FC = () => {
                 description: description.trim() || `A social badge for being a ${title.trim()}`,
                 note: note.trim() || criteria,
                 vibeColor,
-                imageUrl: imageUrl || categoryFallback,
+                imageUrl: badgeImageUrl || categoryFallback,
             });
 
-            const result = await issueViaBoost(wallet, template, {
-                mode: recipientMode,
-                recipients,
-                linkOptions,
-                currentLCNUser,
-                claimLinkSA,
-            });
+            const result = await withTransientRetry(() =>
+                issueViaBoost(wallet, template, {
+                    mode: recipientMode,
+                    recipients,
+                    linkOptions,
+                    currentLCNUser,
+                    claimLinkSA,
+                })
+            );
+
+            if (recipientMode === 'self') {
+                if (!result.credentialUri) {
+                    throw new Error(
+                        'Badge was issued, but it could not be saved to your Passport.'
+                    );
+                }
+                await addVCtoWallet({ uri: result.credentialUri });
+            }
 
             if (result.claimLink) {
                 setClaimLink(result.claimLink);
@@ -152,7 +167,7 @@ const BoostAFriendPage: React.FC = () => {
 
             setStep('celebrate');
         } catch (err: any) {
-            setError(err.message || 'Something went wrong. Please try again.');
+            setError(getFriendlyIssueError(err, recipientMode).message);
         } finally {
             setIsIssuing(false);
         }
@@ -217,6 +232,7 @@ const BoostAFriendPage: React.FC = () => {
         setNote('');
         setCriteria('');
         setDescription('');
+        setCustomImageUrl('');
         setRecipients([]);
         setClaimLink(null);
         setError(null);
@@ -231,7 +247,10 @@ const BoostAFriendPage: React.FC = () => {
             description,
             note: note.trim() || criteria,
             vibeColor,
-            imageUrl: resolveBadgeStyle(selectedBadge, stylePacks).imageUrl || categoryFallback,
+            imageUrl:
+                customImageUrl.trim() ||
+                resolveBadgeStyle(selectedBadge, stylePacks).imageUrl ||
+                categoryFallback,
             issuerName: currentLCNUser?.displayName || currentLCNUser?.profileId || '',
         });
     }, [
@@ -242,6 +261,7 @@ const BoostAFriendPage: React.FC = () => {
         note,
         criteria,
         vibeColor,
+        customImageUrl,
         stylePacks,
         categoryFallback,
         currentLCNUser,
@@ -298,6 +318,8 @@ const BoostAFriendPage: React.FC = () => {
                                     note={note}
                                     notePlaceholder={criteria}
                                     onNoteChange={setNote}
+                                    imageUrl={customImageUrl}
+                                    onImageUrlChange={setCustomImageUrl}
                                     onNext={() => setStep('send')}
                                     onBack={() => setStep('pick')}
                                     stylePacks={stylePacks}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -1,0 +1,350 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router';
+import { IonPage, IonContent } from '@ionic/react';
+import { ArrowLeft, CheckCircle2, Copy, Share, Loader2 } from 'lucide-react';
+import {
+    useWallet,
+    useGetCurrentLCNUser,
+    useSigningAuthority,
+    useToast,
+    ToastTypeEnum,
+    walletSubtypeToDefaultImageSrc,
+} from 'learn-card-base';
+import { WalletCategoryTypes } from 'learn-card-base/components/IssueVC/types';
+
+import MainHeader from '../../components/main-header/MainHeader';
+import { BadgePicker } from './components/BadgePicker';
+import { BadgePersonalize } from './components/BadgePersonalize';
+import { RecipientPicker } from '../issue/components/RecipientPicker';
+import { Confetti } from '../issue/components/Confetti';
+import { RecipientMode, Recipient, LinkOptions } from '../issue/components/recipientTypes';
+import { issueViaBoost } from '../../components/simple-send/simpleSend.helpers';
+import { buildBoostFriendTemplate, BadgePreset, resolveBadgeStyle } from './boostAFriend.helpers';
+import { useStylePackRegistry } from '../../registries/useStylePackRegistry';
+import { useBadgeGroups } from '../../registries/useBadgeGroups';
+
+type Step = 'pick' | 'personalize' | 'send' | 'celebrate';
+
+const BoostAFriendPage: React.FC = () => {
+    const history = useHistory();
+    const { initWallet } = useWallet();
+    const { currentLCNUser } = useGetCurrentLCNUser();
+    const { getRegisteredSigningAuthorities, getRegisteredSigningAuthority } =
+        useSigningAuthority();
+    const { presentToast } = useToast();
+    const { data: stylePacks } = useStylePackRegistry();
+    const { data: badgeGroups } = useBadgeGroups();
+    const categoryFallback = walletSubtypeToDefaultImageSrc(WalletCategoryTypes.socialBadges);
+
+    const [step, setStep] = useState<Step>('pick');
+    const [selectedBadge, setSelectedBadge] = useState<BadgePreset | null>(null);
+    const [vibeColor, setVibeColor] = useState<string>('#3B82F6');
+    const [note, setNote] = useState('');
+
+    const [recipientMode, setRecipientMode] = useState<RecipientMode>('people');
+    const [recipients, setRecipients] = useState<Recipient[]>([]);
+    const [linkOptions, setLinkOptions] = useState<LinkOptions>({});
+
+    const [isIssuing, setIsIssuing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [claimLink, setClaimLink] = useState<string | null>(null);
+
+    const handleSelectBadge = (badge: BadgePreset, color: string) => {
+        const { backgroundColor } = resolveBadgeStyle(badge, stylePacks, categoryFallback);
+        setSelectedBadge(badge);
+        setVibeColor(backgroundColor || color);
+        setStep('personalize');
+    };
+
+    const handleIssue = async () => {
+        if (!selectedBadge) return;
+
+        const isLinkMode = recipientMode === 'link';
+        const hasRecipients = recipients.length > 0;
+
+        if (recipientMode === 'people' && !hasRecipients) {
+            setError('Please add at least one recipient.');
+            return;
+        }
+
+        setError(null);
+        setIsIssuing(true);
+
+        try {
+            const wallet = await initWallet();
+
+            let claimLinkSA: { name?: string; endpoint?: string } | undefined;
+
+            const hasEmailRecipient =
+                recipientMode === 'people' && recipients.some(r => r.kind === 'email');
+
+            if (isLinkMode) {
+                const rsas = await getRegisteredSigningAuthorities(wallet);
+                if (rsas && rsas.length > 0) {
+                    const rsa = rsas[0];
+                    claimLinkSA = {
+                        name: rsa?.relationship?.name,
+                        endpoint: rsa?.signingAuthority?.endpoint,
+                    };
+                } else {
+                    const { registeredSigningAuthority: rsa, signingAuthority: sa } =
+                        await getRegisteredSigningAuthority(wallet);
+                    if (sa) {
+                        claimLinkSA = {
+                            name: sa.name,
+                            endpoint: sa.endpoint,
+                        };
+                    }
+                }
+            } else if (hasEmailRecipient) {
+                await getRegisteredSigningAuthority(wallet);
+            }
+
+            const { imageUrl } = resolveBadgeStyle(selectedBadge, stylePacks, categoryFallback);
+
+            const template = buildBoostFriendTemplate({
+                title: selectedBadge.title,
+                description: `A social badge for being a ${selectedBadge.title}`,
+                note,
+                vibeColor,
+                imageUrl,
+            });
+
+            const result = await issueViaBoost(wallet, template, {
+                mode: recipientMode,
+                recipients,
+                linkOptions,
+                currentLCNUser,
+                claimLinkSA,
+            });
+
+            if (result.claimLink) {
+                setClaimLink(result.claimLink);
+            }
+
+            setStep('celebrate');
+        } catch (err: any) {
+            setError(err.message || 'Something went wrong. Please try again.');
+        } finally {
+            setIsIssuing(false);
+        }
+    };
+
+    const handleCopyLink = async () => {
+        if (!claimLink) return;
+        try {
+            await navigator.clipboard.writeText(claimLink);
+            presentToast('Link copied to clipboard', {
+                type: ToastTypeEnum.Success,
+                hasDismissButton: true,
+            });
+        } catch (err) {
+            presentToast('Failed to copy link', {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+        }
+    };
+
+    const handleShareLink = async () => {
+        if (!claimLink) return;
+        try {
+            await navigator.share({
+                title: 'Claim your badge!',
+                text: `I sent you a ${selectedBadge?.title} badge!`,
+                url: claimLink,
+            });
+        } catch {
+            // The share sheet rejects when the user dismisses it — nothing to handle.
+        }
+    };
+
+    const handleBoostAnother = () => {
+        setSelectedBadge(null);
+        setNote('');
+        setRecipients([]);
+        setClaimLink(null);
+        setError(null);
+        setStep('pick');
+    };
+
+    return (
+        <IonPage className="bg-white">
+            <MainHeader showBackButton customClassName="bg-white" />
+            <IonContent>
+                <div className="min-h-full font-poppins relative overflow-hidden">
+                    <div
+                        className="absolute inset-0 pointer-events-none transition-colors duration-700 ease-in-out opacity-20"
+                        style={{
+                            background: `radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 70%)`,
+                        }}
+                    />
+
+                    <div className="max-w-xl mx-auto h-full flex flex-col px-4 sm:px-6 py-6 relative z-10">
+                        {step === 'pick' && (
+                            <BadgePicker
+                                onSelect={handleSelectBadge}
+                                onBack={() => history.goBack()}
+                                stylePacks={stylePacks}
+                                badgeGroups={badgeGroups}
+                                categoryFallback={categoryFallback}
+                            />
+                        )}
+
+                        {step === 'personalize' && selectedBadge && (
+                            <BadgePersonalize
+                                badge={selectedBadge}
+                                vibeColor={vibeColor}
+                                onVibeColorChange={setVibeColor}
+                                note={note}
+                                onNoteChange={setNote}
+                                onNext={() => setStep('send')}
+                                onBack={() => setStep('pick')}
+                                stylePacks={stylePacks}
+                                categoryFallback={categoryFallback}
+                            />
+                        )}
+
+                        {step === 'send' && (
+                            <div className="flex flex-col h-full animate-fade-in-up">
+                                <div className="flex items-center gap-3 mb-6">
+                                    <button
+                                        type="button"
+                                        onClick={() => setStep('personalize')}
+                                        className="p-2 -ml-2 rounded-full hover:bg-white/50 text-grayscale-600 transition-colors"
+                                        aria-label="Go back"
+                                    >
+                                        <ArrowLeft className="w-5 h-5" />
+                                    </button>
+                                    <div>
+                                        <h1 className="text-2xl font-semibold text-grayscale-900">
+                                            Send to
+                                        </h1>
+                                        <p className="text-sm text-grayscale-600 mt-1">
+                                            Who gets this badge?
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <div className="flex-1 overflow-y-auto pb-20 flex flex-col justify-center">
+                                    <div className="max-w-sm mx-auto w-full">
+                                        <RecipientPicker
+                                            mode={recipientMode}
+                                            onModeChange={setRecipientMode}
+                                            recipients={recipients}
+                                            onRecipientsChange={setRecipients}
+                                            linkOptions={linkOptions}
+                                            onLinkOptionsChange={setLinkOptions}
+                                            hideHeader
+                                        />
+
+                                        {error && (
+                                            <div className="mt-6 p-3 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-2.5 animate-fade-in-up shadow-sm">
+                                                <span className="text-sm text-red-700 leading-relaxed">
+                                                    {error}
+                                                </span>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+
+                                <div className="pt-4 mt-auto">
+                                    <button
+                                        type="button"
+                                        onClick={handleIssue}
+                                        disabled={
+                                            isIssuing ||
+                                            (recipientMode === 'people' && recipients.length === 0)
+                                        }
+                                        className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-sm"
+                                    >
+                                        {isIssuing ? (
+                                            <>
+                                                <Loader2 className="w-5 h-5 animate-spin" />
+                                                {recipientMode === 'link'
+                                                    ? 'Creating link...'
+                                                    : 'Sending...'}
+                                            </>
+                                        ) : recipientMode === 'link' ? (
+                                            'Create Link'
+                                        ) : (
+                                            'Send Badge'
+                                        )}
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+
+                        {step === 'celebrate' && (
+                            <div className="flex flex-col h-full items-center justify-center text-center animate-pop-in relative py-10">
+                                <Confetti />
+
+                                <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto flex-1">
+                                    <div className="w-20 h-20 bg-emerald-50 rounded-full flex items-center justify-center mb-6 shadow-sm">
+                                        <CheckCircle2 className="w-10 h-10 text-emerald-500" />
+                                    </div>
+
+                                    <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
+                                        {recipientMode === 'link' ? 'Link Created!' : 'Badge Sent!'}
+                                    </h1>
+                                    <p className="text-base text-grayscale-600 mb-10">
+                                        {recipientMode === 'link'
+                                            ? 'Your badge is ready to be shared. Anyone with the link can claim it.'
+                                            : "They'll be notified about their new badge."}
+                                    </p>
+
+                                    {claimLink && (
+                                        <div className="w-full mb-10 space-y-3">
+                                            <div className="p-4 bg-white/80 backdrop-blur-sm rounded-2xl break-all text-sm text-grayscale-900 border border-grayscale-200 shadow-sm">
+                                                {claimLink}
+                                            </div>
+                                            <div className="flex gap-3">
+                                                <button
+                                                    type="button"
+                                                    onClick={handleCopyLink}
+                                                    className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-sm hover:bg-white transition-colors"
+                                                >
+                                                    <Copy className="w-4 h-4" />
+                                                    Copy
+                                                </button>
+                                                {navigator.share && (
+                                                    <button
+                                                        type="button"
+                                                        onClick={handleShareLink}
+                                                        className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity shadow-sm"
+                                                    >
+                                                        <Share className="w-4 h-4" />
+                                                        Share
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="w-full max-w-sm space-y-3 mt-auto pt-6">
+                                    <button
+                                        type="button"
+                                        onClick={handleBoostAnother}
+                                        className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
+                                    >
+                                        Boost Another
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => history.push('/wallet')}
+                                        className="w-full py-3.5 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-base hover:bg-white transition-colors"
+                                    >
+                                        Done
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </IonContent>
+        </IonPage>
+    );
+};
+
+export default BoostAFriendPage;

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -12,7 +12,6 @@ import {
 } from 'learn-card-base';
 import { WalletCategoryTypes } from 'learn-card-base/components/IssueVC/types';
 
-import MainHeader from '../../components/main-header/MainHeader';
 import { BadgePicker } from './components/BadgePicker';
 import { BadgePersonalize } from './components/BadgePersonalize';
 import { RecipientPicker } from '../issue/components/RecipientPicker';
@@ -170,19 +169,22 @@ const BoostAFriendPage: React.FC = () => {
 
     return (
         <IonPage className="bg-white">
-            <MainHeader showBackButton customClassName="bg-white" />
             <IonContent>
                 <div className="min-h-full font-poppins relative">
                     <div className="absolute inset-0 pointer-events-none overflow-hidden">
                         <div
-                            className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-20"
+                            className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-25"
                             style={{
-                                background: `radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 70%)`,
+                                background: `
+                                    radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 60%),
+                                    radial-gradient(circle at 100% 100%, #10B981 0%, transparent 50%),
+                                    radial-gradient(circle at 0% 100%, #94A3B8 0%, transparent 50%)
+                                `,
                             }}
                         />
                     </div>
 
-                    <div className="max-w-xl mx-auto h-full flex flex-col px-4 sm:px-6 py-4 relative z-10">
+                    <div className="max-w-xl sm:max-w-2xl lg:max-w-4xl mx-auto h-full flex flex-col px-4 sm:px-6 pb-4 relative z-10 w-full">
                         {step === 'pick' && (
                             <BadgePicker
                                 onSelect={handleSelectBadge}
@@ -193,20 +195,22 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'personalize' && selectedBadge && (
-                            <BadgePersonalize
-                                badge={selectedBadge}
-                                vibeColor={vibeColor}
-                                onVibeColorChange={setVibeColor}
-                                note={note}
-                                onNoteChange={setNote}
-                                onNext={() => setStep('send')}
-                                onBack={() => setStep('pick')}
-                                stylePacks={stylePacks}
-                            />
+                            <div className="max-w-xl mx-auto w-full h-full">
+                                <BadgePersonalize
+                                    badge={selectedBadge}
+                                    vibeColor={vibeColor}
+                                    onVibeColorChange={setVibeColor}
+                                    note={note}
+                                    onNoteChange={setNote}
+                                    onNext={() => setStep('send')}
+                                    onBack={() => setStep('pick')}
+                                    stylePacks={stylePacks}
+                                />
+                            </div>
                         )}
 
                         {step === 'send' && (
-                            <div className="flex flex-col h-full animate-fade-in-up">
+                            <div className="max-w-xl mx-auto w-full flex flex-col h-full animate-fade-in-up pt-[calc(env(safe-area-inset-top)+1rem)]">
                                 <div className="flex items-center gap-3 mb-6">
                                     <button
                                         type="button"
@@ -276,7 +280,7 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'celebrate' && (
-                            <div className="flex flex-col h-full items-center justify-center text-center animate-pop-in relative py-10">
+                            <div className="max-w-xl mx-auto w-full flex flex-col h-full items-center justify-center text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)]">
                                 <Confetti />
 
                                 <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto flex-1">

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -493,51 +493,53 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'celebrate' && !claimLink && (
-                            <div className="relative w-full max-w-[420px] mx-auto my-auto text-center space-y-6 animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)]">
-                                <Confetti />
+                            <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hide">
+                                <div className="relative w-full max-w-[420px] mx-auto min-h-full flex flex-col justify-center text-center space-y-6 animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] pb-[calc(env(safe-area-inset-bottom)+1.5rem)]">
+                                    <Confetti />
 
-                                {celebrateCard && (
-                                    <div className="flex justify-center">
-                                        <div className="w-[160px] sm:w-[200px]">
-                                            {celebrateCard}
+                                    {celebrateCard && (
+                                        <div className="flex justify-center">
+                                            <div className="w-[160px] sm:w-[200px]">
+                                                {celebrateCard}
+                                            </div>
                                         </div>
+                                    )}
+
+                                    <div className="animate-fade-in-up">
+                                        <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
+                                            {recipientMode === 'self'
+                                                ? 'Added to your Passport!'
+                                                : 'Badge sent!'}
+                                        </h1>
+                                        <p className="text-base text-grayscale-600">
+                                            {recipientMode === 'self'
+                                                ? "You'll find it in your badges."
+                                                : `Sent to ${summarizeRecipients(recipients)}`}
+                                        </p>
                                     </div>
-                                )}
 
-                                <div className="animate-fade-in-up">
-                                    <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
-                                        {recipientMode === 'self'
-                                            ? 'Added to your Passport!'
-                                            : 'Badge sent!'}
-                                    </h1>
-                                    <p className="text-base text-grayscale-600">
-                                        {recipientMode === 'self'
-                                            ? "You'll find it in your badges."
-                                            : `Sent to ${formatRecipients(recipients)}`}
-                                    </p>
-                                </div>
-
-                                <div className="w-full max-w-sm mx-auto space-y-3">
-                                    <button
-                                        type="button"
-                                        onClick={handleBoostAnother}
-                                        className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
-                                    >
-                                        Boost Another
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() =>
-                                            history.push(
-                                                recipientMode === 'self'
-                                                    ? '/socialBadges'
-                                                    : '/wallet'
-                                            )
-                                        }
-                                        className="w-full py-3.5 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-base hover:bg-white transition-colors"
-                                    >
-                                        Done
-                                    </button>
+                                    <div className="w-full max-w-sm mx-auto space-y-3">
+                                        <button
+                                            type="button"
+                                            onClick={handleBoostAnother}
+                                            className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
+                                        >
+                                            Boost Another
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                history.push(
+                                                    recipientMode === 'self'
+                                                        ? '/socialBadges'
+                                                        : '/wallet'
+                                                )
+                                            }
+                                            className="w-full py-3.5 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-base hover:bg-white transition-colors"
+                                        >
+                                            Done
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         )}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -322,10 +322,10 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'celebrate' && (
-                            <div className="max-w-xl mx-auto w-full flex flex-col h-full text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] overflow-y-auto scrollbar-hide">
+                            <div className="max-w-xl mx-auto w-full flex flex-col h-full justify-center text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] overflow-y-auto scrollbar-hide">
                                 <Confetti />
 
-                                <div className="flex-1 min-h-0 flex flex-col items-center justify-center w-full py-6 space-y-8">
+                                <div className="flex flex-col items-center justify-center w-full py-6 space-y-8">
                                     <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto">
                                         {selectedBadge && (
                                             <div className="w-[160px] sm:w-[200px] mb-6">
@@ -409,7 +409,7 @@ const BoostAFriendPage: React.FC = () => {
                                     </div>
                                 </div>
 
-                                <div className="w-full max-w-sm mx-auto space-y-3 shrink-0 pt-6">
+                                <div className="w-full max-w-sm mx-auto space-y-3 shrink-0 pt-12">
                                     <button
                                         type="button"
                                         onClick={handleBoostAnother}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { useHistory } from 'react-router';
 import { IonPage, IonContent } from '@ionic/react';
-import { ArrowLeft, CheckCircle2, Copy, Share, Loader2 } from 'lucide-react';
+import { ArrowLeft, Copy, Check, Share, Download, Loader2 } from 'lucide-react';
+import { QRCodeSVG, QRCodeCanvas } from 'qrcode.react';
 import {
     useWallet,
     useGetCurrentLCNUser,
@@ -66,6 +67,8 @@ const BoostAFriendPage: React.FC = () => {
     const [isIssuing, setIsIssuing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [claimLink, setClaimLink] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+    const qrCanvasRef = useRef<HTMLCanvasElement>(null);
 
     const handleSelectBadge = (badge: BadgePreset, color: string) => {
         const {
@@ -162,6 +165,8 @@ const BoostAFriendPage: React.FC = () => {
         if (!claimLink) return;
         try {
             await navigator.clipboard.writeText(claimLink);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
             presentToast('Link copied to clipboard', {
                 type: ToastTypeEnum.Success,
                 hasDismissButton: true,
@@ -187,6 +192,27 @@ const BoostAFriendPage: React.FC = () => {
         }
     };
 
+    const handleDownloadQR = () => {
+        if (!qrCanvasRef.current) return;
+        try {
+            const dataUrl = qrCanvasRef.current.toDataURL('image/png');
+            const link = document.createElement('a');
+            link.download = 'badge-qr.png';
+            link.href = dataUrl;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        } catch {
+            presentToast('Failed to download QR code.', {
+                type: ToastTypeEnum.Error,
+                hasDismissButton: true,
+            });
+        }
+    };
+
+    const truncateLink = (link: string) =>
+        link.length <= 44 ? link : `${link.slice(0, 28)}…${link.slice(-10)}`;
+
     const handleBoostAnother = () => {
         setSelectedBadge(null);
         setTitle('');
@@ -199,6 +225,43 @@ const BoostAFriendPage: React.FC = () => {
         setError(null);
         setStep('pick');
     };
+
+    const celebrateCredential = useMemo(() => {
+        if (!selectedBadge) return null;
+        return buildPreviewCredential({
+            title: title.trim() || 'Your Badge',
+            subtype: subtype.trim() || title.trim() || 'Your Badge',
+            description,
+            note: note.trim() || criteria,
+            vibeColor,
+            imageUrl: resolveBadgeStyle(selectedBadge, stylePacks).imageUrl || categoryFallback,
+            issuerName: currentLCNUser?.displayName || currentLCNUser?.profileId || '',
+        });
+    }, [
+        selectedBadge,
+        title,
+        subtype,
+        description,
+        note,
+        criteria,
+        vibeColor,
+        stylePacks,
+        categoryFallback,
+        currentLCNUser,
+    ]);
+
+    const celebrateCard = celebrateCredential && (
+        <BoostEarnedCard
+            credential={celebrateCredential as any}
+            categoryType={BoostCategoryOptionsEnum.socialBadge}
+            boostPageViewMode={BoostPageViewMode.Card}
+            useWrapper={false}
+            verifierState={false}
+            hideOptionsMenu
+            isPreview
+            className="shadow-xl"
+        />
+    );
 
     return (
         <IonPage className="bg-white">
@@ -321,95 +384,132 @@ const BoostAFriendPage: React.FC = () => {
                             </div>
                         )}
 
-                        {step === 'celebrate' && (
-                            <div className="max-w-xl mx-auto w-full flex flex-col h-full justify-center text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] overflow-y-auto scrollbar-hide">
+                        {step === 'celebrate' && claimLink && (
+                            <div className="relative w-full max-w-[860px] mx-auto my-auto animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] desktop:grid desktop:grid-cols-2 desktop:gap-10 desktop:items-center">
                                 <Confetti />
 
-                                <div className="flex flex-col items-center justify-center w-full py-6 space-y-8">
-                                    <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto">
-                                        {selectedBadge && (
-                                            <div className="w-[160px] sm:w-[200px] mb-6">
-                                                <BoostEarnedCard
-                                                    credential={
-                                                        buildPreviewCredential({
-                                                            title: title.trim() || 'Your Badge',
-                                                            subtype:
-                                                                subtype.trim() ||
-                                                                title.trim() ||
-                                                                'Your Badge',
-                                                            description,
-                                                            note: note.trim() || criteria,
-                                                            vibeColor,
-                                                            imageUrl:
-                                                                resolveBadgeStyle(
-                                                                    selectedBadge,
-                                                                    stylePacks
-                                                                ).imageUrl || categoryFallback,
-                                                            issuerName:
-                                                                currentLCNUser?.displayName ||
-                                                                currentLCNUser?.profileId ||
-                                                                '',
-                                                        }) as any
-                                                    }
-                                                    categoryType={
-                                                        BoostCategoryOptionsEnum.socialBadge
-                                                    }
-                                                    boostPageViewMode={BoostPageViewMode.Card}
-                                                    useWrapper={false}
-                                                    verifierState={false}
-                                                    hideOptionsMenu
-                                                    isPreview
-                                                    className="shadow-xl"
-                                                />
+                                <div className="text-center space-y-6 mb-8 desktop:mb-0">
+                                    {celebrateCard && (
+                                        <div className="flex justify-center">
+                                            <div className="w-[160px] sm:w-[200px]">
+                                                {celebrateCard}
                                             </div>
-                                        )}
-
-                                        <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
-                                            {recipientMode === 'link'
-                                                ? 'Link ready!'
-                                                : recipientMode === 'self'
-                                                ? 'Added to your Passport!'
-                                                : 'Badge sent!'}
+                                        </div>
+                                    )}
+                                    <div className="animate-fade-in-up">
+                                        <h1 className="text-xl font-semibold text-grayscale-900 mb-1">
+                                            Link ready!
                                         </h1>
-                                        <p className="text-base text-grayscale-600 mb-10">
-                                            {recipientMode === 'link'
-                                                ? 'Your badge is ready to be shared. Anyone with the link can claim it.'
-                                                : recipientMode === 'self'
-                                                ? "You'll find it in your badges."
-                                                : `Sent to ${formatRecipients(recipients)}`}
+                                        <p className="text-sm text-grayscale-600 leading-relaxed">
+                                            Anyone with this link or QR code can claim it.
                                         </p>
-
-                                        {claimLink && (
-                                            <div className="w-full mb-10 space-y-3">
-                                                <div className="p-4 bg-white/80 backdrop-blur-sm rounded-2xl break-all text-sm text-grayscale-900 border border-grayscale-200 shadow-sm">
-                                                    {claimLink}
-                                                </div>
-                                                <div className="flex gap-3">
-                                                    <button
-                                                        type="button"
-                                                        onClick={handleCopyLink}
-                                                        className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-sm hover:bg-white transition-colors"
-                                                    >
-                                                        <Copy className="w-4 h-4" />
-                                                        Copy
-                                                    </button>
-                                                    {navigator.share && (
-                                                        <button
-                                                            type="button"
-                                                            onClick={handleShareLink}
-                                                            className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity shadow-sm"
-                                                        >
-                                                            <Share className="w-4 h-4" />
-                                                            Share
-                                                        </button>
-                                                    )}
-                                                </div>
-                                            </div>
-                                        )}
                                     </div>
                                 </div>
 
-                                <div className="w-full max-w-sm mx-auto space-y-3 shrink-0 pt-12">
+                                <div className="animate-fade-in-up space-y-6 text-center max-w-[420px] mx-auto w-full">
+                                    <div className="bg-white p-6 rounded-[20px] shadow-sm border border-grayscale-200 flex flex-col items-center gap-4">
+                                        <div className="w-48 h-48 relative">
+                                            <QRCodeSVG
+                                                className="w-full h-full"
+                                                value={claimLink}
+                                                bgColor="transparent"
+                                            />
+                                            <div className="hidden">
+                                                <QRCodeCanvas
+                                                    value={claimLink}
+                                                    size={1024}
+                                                    bgColor="#ffffff"
+                                                    fgColor="#000000"
+                                                    level="H"
+                                                    includeMargin={true}
+                                                    ref={qrCanvasRef}
+                                                />
+                                            </div>
+                                        </div>
+
+                                        <div className="w-full bg-grayscale-10 p-3 rounded-xl border border-grayscale-200 text-center">
+                                            <p
+                                                className="text-xs text-grayscale-600 font-mono truncate"
+                                                title={claimLink}
+                                            >
+                                                {truncateLink(claimLink)}
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <div className="space-y-3">
+                                        <button
+                                            type="button"
+                                            onClick={handleCopyLink}
+                                            className="w-full py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                                        >
+                                            {copied ? (
+                                                <Check className="w-4 h-4 text-emerald-500" />
+                                            ) : (
+                                                <Copy className="w-4 h-4" />
+                                            )}
+                                            {copied ? 'Copied' : 'Copy link'}
+                                        </button>
+                                        <div className="flex gap-3">
+                                            {typeof navigator !== 'undefined' &&
+                                                navigator.share && (
+                                                    <button
+                                                        type="button"
+                                                        onClick={handleShareLink}
+                                                        className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                                    >
+                                                        <Share className="w-4 h-4" />
+                                                        Share
+                                                    </button>
+                                                )}
+                                            <button
+                                                type="button"
+                                                onClick={handleDownloadQR}
+                                                className="flex-1 py-3 px-4 rounded-[20px] border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2"
+                                            >
+                                                <Download className="w-4 h-4" />
+                                                Download QR
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <button
+                                        type="button"
+                                        onClick={handleBoostAnother}
+                                        className="w-full text-sm text-grayscale-600 hover:text-grayscale-900 transition-colors"
+                                    >
+                                        Boost Another
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+
+                        {step === 'celebrate' && !claimLink && (
+                            <div className="relative w-full max-w-[420px] mx-auto my-auto text-center space-y-6 animate-pop-in py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)]">
+                                <Confetti />
+
+                                {celebrateCard && (
+                                    <div className="flex justify-center">
+                                        <div className="w-[160px] sm:w-[200px]">
+                                            {celebrateCard}
+                                        </div>
+                                    </div>
+                                )}
+
+                                <div className="animate-fade-in-up">
+                                    <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
+                                        {recipientMode === 'self'
+                                            ? 'Added to your Passport!'
+                                            : 'Badge sent!'}
+                                    </h1>
+                                    <p className="text-base text-grayscale-600">
+                                        {recipientMode === 'self'
+                                            ? "You'll find it in your badges."
+                                            : `Sent to ${formatRecipients(recipients)}`}
+                                    </p>
+                                </div>
+
+                                <div className="w-full max-w-sm mx-auto space-y-3">
                                     <button
                                         type="button"
                                         onClick={handleBoostAnother}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -56,6 +56,8 @@ const BoostAFriendPage: React.FC = () => {
     const [subtype, setSubtype] = useState('');
     const [vibeColor, setVibeColor] = useState<string>('#3B82F6');
     const [note, setNote] = useState('');
+    const [criteria, setCriteria] = useState('');
+    const [description, setDescription] = useState('');
 
     const [recipientMode, setRecipientMode] = useState<RecipientMode>('people');
     const [recipients, setRecipients] = useState<Recipient[]>([]);
@@ -66,11 +68,18 @@ const BoostAFriendPage: React.FC = () => {
     const [claimLink, setClaimLink] = useState<string | null>(null);
 
     const handleSelectBadge = (badge: BadgePreset, color: string) => {
-        const { backgroundColor } = resolveBadgeStyle(badge, stylePacks);
+        const {
+            backgroundColor,
+            description: presetDescription,
+            criteria: presetCriteria,
+        } = resolveBadgeStyle(badge, stylePacks);
         setSelectedBadge(badge);
         setTitle(badge.title);
         setSubtype(badge.title);
         setVibeColor(backgroundColor || color);
+        setDescription(presetDescription ?? '');
+        setNote('');
+        setCriteria(presetCriteria ?? '');
         setStep('personalize');
     };
 
@@ -123,8 +132,8 @@ const BoostAFriendPage: React.FC = () => {
             const template = buildBoostFriendTemplate({
                 title: title.trim(),
                 subtype: subtype.trim(),
-                description: `A social badge for being a ${title.trim()}`,
-                note,
+                description: description.trim() || `A social badge for being a ${title.trim()}`,
+                note: note.trim() || criteria,
                 vibeColor,
                 imageUrl: imageUrl || categoryFallback,
             });
@@ -183,6 +192,8 @@ const BoostAFriendPage: React.FC = () => {
         setTitle('');
         setSubtype('');
         setNote('');
+        setCriteria('');
+        setDescription('');
         setRecipients([]);
         setClaimLink(null);
         setError(null);
@@ -223,7 +234,9 @@ const BoostAFriendPage: React.FC = () => {
                                     isCustom={selectedBadge?.type === 'ext:Custom'}
                                     vibeColor={vibeColor}
                                     onVibeColorChange={setVibeColor}
+                                    description={description}
                                     note={note}
+                                    notePlaceholder={criteria}
                                     onNoteChange={setNote}
                                     onNext={() => setStep('send')}
                                     onBack={() => setStep('pick')}
@@ -324,7 +337,8 @@ const BoostAFriendPage: React.FC = () => {
                                                                 subtype.trim() ||
                                                                 title.trim() ||
                                                                 'Your Badge',
-                                                            note,
+                                                            description,
+                                                            note: note.trim() || criteria,
                                                             vibeColor,
                                                             imageUrl:
                                                                 resolveBadgeStyle(
@@ -405,7 +419,13 @@ const BoostAFriendPage: React.FC = () => {
                                     </button>
                                     <button
                                         type="button"
-                                        onClick={() => history.push('/wallet')}
+                                        onClick={() =>
+                                            history.push(
+                                                recipientMode === 'self'
+                                                    ? '/socialBadges'
+                                                    : '/wallet'
+                                            )
+                                        }
                                         className="w-full py-3.5 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-base hover:bg-white transition-colors"
                                     >
                                         Done

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -14,7 +14,7 @@ import { WalletCategoryTypes } from 'learn-card-base/components/IssueVC/types';
 
 import { BadgePicker } from './components/BadgePicker';
 import { BadgePersonalize } from './components/BadgePersonalize';
-import { RecipientPicker } from '../issue/components/RecipientPicker';
+import { BoostRecipientPicker } from './components/BoostRecipientPicker';
 import { Confetti } from '../issue/components/Confetti';
 import { RecipientMode, Recipient, LinkOptions } from '../issue/components/recipientTypes';
 import { issueViaBoost } from '../../components/simple-send/simpleSend.helpers';
@@ -37,6 +37,8 @@ const BoostAFriendPage: React.FC = () => {
 
     const [step, setStep] = useState<Step>('pick');
     const [selectedBadge, setSelectedBadge] = useState<BadgePreset | null>(null);
+    const [title, setTitle] = useState('');
+    const [subtype, setSubtype] = useState('');
     const [vibeColor, setVibeColor] = useState<string>('#3B82F6');
     const [note, setNote] = useState('');
 
@@ -51,6 +53,8 @@ const BoostAFriendPage: React.FC = () => {
     const handleSelectBadge = (badge: BadgePreset, color: string) => {
         const { backgroundColor } = resolveBadgeStyle(badge, stylePacks);
         setSelectedBadge(badge);
+        setTitle(badge.title);
+        setSubtype(badge.title);
         setVibeColor(backgroundColor || color);
         setStep('personalize');
     };
@@ -102,8 +106,9 @@ const BoostAFriendPage: React.FC = () => {
             const { imageUrl } = resolveBadgeStyle(selectedBadge, stylePacks);
 
             const template = buildBoostFriendTemplate({
-                title: selectedBadge.title,
-                description: `A social badge for being a ${selectedBadge.title}`,
+                title: title.trim(),
+                subtype: subtype.trim(),
+                description: `A social badge for being a ${title.trim()}`,
                 note,
                 vibeColor,
                 imageUrl: imageUrl || categoryFallback,
@@ -160,6 +165,8 @@ const BoostAFriendPage: React.FC = () => {
 
     const handleBoostAnother = () => {
         setSelectedBadge(null);
+        setTitle('');
+        setSubtype('');
         setNote('');
         setRecipients([]);
         setClaimLink(null);
@@ -198,6 +205,11 @@ const BoostAFriendPage: React.FC = () => {
                             <div className="max-w-xl mx-auto w-full h-full">
                                 <BadgePersonalize
                                     badge={selectedBadge}
+                                    title={title}
+                                    onTitleChange={setTitle}
+                                    subtype={subtype}
+                                    onSubtypeChange={setSubtype}
+                                    isCustom={selectedBadge?.type === 'ext:Custom'}
                                     vibeColor={vibeColor}
                                     onVibeColorChange={setVibeColor}
                                     note={note}
@@ -205,6 +217,11 @@ const BoostAFriendPage: React.FC = () => {
                                     onNext={() => setStep('send')}
                                     onBack={() => setStep('pick')}
                                     stylePacks={stylePacks}
+                                    issuerName={
+                                        currentLCNUser?.displayName ||
+                                        currentLCNUser?.profileId ||
+                                        ''
+                                    }
                                 />
                             </div>
                         )}
@@ -230,20 +247,19 @@ const BoostAFriendPage: React.FC = () => {
                                     </div>
                                 </div>
 
-                                <div className="flex-1 overflow-y-auto pb-20 flex flex-col justify-center">
-                                    <div className="max-w-sm mx-auto w-full">
-                                        <RecipientPicker
+                                <div className="flex-1 min-h-0 flex flex-col pb-20">
+                                    <div className="max-w-sm mx-auto w-full flex-1 flex flex-col min-h-0">
+                                        <BoostRecipientPicker
                                             mode={recipientMode}
                                             onModeChange={setRecipientMode}
                                             recipients={recipients}
                                             onRecipientsChange={setRecipients}
                                             linkOptions={linkOptions}
                                             onLinkOptionsChange={setLinkOptions}
-                                            hideHeader
                                         />
 
                                         {error && (
-                                            <div className="mt-6 p-3 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-2.5 animate-fade-in-up shadow-sm">
+                                            <div className="mt-6 p-3 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-2.5 animate-fade-in-up shadow-sm shrink-0">
                                                 <span className="text-sm text-red-700 leading-relaxed">
                                                     {error}
                                                 </span>
@@ -271,6 +287,8 @@ const BoostAFriendPage: React.FC = () => {
                                             </>
                                         ) : recipientMode === 'link' ? (
                                             'Create Link'
+                                        ) : recipientMode === 'self' ? (
+                                            'Boost Myself'
                                         ) : (
                                             'Send Badge'
                                         )}
@@ -280,53 +298,57 @@ const BoostAFriendPage: React.FC = () => {
                         )}
 
                         {step === 'celebrate' && (
-                            <div className="max-w-xl mx-auto w-full flex flex-col h-full items-center justify-center text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)]">
+                            <div className="max-w-xl mx-auto w-full flex flex-col h-full text-center animate-pop-in relative py-10 pt-[calc(env(safe-area-inset-top)+2.5rem)] overflow-y-auto scrollbar-hide">
                                 <Confetti />
 
-                                <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto flex-1">
-                                    <div className="w-20 h-20 bg-emerald-50 rounded-full flex items-center justify-center mb-6 shadow-sm">
-                                        <CheckCircle2 className="w-10 h-10 text-emerald-500" />
-                                    </div>
+                                <div className="my-auto w-full py-6 space-y-8">
+                                    <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto">
+                                        <div className="w-20 h-20 bg-emerald-50 rounded-full flex items-center justify-center mb-6 shadow-sm">
+                                            <CheckCircle2 className="w-10 h-10 text-emerald-500" />
+                                        </div>
 
-                                    <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
-                                        {recipientMode === 'link' ? 'Link Created!' : 'Badge Sent!'}
-                                    </h1>
-                                    <p className="text-base text-grayscale-600 mb-10">
-                                        {recipientMode === 'link'
-                                            ? 'Your badge is ready to be shared. Anyone with the link can claim it.'
-                                            : "They'll be notified about their new badge."}
-                                    </p>
+                                        <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
+                                            {recipientMode === 'link'
+                                                ? 'Link Created!'
+                                                : 'Badge Sent!'}
+                                        </h1>
+                                        <p className="text-base text-grayscale-600 mb-10">
+                                            {recipientMode === 'link'
+                                                ? 'Your badge is ready to be shared. Anyone with the link can claim it.'
+                                                : "They'll be notified about their new badge."}
+                                        </p>
 
-                                    {claimLink && (
-                                        <div className="w-full mb-10 space-y-3">
-                                            <div className="p-4 bg-white/80 backdrop-blur-sm rounded-2xl break-all text-sm text-grayscale-900 border border-grayscale-200 shadow-sm">
-                                                {claimLink}
-                                            </div>
-                                            <div className="flex gap-3">
-                                                <button
-                                                    type="button"
-                                                    onClick={handleCopyLink}
-                                                    className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-sm hover:bg-white transition-colors"
-                                                >
-                                                    <Copy className="w-4 h-4" />
-                                                    Copy
-                                                </button>
-                                                {navigator.share && (
+                                        {claimLink && (
+                                            <div className="w-full mb-10 space-y-3">
+                                                <div className="p-4 bg-white/80 backdrop-blur-sm rounded-2xl break-all text-sm text-grayscale-900 border border-grayscale-200 shadow-sm">
+                                                    {claimLink}
+                                                </div>
+                                                <div className="flex gap-3">
                                                     <button
                                                         type="button"
-                                                        onClick={handleShareLink}
-                                                        className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity shadow-sm"
+                                                        onClick={handleCopyLink}
+                                                        className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] border border-grayscale-300 bg-white/50 backdrop-blur-sm text-grayscale-700 font-medium text-sm hover:bg-white transition-colors"
                                                     >
-                                                        <Share className="w-4 h-4" />
-                                                        Share
+                                                        <Copy className="w-4 h-4" />
+                                                        Copy
                                                     </button>
-                                                )}
+                                                    {navigator.share && (
+                                                        <button
+                                                            type="button"
+                                                            onClick={handleShareLink}
+                                                            className="flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity shadow-sm"
+                                                        >
+                                                            <Share className="w-4 h-4" />
+                                                            Share
+                                                        </button>
+                                                    )}
+                                                </div>
                                             </div>
-                                        </div>
-                                    )}
+                                        )}
+                                    </div>
                                 </div>
 
-                                <div className="w-full max-w-sm space-y-3 mt-auto pt-6">
+                                <div className="w-full max-w-sm mx-auto space-y-3 mt-auto pt-6">
                                     <button
                                         type="button"
                                         onClick={handleBoostAnother}

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -18,11 +18,26 @@ import { BoostRecipientPicker } from './components/BoostRecipientPicker';
 import { Confetti } from '../issue/components/Confetti';
 import { RecipientMode, Recipient, LinkOptions } from '../issue/components/recipientTypes';
 import { issueViaBoost } from '../../components/simple-send/simpleSend.helpers';
-import { buildBoostFriendTemplate, BadgePreset, resolveBadgeStyle } from './boostAFriend.helpers';
+import {
+    buildBoostFriendTemplate,
+    BadgePreset,
+    resolveBadgeStyle,
+    buildPreviewCredential,
+} from './boostAFriend.helpers';
 import { useStylePackRegistry } from '../../registries/useStylePackRegistry';
 import { useBadgeGroups } from '../../registries/useBadgeGroups';
+import BoostEarnedCard from '../../components/boost/boost-earned-card/BoostEarnedCard';
+import { BoostCategoryOptionsEnum, BoostPageViewMode } from 'learn-card-base';
 
 type Step = 'pick' | 'personalize' | 'send' | 'celebrate';
+
+const formatRecipients = (recs: Recipient[]) => {
+    if (recs.length === 0) return '';
+    const names = recs.map(r => (r.kind === 'profile' ? r.displayName : r.email));
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return `${names[0]} and ${names[1]}`;
+    return `${names[0]}, ${names[1]} +${names.length - 2}`;
+};
 
 const BoostAFriendPage: React.FC = () => {
     const history = useHistory();
@@ -180,13 +195,9 @@ const BoostAFriendPage: React.FC = () => {
                 <div className="h-full font-poppins relative">
                     <div className="absolute inset-0 pointer-events-none overflow-hidden">
                         <div
-                            className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-25"
+                            className="absolute inset-0 transition-colors duration-700 ease-in-out opacity-[0.16]"
                             style={{
-                                background: `
-                                    radial-gradient(circle at 50% 0%, ${vibeColor} 0%, transparent 60%),
-                                    radial-gradient(circle at 100% 100%, #10B981 0%, transparent 50%),
-                                    radial-gradient(circle at 0% 100%, #94A3B8 0%, transparent 50%)
-                                `,
+                                background: `radial-gradient(120% 60% at 50% 0%, ${vibeColor} 0%, transparent 60%)`,
                             }}
                         />
                     </div>
@@ -303,19 +314,55 @@ const BoostAFriendPage: React.FC = () => {
 
                                 <div className="my-auto w-full py-6 space-y-8">
                                     <div className="flex flex-col items-center justify-center max-w-sm w-full mx-auto">
-                                        <div className="w-20 h-20 bg-emerald-50 rounded-full flex items-center justify-center mb-6 shadow-sm">
-                                            <CheckCircle2 className="w-10 h-10 text-emerald-500" />
-                                        </div>
+                                        {selectedBadge && (
+                                            <div className="w-[160px] sm:w-[200px] mb-6">
+                                                <BoostEarnedCard
+                                                    credential={
+                                                        buildPreviewCredential({
+                                                            title: title.trim() || 'Your Badge',
+                                                            subtype:
+                                                                subtype.trim() ||
+                                                                title.trim() ||
+                                                                'Your Badge',
+                                                            note,
+                                                            vibeColor,
+                                                            imageUrl:
+                                                                resolveBadgeStyle(
+                                                                    selectedBadge,
+                                                                    stylePacks
+                                                                ).imageUrl || categoryFallback,
+                                                            issuerName:
+                                                                currentLCNUser?.displayName ||
+                                                                currentLCNUser?.profileId ||
+                                                                '',
+                                                        }) as any
+                                                    }
+                                                    categoryType={
+                                                        BoostCategoryOptionsEnum.socialBadge
+                                                    }
+                                                    boostPageViewMode={BoostPageViewMode.Card}
+                                                    useWrapper={false}
+                                                    verifierState={false}
+                                                    hideOptionsMenu
+                                                    isPreview
+                                                    className="shadow-xl"
+                                                />
+                                            </div>
+                                        )}
 
                                         <h1 className="text-3xl font-semibold text-grayscale-900 mb-2">
                                             {recipientMode === 'link'
-                                                ? 'Link Created!'
-                                                : 'Badge Sent!'}
+                                                ? 'Link ready!'
+                                                : recipientMode === 'self'
+                                                ? 'Added to your Passport!'
+                                                : 'Badge sent!'}
                                         </h1>
                                         <p className="text-base text-grayscale-600 mb-10">
                                             {recipientMode === 'link'
                                                 ? 'Your badge is ready to be shared. Anyone with the link can claim it.'
-                                                : "They'll be notified about their new badge."}
+                                                : recipientMode === 'self'
+                                                ? "You'll find it in your badges."
+                                                : `Sent to ${formatRecipients(recipients)}`}
                                         </p>
 
                                         {claimLink && (

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -9,8 +9,6 @@ import { templateToJson } from '../appStoreDeveloper/partner-onboarding/componen
 import { buildLcTags } from 'learn-card-base/helpers/displayTags.helpers';
 import { deriveAccentColor } from 'learn-card-base/helpers/colorHelpers';
 import { DisplayTypeEnum } from 'learn-card-base/helpers/display-types';
-import { CATEGORY_TO_SUBCATEGORY_LIST } from '../../components/boost/boost-options/boostOptions';
-import { BoostCategoryOptionsEnum } from 'learn-card-base';
 import { LCAStylesPackRegistryEntry } from 'learn-card-base';
 
 export interface BoostFriendInput {
@@ -26,6 +24,7 @@ export interface BoostFriendInput {
 export const buildPreviewCredential = (input: {
     title: string;
     subtype?: string;
+    description?: string;
     note?: string;
     vibeColor?: string;
     imageUrl?: string;
@@ -34,7 +33,7 @@ export const buildPreviewCredential = (input: {
     const template = buildBoostFriendTemplate({
         title: input.title,
         subtype: input.subtype,
-        description: `A social badge for being a ${input.title}`,
+        description: input.description?.trim() || `A social badge for being a ${input.title}`,
         note: input.note,
         vibeColor: input.vibeColor,
         imageUrl: input.imageUrl,
@@ -90,20 +89,58 @@ export const buildBoostFriendTemplate = (input: BoostFriendInput): OBv3Credentia
 export interface BadgePreset {
     title: string;
     type: string;
+    category?: string;
 }
 
-export const getSocialBadgePresets = (): BadgePreset[] => {
-    const list = CATEGORY_TO_SUBCATEGORY_LIST[BoostCategoryOptionsEnum.socialBadge] || [];
-    return list.map(item => ({ title: item.title, type: item.type }));
+export const PICKER_BADGE_CATEGORIES = ['Social Badge', 'Standards Badge'];
+
+export const humanizeBadgeType = (type: string): string =>
+    type
+        .replace(/^ext:/, '')
+        // split camelCase/PascalCase and acronym boundaries: "CLRCartographer" -> "CLR Cartographer"
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .replace(/[_-]+/g, ' ')
+        .trim();
+
+export const getStylePackPresets = (
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined
+): BadgePreset[] => {
+    if (!stylePacks) return [];
+
+    const seen = new Set<string>();
+    const presets: BadgePreset[] = [];
+
+    for (const entry of stylePacks) {
+        if (!entry?.type || !PICKER_BADGE_CATEGORIES.includes(entry.category)) continue;
+        const key = `${entry.category}::${entry.type}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        presets.push({
+            title: entry.title?.trim() || humanizeBadgeType(entry.type),
+            type: entry.type,
+            category: entry.category,
+        });
+    }
+
+    return presets;
 };
 
 export const resolveBadgeStyle = (
     preset: BadgePreset,
     stylePacks: LCAStylesPackRegistryEntry[] | undefined
-): { imageUrl: string; backgroundColor?: string } => {
-    const entry = stylePacks?.find(e => e.category === 'Social Badge' && e.type === preset.type);
+): { imageUrl: string; backgroundColor?: string; description?: string; criteria?: string } => {
+    const entry =
+        stylePacks?.find(
+            e => (!preset.category || e.category === preset.category) && e.type === preset.type
+        ) ?? stylePacks?.find(e => e.type === preset.type);
     const imageUrl = entry?.url && entry.url.trim() ? entry.url : '';
-    return { imageUrl, backgroundColor: entry?.backgroundColor };
+    return {
+        imageUrl,
+        backgroundColor: entry?.backgroundColor,
+        description: entry?.description,
+        criteria: entry?.criteria,
+    };
 };
 
 export const VIBE_COLORS = [

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -10,7 +10,6 @@ import { DisplayTypeEnum } from 'learn-card-base/helpers/display-types';
 import { CATEGORY_TO_SUBCATEGORY_LIST } from '../../components/boost/boost-options/boostOptions';
 import { BoostCategoryOptionsEnum } from 'learn-card-base';
 import { LCAStylesPackRegistryEntry } from 'learn-card-base';
-import { getDefaultAchievementTypeImage } from '../../components/boost/boostHelpers';
 
 export interface BoostFriendInput {
     title: string;
@@ -67,20 +66,11 @@ export const getSocialBadgePresets = (): BadgePreset[] => {
 
 export const resolveBadgeStyle = (
     preset: BadgePreset,
-    stylePacks: LCAStylesPackRegistryEntry[] | undefined,
-    categoryFallbackImage: string
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined
 ): { imageUrl: string; backgroundColor?: string } => {
-    const imageUrl =
-        getDefaultAchievementTypeImage(
-            'Social Badge',
-            preset.type,
-            categoryFallbackImage,
-            stylePacks
-        ) || categoryFallbackImage;
-    const backgroundColor = stylePacks?.find(
-        e => e.category === 'Social Badge' && e.type === preset.type
-    )?.backgroundColor;
-    return { imageUrl, backgroundColor };
+    const entry = stylePacks?.find(e => e.category === 'Social Badge' && e.type === preset.type);
+    const imageUrl = entry?.url && entry.url.trim() ? entry.url : '';
+    return { imageUrl, backgroundColor: entry?.backgroundColor };
 };
 
 export const VIBE_COLORS = [

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -6,6 +6,7 @@ import {
     DEFAULT_TYPES,
 } from '../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/types';
 import { buildLcTags } from 'learn-card-base/helpers/displayTags.helpers';
+import { deriveAccentColor } from 'learn-card-base/helpers/colorHelpers';
 import { DisplayTypeEnum } from 'learn-card-base/helpers/display-types';
 import { CATEGORY_TO_SUBCATEGORY_LIST } from '../../components/boost/boost-options/boostOptions';
 import { BoostCategoryOptionsEnum } from 'learn-card-base';
@@ -13,6 +14,7 @@ import { LCAStylesPackRegistryEntry } from 'learn-card-base';
 
 export interface BoostFriendInput {
     title: string;
+    subtype?: string;
     description: string;
     note?: string;
     issuerName?: string;
@@ -22,9 +24,10 @@ export interface BoostFriendInput {
 
 export const buildBoostFriendTemplate = (input: BoostFriendInput): OBv3CredentialTemplate => {
     const tags = buildLcTags({
-        subtype: input.title,
+        subtype: input.subtype?.trim() || input.title,
         displayType: DisplayTypeEnum.Badge,
         backgroundColor: input.vibeColor,
+        accentColor: deriveAccentColor(input.vibeColor),
     });
 
     return {

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -1,0 +1,95 @@
+import {
+    OBv3CredentialTemplate,
+    staticField,
+    systemField,
+    DEFAULT_CONTEXTS,
+    DEFAULT_TYPES,
+} from '../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/types';
+import { buildLcTags } from 'learn-card-base/helpers/displayTags.helpers';
+import { DisplayTypeEnum } from 'learn-card-base/helpers/display-types';
+import { CATEGORY_TO_SUBCATEGORY_LIST } from '../../components/boost/boost-options/boostOptions';
+import { BoostCategoryOptionsEnum } from 'learn-card-base';
+import { LCAStylesPackRegistryEntry } from 'learn-card-base';
+import { getDefaultAchievementTypeImage } from '../../components/boost/boostHelpers';
+
+export interface BoostFriendInput {
+    title: string;
+    description: string;
+    note?: string;
+    issuerName?: string;
+    imageUrl?: string;
+    vibeColor?: string;
+}
+
+export const buildBoostFriendTemplate = (input: BoostFriendInput): OBv3CredentialTemplate => {
+    const tags = buildLcTags({
+        subtype: input.title,
+        displayType: DisplayTypeEnum.Badge,
+        backgroundColor: input.vibeColor,
+    });
+
+    return {
+        schemaType: 'obv3',
+        contexts: DEFAULT_CONTEXTS,
+        types: DEFAULT_TYPES,
+        name: staticField(input.title),
+        issuer: {
+            id: systemField('issuer_did'),
+            name: input.issuerName ? staticField(input.issuerName) : staticField(''),
+        },
+        credentialSubject: {
+            id: systemField('recipient_did'),
+            achievement: {
+                name: staticField(input.title),
+                description: staticField(input.description),
+                achievementType: staticField('Badge'),
+                ...(input.imageUrl ? { image: staticField(input.imageUrl) } : {}),
+                ...(tags.length > 0 ? { tag: tags } : {}),
+                criteria: {
+                    narrative: staticField(input.note ?? ''),
+                },
+            },
+        },
+        validFrom: systemField('issue_date'),
+        customFields: [],
+    };
+};
+
+export interface BadgePreset {
+    title: string;
+    type: string;
+}
+
+export const getSocialBadgePresets = (): BadgePreset[] => {
+    const list = CATEGORY_TO_SUBCATEGORY_LIST[BoostCategoryOptionsEnum.socialBadge] || [];
+    return list.map(item => ({ title: item.title, type: item.type }));
+};
+
+export const resolveBadgeStyle = (
+    preset: BadgePreset,
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined,
+    categoryFallbackImage: string
+): { imageUrl: string; backgroundColor?: string } => {
+    const imageUrl =
+        getDefaultAchievementTypeImage(
+            'Social Badge',
+            preset.type,
+            categoryFallbackImage,
+            stylePacks
+        ) || categoryFallbackImage;
+    const backgroundColor = stylePacks?.find(
+        e => e.category === 'Social Badge' && e.type === preset.type
+    )?.backgroundColor;
+    return { imageUrl, backgroundColor };
+};
+
+export const VIBE_COLORS = [
+    '#3B82F6',
+    '#10B981',
+    '#F59E0B',
+    '#EF4444',
+    '#8B5CF6',
+    '#EC4899',
+    '#14B8A6',
+    '#F97316',
+];

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -5,6 +5,7 @@ import {
     DEFAULT_CONTEXTS,
     DEFAULT_TYPES,
 } from '../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/types';
+import { templateToJson } from '../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/utils';
 import { buildLcTags } from 'learn-card-base/helpers/displayTags.helpers';
 import { deriveAccentColor } from 'learn-card-base/helpers/colorHelpers';
 import { DisplayTypeEnum } from 'learn-card-base/helpers/display-types';
@@ -21,6 +22,35 @@ export interface BoostFriendInput {
     imageUrl?: string;
     vibeColor?: string;
 }
+
+export const buildPreviewCredential = (input: {
+    title: string;
+    subtype?: string;
+    note?: string;
+    vibeColor?: string;
+    imageUrl?: string;
+    issuerName?: string;
+}): Record<string, unknown> => {
+    const template = buildBoostFriendTemplate({
+        title: input.title,
+        subtype: input.subtype,
+        description: `A social badge for being a ${input.title}`,
+        note: input.note,
+        vibeColor: input.vibeColor,
+        imageUrl: input.imageUrl,
+        issuerName: input.issuerName,
+    });
+    const json = templateToJson(template) as Record<string, any>;
+
+    json.validFrom = new Date().toISOString();
+    if (json.issuer) {
+        json.issuer.id = 'did:key:preview';
+    }
+    if (json.credentialSubject) {
+        delete json.credentialSubject.id;
+    }
+    return json;
+};
 
 export const buildBoostFriendTemplate = (input: BoostFriendInput): OBv3CredentialTemplate => {
     const tags = buildLcTags({

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -30,7 +30,7 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     const isRealImage = Boolean(imageUrl) && !imgError;
 
     return (
-        <div className="flex flex-col h-full animate-fade-in-up">
+        <div className="flex flex-col h-full animate-fade-in-up pt-[calc(env(safe-area-inset-top)+1rem)]">
             <div className="flex items-center gap-3 mb-6">
                 <button
                     type="button"

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -171,7 +171,7 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                 </div>
             </div>
 
-            <div className="pt-4 mt-auto">
+            <div className="pt-4 mt-auto pb-[env(safe-area-inset-bottom,0px)]">
                 <button
                     type="button"
                     onClick={onNext}

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ImagePlus, Loader2, X } from 'lucide-react';
 import {
     BadgePreset,
     VIBE_COLORS,
@@ -10,6 +10,7 @@ import {
     LCAStylesPackRegistryEntry,
     BoostCategoryOptionsEnum,
     BoostPageViewMode,
+    useFilestack,
 } from 'learn-card-base';
 import BoostEarnedCard from '../../../components/boost/boost-earned-card/BoostEarnedCard';
 
@@ -26,6 +27,8 @@ interface BadgePersonalizeProps {
     note: string;
     notePlaceholder?: string;
     onNoteChange: (note: string) => void;
+    imageUrl?: string;
+    onImageUrlChange?: (url: string) => void;
     onNext: () => void;
     onBack: () => void;
     stylePacks: LCAStylesPackRegistryEntry[] | undefined;
@@ -45,12 +48,19 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     note,
     notePlaceholder,
     onNoteChange,
+    imageUrl,
+    onImageUrlChange,
     onNext,
     onBack,
     stylePacks,
     issuerName,
 }) => {
-    const { imageUrl } = resolveBadgeStyle(badge, stylePacks);
+    const stylePackImageUrl = resolveBadgeStyle(badge, stylePacks).imageUrl;
+    const effectiveImageUrl = imageUrl?.trim() || stylePackImageUrl;
+
+    const { handleFileSelect, isLoading: isUploadingImage } = useFilestack({
+        onUpload: url => onImageUrlChange?.(url),
+    });
 
     const previewCredential = useMemo(() => {
         const displayTitle = title.trim() || 'Your Badge';
@@ -60,10 +70,19 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
             description,
             note: note.trim() || notePlaceholder,
             vibeColor,
-            imageUrl,
+            imageUrl: effectiveImageUrl,
             issuerName,
         });
-    }, [title, subtype, description, note, notePlaceholder, vibeColor, imageUrl, issuerName]);
+    }, [
+        title,
+        subtype,
+        description,
+        note,
+        notePlaceholder,
+        vibeColor,
+        effectiveImageUrl,
+        issuerName,
+    ]);
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up">
@@ -130,6 +149,62 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                                     placeholder="e.g. Trailblazer"
                                     className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all shadow-sm"
                                 />
+                            </div>
+                        )}
+
+                        {isCustom && (
+                            <div>
+                                <label className="block text-sm font-medium text-grayscale-900 mb-2">
+                                    Badge image (optional)
+                                </label>
+                                <div className="flex items-center gap-3">
+                                    <button
+                                        type="button"
+                                        onClick={() => handleFileSelect()}
+                                        disabled={isUploadingImage}
+                                        className="relative w-16 h-16 rounded-2xl border border-grayscale-300 bg-white flex items-center justify-center overflow-hidden shrink-0 hover:bg-grayscale-10 transition-colors disabled:opacity-60"
+                                        aria-label="Upload badge image"
+                                    >
+                                        {isUploadingImage ? (
+                                            <Loader2 className="w-5 h-5 text-grayscale-400 animate-spin" />
+                                        ) : effectiveImageUrl ? (
+                                            <img
+                                                src={effectiveImageUrl}
+                                                alt="Badge"
+                                                className="w-full h-full object-cover"
+                                            />
+                                        ) : (
+                                            <ImagePlus className="w-6 h-6 text-grayscale-400" />
+                                        )}
+                                    </button>
+                                    <div className="flex-1 min-w-0">
+                                        <button
+                                            type="button"
+                                            onClick={() => handleFileSelect()}
+                                            disabled={isUploadingImage}
+                                            className="text-sm font-medium text-grayscale-900 hover:text-grayscale-600 transition-colors disabled:opacity-60"
+                                        >
+                                            {isUploadingImage
+                                                ? 'Uploading...'
+                                                : effectiveImageUrl
+                                                ? 'Change image'
+                                                : 'Upload image'}
+                                        </button>
+                                        {imageUrl?.trim() && !isUploadingImage && (
+                                            <button
+                                                type="button"
+                                                onClick={() => onImageUrlChange?.('')}
+                                                className="flex items-center gap-1 text-xs text-grayscale-500 hover:text-red-600 transition-colors mt-1"
+                                            >
+                                                <X className="w-3.5 h-3.5" />
+                                                Remove
+                                            </button>
+                                        )}
+                                        <p className="text-xs text-grayscale-500 mt-1">
+                                            PNG, JPG, or GIF.
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
                         )}
 

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -1,10 +1,26 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import { BadgePreset, VIBE_COLORS, resolveBadgeStyle } from '../boostAFriend.helpers';
-import { LCAStylesPackRegistryEntry } from 'learn-card-base';
+import {
+    BadgePreset,
+    VIBE_COLORS,
+    resolveBadgeStyle,
+    buildBoostFriendTemplate,
+} from '../boostAFriend.helpers';
+import {
+    LCAStylesPackRegistryEntry,
+    BoostCategoryOptionsEnum,
+    BoostPageViewMode,
+} from 'learn-card-base';
+import BoostEarnedCard from '../../../components/boost/boost-earned-card/BoostEarnedCard';
+import { templateToJson } from '../../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/utils';
 
 interface BadgePersonalizeProps {
     badge: BadgePreset;
+    title: string;
+    onTitleChange: (title: string) => void;
+    subtype: string;
+    onSubtypeChange: (subtype: string) => void;
+    isCustom: boolean;
     vibeColor: string;
     onVibeColorChange: (color: string) => void;
     note: string;
@@ -12,10 +28,16 @@ interface BadgePersonalizeProps {
     onNext: () => void;
     onBack: () => void;
     stylePacks: LCAStylesPackRegistryEntry[] | undefined;
+    issuerName?: string;
 }
 
 export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     badge,
+    title,
+    onTitleChange,
+    subtype,
+    onSubtypeChange,
+    isCustom,
     vibeColor,
     onVibeColorChange,
     note,
@@ -23,11 +45,32 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     onNext,
     onBack,
     stylePacks,
+    issuerName,
 }) => {
-    const [imgError, setImgError] = useState(false);
     const { imageUrl } = resolveBadgeStyle(badge, stylePacks);
 
-    const isRealImage = Boolean(imageUrl) && !imgError;
+    const previewCredential = useMemo(() => {
+        const displayTitle = title.trim() || 'Your Badge';
+        const template = buildBoostFriendTemplate({
+            title: displayTitle,
+            subtype: subtype.trim() || displayTitle,
+            description: `A social badge for being a ${displayTitle}`,
+            note,
+            vibeColor,
+            imageUrl,
+            issuerName,
+        });
+        const json = templateToJson(template) as Record<string, any>;
+
+        json.validFrom = new Date().toISOString();
+        if (json.issuer) {
+            json.issuer.id = 'did:key:preview';
+        }
+        if (json.credentialSubject) {
+            delete json.credentialSubject.id;
+        }
+        return json;
+    }, [title, subtype, note, vibeColor, imageUrl, issuerName]);
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up pt-[calc(env(safe-area-inset-top)+1rem)]">
@@ -46,78 +89,89 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                 </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto pb-20 flex flex-col justify-center space-y-8">
-                <div className="flex justify-center">
-                    <div
-                        className="w-56 h-56 rounded-[32px] flex flex-col items-center justify-center p-6 shadow-lg border border-white/40 backdrop-blur-md transition-all duration-300 ring-1 ring-black/5"
-                        style={{
-                            background: `linear-gradient(135deg, ${vibeColor}30 0%, ${vibeColor}10 100%)`,
-                        }}
-                    >
-                        <div className="w-24 h-24 rounded-2xl flex items-center justify-center mb-4 relative">
-                            {isRealImage ? (
-                                <>
-                                    <div
-                                        className="absolute inset-0 rounded-2xl blur-xl opacity-40 transition-colors duration-300"
-                                        style={{ backgroundColor: vibeColor }}
-                                    />
-                                    <img
-                                        src={imageUrl}
-                                        alt={badge.title}
-                                        className="w-full h-full object-cover relative z-10"
-                                        onError={() => setImgError(true)}
-                                    />
-                                </>
-                            ) : (
-                                <div
-                                    className="absolute inset-0 w-full h-full transition-colors duration-300 rounded-2xl"
-                                    style={{ backgroundColor: vibeColor }}
-                                />
-                            )}
-                        </div>
-                        <span className="text-xl font-semibold text-center text-grayscale-900 line-clamp-2">
-                            {badge.title}
-                        </span>
-                        <span className="text-xs font-medium text-grayscale-600 mt-1 opacity-80">
-                            Social Badge
-                        </span>
-                    </div>
-                </div>
-
-                <div className="max-w-sm mx-auto w-full space-y-8">
-                    <div>
-                        <label className="block text-sm font-medium text-grayscale-900 mb-3 text-center">
-                            Vibe Color
-                        </label>
-                        <div className="flex flex-wrap justify-center gap-3">
-                            {VIBE_COLORS.map(color => (
-                                <button
-                                    key={color}
-                                    type="button"
-                                    onClick={() => onVibeColorChange(color)}
-                                    className={`w-10 h-10 rounded-full flex items-center justify-center transition-transform shadow-sm ${
-                                        vibeColor === color
-                                            ? 'scale-110 ring-2 ring-offset-2 ring-grayscale-900'
-                                            : 'hover:scale-105'
-                                    }`}
-                                    style={{ backgroundColor: color }}
-                                    aria-label={`Select color ${color}`}
-                                />
-                            ))}
+            <div className="flex-1 overflow-y-auto pb-20 flex flex-col scrollbar-hide">
+                <div className="my-auto w-full py-6 space-y-8">
+                    <div className="flex justify-center">
+                        <div className="w-[160px] sm:w-[200px]">
+                            <BoostEarnedCard
+                                credential={previewCredential as any}
+                                categoryType={BoostCategoryOptionsEnum.socialBadge}
+                                boostPageViewMode={BoostPageViewMode.Card}
+                                useWrapper={false}
+                                verifierState={false}
+                                hideOptionsMenu
+                                isPreview
+                                className="shadow-xl"
+                            />
                         </div>
                     </div>
 
-                    <div>
-                        <label className="block text-sm font-medium text-grayscale-900 mb-2">
-                            Add a note (optional)
-                        </label>
-                        <textarea
-                            value={note}
-                            onChange={e => onNoteChange(e.target.value)}
-                            placeholder="You're awesome because..."
-                            rows={3}
-                            className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all resize-none shadow-sm"
-                        />
+                    <div className="max-w-sm mx-auto w-full space-y-8">
+                        <div>
+                            <label className="block text-sm font-medium text-grayscale-900 mb-2">
+                                Badge name
+                            </label>
+                            <input
+                                type="text"
+                                value={title}
+                                onChange={e => onTitleChange(e.target.value)}
+                                placeholder="e.g. Trailblazer"
+                                className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all shadow-sm"
+                            />
+                        </div>
+
+                        {isCustom && (
+                            <div>
+                                <label className="block text-sm font-medium text-grayscale-900 mb-1">
+                                    Subtype
+                                </label>
+                                <p className="text-xs text-grayscale-500 mb-2">
+                                    A short label for this kind of badge.
+                                </p>
+                                <input
+                                    type="text"
+                                    value={subtype}
+                                    onChange={e => onSubtypeChange(e.target.value)}
+                                    placeholder="e.g. Trailblazer"
+                                    className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all shadow-sm"
+                                />
+                            </div>
+                        )}
+
+                        <div>
+                            <label className="block text-sm font-medium text-grayscale-900 mb-3 text-center">
+                                Vibe Color
+                            </label>
+                            <div className="grid grid-cols-8 gap-2">
+                                {VIBE_COLORS.map(color => (
+                                    <button
+                                        key={color}
+                                        type="button"
+                                        onClick={() => onVibeColorChange(color)}
+                                        className={`aspect-square w-full rounded-full transition-transform shadow-sm ${
+                                            vibeColor === color
+                                                ? 'ring-2 ring-offset-2 ring-grayscale-900'
+                                                : 'hover:scale-105'
+                                        }`}
+                                        style={{ backgroundColor: color }}
+                                        aria-label={`Select color ${color}`}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-grayscale-900 mb-2">
+                                Add a note (optional)
+                            </label>
+                            <textarea
+                                value={note}
+                                onChange={e => onNoteChange(e.target.value)}
+                                placeholder="You're awesome because..."
+                                rows={3}
+                                className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all resize-none shadow-sm"
+                            />
+                        </div>
                     </div>
                 </div>
             </div>
@@ -126,7 +180,8 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                 <button
                     type="button"
                     onClick={onNext}
-                    className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
+                    disabled={!title.trim()}
+                    className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                     Next
                 </button>

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import BoostsIcon from 'learn-card-base/svgs/wallet/BoostsIcon';
+import { BadgePreset, VIBE_COLORS, resolveBadgeStyle } from '../boostAFriend.helpers';
+import { LCAStylesPackRegistryEntry } from 'learn-card-base';
+
+interface BadgePersonalizeProps {
+    badge: BadgePreset;
+    vibeColor: string;
+    onVibeColorChange: (color: string) => void;
+    note: string;
+    onNoteChange: (note: string) => void;
+    onNext: () => void;
+    onBack: () => void;
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined;
+    categoryFallback: string;
+}
+
+export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
+    badge,
+    vibeColor,
+    onVibeColorChange,
+    note,
+    onNoteChange,
+    onNext,
+    onBack,
+    stylePacks,
+    categoryFallback,
+}) => {
+    const [imgError, setImgError] = useState(false);
+    const { imageUrl } = resolveBadgeStyle(badge, stylePacks, categoryFallback);
+
+    const isRealImage = imageUrl && imageUrl !== categoryFallback && !imgError;
+
+    return (
+        <div className="flex flex-col h-full animate-fade-in-up">
+            <div className="flex items-center gap-3 mb-6">
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="p-2 -ml-2 rounded-full hover:bg-white/50 text-grayscale-600 transition-colors"
+                    aria-label="Go back"
+                >
+                    <ArrowLeft className="w-5 h-5" />
+                </button>
+                <div>
+                    <h1 className="text-2xl font-semibold text-grayscale-900">Personalize</h1>
+                    <p className="text-sm text-grayscale-600 mt-1">Add a note and pick a color.</p>
+                </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto pb-20 flex flex-col justify-center space-y-8">
+                <div className="flex justify-center">
+                    <div
+                        className="w-56 h-56 rounded-[32px] flex flex-col items-center justify-center p-6 shadow-lg border border-white/40 backdrop-blur-md transition-all duration-300 ring-1 ring-black/5"
+                        style={{
+                            background: `linear-gradient(135deg, ${vibeColor}30 0%, ${vibeColor}10 100%)`,
+                        }}
+                    >
+                        <div className="w-24 h-24 rounded-2xl flex items-center justify-center mb-4 relative">
+                            {isRealImage ? (
+                                <>
+                                    <div
+                                        className="absolute inset-0 rounded-2xl blur-xl opacity-40 transition-colors duration-300"
+                                        style={{ backgroundColor: vibeColor }}
+                                    />
+                                    <img
+                                        src={imageUrl}
+                                        alt={badge.title}
+                                        className="w-full h-full object-cover relative z-10"
+                                        onError={() => setImgError(true)}
+                                    />
+                                </>
+                            ) : (
+                                <div
+                                    className="w-full h-full rounded-2xl flex items-center justify-center shadow-sm overflow-hidden transition-colors duration-300"
+                                    style={{
+                                        background: `linear-gradient(135deg, ${vibeColor}40 0%, ${vibeColor}10 100%)`,
+                                        color: vibeColor,
+                                    }}
+                                >
+                                    <BoostsIcon className="w-12 h-12" />
+                                </div>
+                            )}
+                        </div>
+                        <span className="text-xl font-semibold text-center text-grayscale-900 line-clamp-2">
+                            {badge.title}
+                        </span>
+                        <span className="text-xs font-medium text-grayscale-600 mt-1 opacity-80">
+                            Social Badge
+                        </span>
+                    </div>
+                </div>
+
+                <div className="max-w-sm mx-auto w-full space-y-8">
+                    <div>
+                        <label className="block text-sm font-medium text-grayscale-900 mb-3 text-center">
+                            Vibe Color
+                        </label>
+                        <div className="flex flex-wrap justify-center gap-3">
+                            {VIBE_COLORS.map(color => (
+                                <button
+                                    key={color}
+                                    type="button"
+                                    onClick={() => onVibeColorChange(color)}
+                                    className={`w-10 h-10 rounded-full flex items-center justify-center transition-transform shadow-sm ${
+                                        vibeColor === color
+                                            ? 'scale-110 ring-2 ring-offset-2 ring-grayscale-900'
+                                            : 'hover:scale-105'
+                                    }`}
+                                    style={{ backgroundColor: color }}
+                                    aria-label={`Select color ${color}`}
+                                />
+                            ))}
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-grayscale-900 mb-2">
+                            Add a note (optional)
+                        </label>
+                        <textarea
+                            value={note}
+                            onChange={e => onNoteChange(e.target.value)}
+                            placeholder="You're awesome because..."
+                            rows={3}
+                            className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all resize-none shadow-sm"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div className="pt-4 mt-auto">
+                <button
+                    type="button"
+                    onClick={onNext}
+                    className="w-full py-3.5 px-4 rounded-[20px] bg-grayscale-900 text-white font-medium text-base hover:opacity-90 transition-opacity shadow-sm"
+                >
+                    Next
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import BoostsIcon from 'learn-card-base/svgs/wallet/BoostsIcon';
 import { BadgePreset, VIBE_COLORS, resolveBadgeStyle } from '../boostAFriend.helpers';
 import { LCAStylesPackRegistryEntry } from 'learn-card-base';
 
@@ -13,7 +12,6 @@ interface BadgePersonalizeProps {
     onNext: () => void;
     onBack: () => void;
     stylePacks: LCAStylesPackRegistryEntry[] | undefined;
-    categoryFallback: string;
 }
 
 export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
@@ -25,12 +23,11 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     onNext,
     onBack,
     stylePacks,
-    categoryFallback,
 }) => {
     const [imgError, setImgError] = useState(false);
-    const { imageUrl } = resolveBadgeStyle(badge, stylePacks, categoryFallback);
+    const { imageUrl } = resolveBadgeStyle(badge, stylePacks);
 
-    const isRealImage = imageUrl && imageUrl !== categoryFallback && !imgError;
+    const isRealImage = Boolean(imageUrl) && !imgError;
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up">
@@ -73,14 +70,9 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                                 </>
                             ) : (
                                 <div
-                                    className="w-full h-full rounded-2xl flex items-center justify-center shadow-sm overflow-hidden transition-colors duration-300"
-                                    style={{
-                                        background: `linear-gradient(135deg, ${vibeColor}40 0%, ${vibeColor}10 100%)`,
-                                        color: vibeColor,
-                                    }}
-                                >
-                                    <BoostsIcon className="w-12 h-12" />
-                                </div>
+                                    className="absolute inset-0 w-full h-full transition-colors duration-300 rounded-2xl"
+                                    style={{ backgroundColor: vibeColor }}
+                                />
                             )}
                         </div>
                         <span className="text-xl font-semibold text-center text-grayscale-900 line-clamp-2">

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -22,7 +22,9 @@ interface BadgePersonalizeProps {
     isCustom: boolean;
     vibeColor: string;
     onVibeColorChange: (color: string) => void;
+    description?: string;
     note: string;
+    notePlaceholder?: string;
     onNoteChange: (note: string) => void;
     onNext: () => void;
     onBack: () => void;
@@ -39,7 +41,9 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     isCustom,
     vibeColor,
     onVibeColorChange,
+    description,
     note,
+    notePlaceholder,
     onNoteChange,
     onNext,
     onBack,
@@ -53,12 +57,13 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
         return buildPreviewCredential({
             title: displayTitle,
             subtype: subtype.trim() || displayTitle,
-            note,
+            description,
+            note: note.trim() || notePlaceholder,
             vibeColor,
             imageUrl,
             issuerName,
         });
-    }, [title, subtype, note, vibeColor, imageUrl, issuerName]);
+    }, [title, subtype, description, note, notePlaceholder, vibeColor, imageUrl, issuerName]);
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up pt-[calc(env(safe-area-inset-top)+1rem)]">
@@ -155,7 +160,7 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
                             <textarea
                                 value={note}
                                 onChange={e => onNoteChange(e.target.value)}
-                                placeholder="You're awesome because..."
+                                placeholder={notePlaceholder?.trim() || "You're awesome because..."}
                                 rows={3}
                                 className="w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 backdrop-blur-sm transition-all resize-none shadow-sm"
                             />

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -66,24 +66,26 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
     }, [title, subtype, description, note, notePlaceholder, vibeColor, imageUrl, issuerName]);
 
     return (
-        <div className="flex flex-col h-full animate-fade-in-up pt-[calc(env(safe-area-inset-top)+1rem)]">
-            <div className="flex items-center gap-3 mb-6">
-                <button
-                    type="button"
-                    onClick={onBack}
-                    className="p-2 -ml-2 rounded-full hover:bg-white/50 text-grayscale-600 transition-colors"
-                    aria-label="Go back"
-                >
-                    <ArrowLeft className="w-5 h-5" />
-                </button>
-                <div>
-                    <h1 className="text-2xl font-semibold text-grayscale-900">Personalize</h1>
-                    <p className="text-sm text-grayscale-600 mt-1">Add a note and pick a color.</p>
+        <div className="flex flex-col h-full animate-fade-in-up">
+            <div className="flex-1 overflow-y-auto pb-20 flex flex-col scrollbar-hide -mx-4 sm:mx-0">
+                <div className="sticky top-0 z-30 flex items-center gap-3 mb-6 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] pb-4 bg-white/70 backdrop-blur-xl border-b border-grayscale-200/60 sm:bg-transparent sm:backdrop-blur-none sm:border-0">
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        className="p-2 -ml-2 rounded-full hover:bg-white/50 text-grayscale-600 transition-colors"
+                        aria-label="Go back"
+                    >
+                        <ArrowLeft className="w-5 h-5" />
+                    </button>
+                    <div>
+                        <h1 className="text-2xl font-semibold text-grayscale-900">Personalize</h1>
+                        <p className="text-sm text-grayscale-600 mt-1">
+                            Add a note and pick a color.
+                        </p>
+                    </div>
                 </div>
-            </div>
 
-            <div className="flex-1 overflow-y-auto pb-20 flex flex-col scrollbar-hide">
-                <div className="my-auto w-full py-6 space-y-8">
+                <div className="w-full py-6 space-y-8 px-6 sm:px-2 relative z-0">
                     <div className="flex justify-center">
                         <div className="w-[160px] sm:w-[200px]">
                             <BoostEarnedCard

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePersonalize.tsx
@@ -4,7 +4,7 @@ import {
     BadgePreset,
     VIBE_COLORS,
     resolveBadgeStyle,
-    buildBoostFriendTemplate,
+    buildPreviewCredential,
 } from '../boostAFriend.helpers';
 import {
     LCAStylesPackRegistryEntry,
@@ -12,7 +12,6 @@ import {
     BoostPageViewMode,
 } from 'learn-card-base';
 import BoostEarnedCard from '../../../components/boost/boost-earned-card/BoostEarnedCard';
-import { templateToJson } from '../../appStoreDeveloper/partner-onboarding/components/CredentialBuilder/utils';
 
 interface BadgePersonalizeProps {
     badge: BadgePreset;
@@ -51,25 +50,14 @@ export const BadgePersonalize: React.FC<BadgePersonalizeProps> = ({
 
     const previewCredential = useMemo(() => {
         const displayTitle = title.trim() || 'Your Badge';
-        const template = buildBoostFriendTemplate({
+        return buildPreviewCredential({
             title: displayTitle,
             subtype: subtype.trim() || displayTitle,
-            description: `A social badge for being a ${displayTitle}`,
             note,
             vibeColor,
             imageUrl,
             issuerName,
         });
-        const json = templateToJson(template) as Record<string, any>;
-
-        json.validFrom = new Date().toISOString();
-        if (json.issuer) {
-            json.issuer.id = 'did:key:preview';
-        }
-        if (json.credentialSubject) {
-            delete json.credentialSubject.id;
-        }
-        return json;
     }, [title, subtype, note, vibeColor, imageUrl, issuerName]);
 
     return (

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from 'react';
 import { Search, Sparkles, Plus } from 'lucide-react';
 import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { Capacitor } from '@capacitor/core';
-import BoostsIcon from 'learn-card-base/svgs/wallet/BoostsIcon';
 import {
     BadgePreset,
     getSocialBadgePresets,
@@ -16,7 +15,6 @@ interface BadgePickerProps {
     onBack: () => void;
     stylePacks: LCAStylesPackRegistryEntry[] | undefined;
     badgeGroups: BadgeGroup[] | undefined;
-    categoryFallback: string;
 }
 
 export const BadgePicker: React.FC<BadgePickerProps> = ({
@@ -24,7 +22,6 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     onBack,
     stylePacks,
     badgeGroups,
-    categoryFallback,
 }) => {
     const [search, setSearch] = useState('');
     const presets = useMemo(() => getSocialBadgePresets(), []);
@@ -87,10 +84,10 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up">
-            <div className="flex items-center justify-between mb-6 shrink-0">
+            <div className="flex items-center justify-between mb-3 shrink-0">
                 <div>
-                    <h1 className="text-2xl font-semibold text-grayscale-900">Pick a Badge</h1>
-                    <p className="text-sm text-grayscale-600 mt-1">
+                    <h1 className="text-xl font-semibold text-grayscale-900">Pick a Badge</h1>
+                    <p className="text-sm text-grayscale-600 mt-0.5">
                         Send a fun badge to a friend to show appreciation.
                     </p>
                 </div>
@@ -103,7 +100,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                 </button>
             </div>
 
-            <div className="relative mb-6 shrink-0">
+            <div className="relative mb-4 shrink-0">
                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
                 <input
                     type="text"
@@ -114,13 +111,13 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                 />
             </div>
 
-            <div className="flex gap-3 mb-6 overflow-x-auto pb-2 scrollbar-hide shrink-0">
+            <div className="flex gap-3 mb-4 overflow-x-auto pb-2 scrollbar-hide shrink-0">
                 <button
                     type="button"
                     onClick={handleSurpriseMe}
-                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-100 text-grayscale-900 font-medium text-sm hover:bg-grayscale-200 transition-colors whitespace-nowrap"
+                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity whitespace-nowrap"
                 >
-                    <Sparkles className="w-4 h-4 text-amber-500" />
+                    <Sparkles className="w-4 h-4 text-amber-300" />
                     Surprise me
                 </button>
                 {search && !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
@@ -135,9 +132,9 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                 )}
             </div>
 
-            <div className="flex-1 overflow-y-auto pb-20 -mx-4 px-4 sm:mx-0 sm:px-0">
+            <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0">
                 {search ? (
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 px-6 sm:px-0">
                         {filteredPresets.map((preset, index) => {
                             const color = VIBE_COLORS[index % VIBE_COLORS.length];
                             return (
@@ -147,7 +144,6 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                                     color={color}
                                     onSelect={() => handleSelect(preset, color)}
                                     stylePacks={stylePacks}
-                                    categoryFallback={categoryFallback}
                                     index={index}
                                 />
                             );
@@ -162,7 +158,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                     <div className="space-y-8">
                         {groupedPresets?.map((groupData, groupIndex) => (
                             <div key={groupData.group.id} className="space-y-3">
-                                <div className="px-1">
+                                <div className="px-6 sm:px-1">
                                     <h2 className="text-lg sm:text-xl font-semibold text-grayscale-900">
                                         {groupData.group.label}
                                     </h2>
@@ -172,7 +168,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                                         </p>
                                     )}
                                 </div>
-                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide">
+                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide px-6 sm:px-0 scroll-pl-6 sm:scroll-pl-0">
                                     {groupData.presets.map((preset, index) => {
                                         const color =
                                             VIBE_COLORS[
@@ -188,7 +184,6 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                                                     color={color}
                                                     onSelect={() => handleSelect(preset, color)}
                                                     stylePacks={stylePacks}
-                                                    categoryFallback={categoryFallback}
                                                     index={index}
                                                 />
                                             </div>
@@ -209,14 +204,13 @@ const BadgeTile: React.FC<{
     color: string;
     onSelect: () => void;
     stylePacks: LCAStylesPackRegistryEntry[] | undefined;
-    categoryFallback: string;
     index: number;
-}> = ({ preset, color, onSelect, stylePacks, categoryFallback, index }) => {
+}> = ({ preset, color, onSelect, stylePacks, index }) => {
     const [imgError, setImgError] = useState(false);
-    const { imageUrl, backgroundColor } = resolveBadgeStyle(preset, stylePacks, categoryFallback);
+    const { imageUrl, backgroundColor } = resolveBadgeStyle(preset, stylePacks);
     const tileColor = backgroundColor || color;
 
-    const isRealImage = imageUrl && imageUrl !== categoryFallback && !imgError;
+    const isRealImage = Boolean(imageUrl) && !imgError;
 
     return (
         <button
@@ -234,18 +228,21 @@ const BadgeTile: React.FC<{
                 />
             ) : (
                 <div
-                    className="absolute inset-0 w-full h-full flex items-center justify-center transition-transform duration-300 motion-safe:group-hover:scale-105"
-                    style={{
-                        background: `linear-gradient(135deg, ${tileColor}CC 0%, ${tileColor}77 100%)`,
-                        color: '#FFFFFF',
-                    }}
-                >
-                    <BoostsIcon className="w-12 h-12 sm:w-16 sm:h-16 opacity-90" />
-                </div>
+                    className="absolute inset-0 w-full h-full transition-transform duration-300 motion-safe:group-hover:scale-105"
+                    style={{ backgroundColor: tileColor }}
+                />
             )}
 
-            <div className="absolute inset-x-0 bottom-0 pt-12 pb-3 px-3 sm:px-4 bg-gradient-to-t from-black/70 via-black/25 to-transparent flex items-end">
-                <span className="text-sm sm:text-base font-semibold text-white line-clamp-1 w-full drop-shadow-sm">
+            <div
+                className={`absolute inset-x-0 bottom-0 pt-12 pb-3 px-3 sm:px-4 flex items-end ${
+                    isRealImage ? 'bg-gradient-to-t from-black/70 via-black/25 to-transparent' : ''
+                }`}
+            >
+                <span
+                    className={`text-sm sm:text-base font-semibold text-white line-clamp-1 w-full ${
+                        isRealImage ? 'drop-shadow-sm' : ''
+                    }`}
+                >
                     {preset.title}
                 </span>
             </div>

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -64,9 +64,9 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     };
 
     const handleCustom = () => {
-        if (!search) return;
+        const trimmedSearch = search.trim();
         const randomColor = VIBE_COLORS[Math.floor(Math.random() * VIBE_COLORS.length)];
-        handleSelect({ title: search, type: `ext:${search.replace(/\s+/g, '')}` }, randomColor);
+        handleSelect({ title: trimmedSearch, type: 'ext:Custom' }, randomColor);
     };
 
     const groupedPresets = useMemo(() => {
@@ -98,7 +98,10 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
 
     return (
         <div className="flex flex-col h-full animate-fade-in-up">
-            <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0" onScroll={handleScroll}>
+            <div
+                className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0 scrollbar-hide"
+                onScroll={handleScroll}
+            >
                 <div
                     className={`sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 transition-all duration-300 motion-reduce:transition-none ${
                         isCollapsed ? 'pb-3 mb-4 sm:pb-4 sm:mb-6' : 'pb-4 mb-6'
@@ -109,7 +112,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                             type="button"
                             onClick={onBack}
                             className={`absolute right-0 z-10 text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-all duration-300 motion-reduce:transition-none ${
-                                isCollapsed ? 'top-4 sm:top-1' : 'top-1'
+                                isCollapsed ? 'top-[18px] sm:top-1' : 'top-1'
                             }`}
                         >
                             Cancel
@@ -131,16 +134,16 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                         </div>
 
                         <div
-                            className={`relative transition-all duration-300 motion-reduce:transition-none ${
-                                isCollapsed ? 'pr-14 sm:pr-0 mb-0 sm:mb-4' : 'mb-4'
+                            className={`relative py-0.5 pl-0.5 transition-all duration-300 motion-reduce:transition-none ${
+                                isCollapsed ? 'pr-14 sm:pr-0.5 mb-0 sm:mb-4' : 'pr-0.5 mb-4'
                             }`}
                         >
-                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400 ml-0.5" />
                             <input
                                 type="text"
                                 value={search}
                                 onChange={e => setSearch(e.target.value)}
-                                placeholder="Search or create custom..."
+                                placeholder="Search badges..."
                                 className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
                             />
                         </div>
@@ -161,17 +164,14 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                             <Sparkles className="w-4 h-4 text-amber-300" />
                             Surprise me
                         </button>
-                        {search &&
-                            !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
-                                <button
-                                    type="button"
-                                    onClick={handleCustom}
-                                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
-                                >
-                                    <Plus className="w-4 h-4" />
-                                    Create "{search}"
-                                </button>
-                            )}
+                        <button
+                            type="button"
+                            onClick={handleCustom}
+                            className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
+                        >
+                            <Plus className="w-4 h-4" />
+                            New
+                        </button>
                     </div>
                 </div>
 

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -83,58 +83,61 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     }, [presets, badgeGroups, search]);
 
     return (
-        <div className="flex flex-col h-full animate-fade-in-up">
-            <div className="flex items-center justify-between mb-3 shrink-0">
-                <div>
-                    <h1 className="text-xl font-semibold text-grayscale-900">Pick a Badge</h1>
-                    <p className="text-sm text-grayscale-600 mt-0.5">
-                        Send a fun badge to a friend to show appreciation.
-                    </p>
-                </div>
-                <button
-                    type="button"
-                    onClick={onBack}
-                    className="text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-colors"
-                >
-                    Cancel
-                </button>
-            </div>
-
-            <div className="relative mb-4 shrink-0">
-                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
-                <input
-                    type="text"
-                    value={search}
-                    onChange={e => setSearch(e.target.value)}
-                    placeholder="Search or create custom..."
-                    className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
-                />
-            </div>
-
-            <div className="flex gap-3 mb-4 overflow-x-auto pb-2 scrollbar-hide shrink-0">
-                <button
-                    type="button"
-                    onClick={handleSurpriseMe}
-                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                >
-                    <Sparkles className="w-4 h-4 text-amber-300" />
-                    Surprise me
-                </button>
-                {search && !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
+        <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0 animate-fade-in-up">
+            <div className="sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 pb-4 mb-6">
+                <div className="flex items-center justify-between mb-3">
+                    <div>
+                        <h1 className="text-xl font-semibold text-grayscale-900">Pick a Badge</h1>
+                        <p className="text-sm text-grayscale-600 mt-0.5">
+                            Send a fun badge to a friend to show appreciation.
+                        </p>
+                    </div>
                     <button
                         type="button"
-                        onClick={handleCustom}
-                        className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
+                        onClick={onBack}
+                        className="text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-colors"
                     >
-                        <Plus className="w-4 h-4" />
-                        Create "{search}"
+                        Cancel
                     </button>
-                )}
+                </div>
+
+                <div className="relative mb-4">
+                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        placeholder="Search or create custom..."
+                        className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
+                    />
+                </div>
+
+                <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+                    <button
+                        type="button"
+                        onClick={handleSurpriseMe}
+                        className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                    >
+                        <Sparkles className="w-4 h-4 text-amber-300" />
+                        Surprise me
+                    </button>
+                    {search &&
+                        !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
+                            <button
+                                type="button"
+                                onClick={handleCustom}
+                                className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
+                            >
+                                <Plus className="w-4 h-4" />
+                                Create "{search}"
+                            </button>
+                        )}
+                </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0">
+            <div className="px-0">
                 {search ? (
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 px-6 sm:px-0">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 px-6 sm:px-0">
                         {filteredPresets.map((preset, index) => {
                             const color = VIBE_COLORS[index % VIBE_COLORS.length];
                             return (
@@ -168,7 +171,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
                                         </p>
                                     )}
                                 </div>
-                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide px-6 sm:px-0 scroll-pl-6 sm:scroll-pl-0">
+                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide px-6 sm:px-0 scroll-pl-6 sm:scroll-pl-0">
                                     {groupData.presets.map((preset, index) => {
                                         const color =
                                             VIBE_COLORS[
@@ -235,12 +238,12 @@ const BadgeTile: React.FC<{
 
             <div
                 className={`absolute inset-x-0 bottom-0 pt-12 pb-3 px-3 sm:px-4 flex items-end ${
-                    isRealImage ? 'bg-gradient-to-t from-black/70 via-black/25 to-transparent' : ''
+                    isRealImage ? 'bg-gradient-to-t from-black/80 via-black/30 to-transparent' : ''
                 }`}
             >
                 <span
-                    className={`text-sm sm:text-base font-semibold text-white line-clamp-1 w-full ${
-                        isRealImage ? 'drop-shadow-sm' : ''
+                    className={`text-sm font-semibold text-white line-clamp-1 w-full ${
+                        isRealImage ? 'drop-shadow-md' : ''
                     }`}
                 >
                     {preset.title}

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { Search, Sparkles, Plus } from 'lucide-react';
 import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { Capacitor } from '@capacitor/core';
@@ -31,6 +31,20 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
         const lower = search.toLowerCase();
         return presets.filter(p => p.title.toLowerCase().includes(lower));
     }, [presets, search]);
+
+    const [isCollapsed, setIsCollapsed] = useState(false);
+
+    const handleScroll = useCallback(
+        (e: React.UIEvent<HTMLDivElement>) => {
+            const scrollTop = e.currentTarget.scrollTop;
+            if (scrollTop > 24 && !isCollapsed) {
+                setIsCollapsed(true);
+            } else if (scrollTop <= 8 && isCollapsed) {
+                setIsCollapsed(false);
+            }
+        },
+        [isCollapsed]
+    );
 
     const handleSelect = (badge: BadgePreset, color: string) => {
         if (Capacitor.isNativePlatform()) {
@@ -83,36 +97,62 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     }, [presets, badgeGroups, search]);
 
     return (
-        <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0 animate-fade-in-up">
-            <div className="sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 pb-4 mb-6">
-                <div className="flex items-center justify-between mb-3">
-                    <div>
+        <div
+            className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0 animate-fade-in-up"
+            onScroll={handleScroll}
+        >
+            <div
+                className={`sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 transition-all duration-300 motion-reduce:transition-none ${
+                    isCollapsed ? 'pb-3 mb-4 sm:pb-4 sm:mb-6' : 'pb-4 mb-6'
+                }`}
+            >
+                <div className="relative">
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        className={`absolute right-0 z-10 text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-all duration-300 motion-reduce:transition-none ${
+                            isCollapsed ? 'top-4 sm:top-1' : 'top-1'
+                        }`}
+                    >
+                        Cancel
+                    </button>
+
+                    <div
+                        className={`transition-all duration-300 motion-reduce:transition-none overflow-hidden pr-14 ${
+                            isCollapsed
+                                ? 'max-h-0 opacity-0 mb-0 sm:max-h-none sm:opacity-100 sm:mb-3'
+                                : 'max-h-24 opacity-100 mb-3 sm:max-h-none sm:opacity-100 sm:mb-3'
+                        }`}
+                    >
                         <h1 className="text-xl font-semibold text-grayscale-900">Pick a Badge</h1>
                         <p className="text-sm text-grayscale-600 mt-0.5">
                             Send a fun badge to a friend to show appreciation.
                         </p>
                     </div>
-                    <button
-                        type="button"
-                        onClick={onBack}
-                        className="text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-colors"
+
+                    <div
+                        className={`relative transition-all duration-300 motion-reduce:transition-none ${
+                            isCollapsed ? 'pr-14 sm:pr-0 mb-0 sm:mb-4' : 'mb-4'
+                        }`}
                     >
-                        Cancel
-                    </button>
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                        <input
+                            type="text"
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                            placeholder="Search or create custom..."
+                            className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
+                        />
+                    </div>
                 </div>
 
-                <div className="relative mb-4">
-                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
-                    <input
-                        type="text"
-                        value={search}
-                        onChange={e => setSearch(e.target.value)}
-                        placeholder="Search or create custom..."
-                        className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
-                    />
-                </div>
-
-                <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+                <div
+                    className={`flex gap-3 overflow-x-auto scrollbar-hide transition-all duration-300 motion-reduce:transition-none ${
+                        isCollapsed
+                            ? 'max-h-0 opacity-0 pb-0 sm:max-h-none sm:opacity-100 sm:pb-1'
+                            : 'max-h-16 opacity-100 pb-1 sm:max-h-none sm:opacity-100 sm:pb-1'
+                    }`}
+                >
                     <button
                         type="button"
                         onClick={handleSurpriseMe}

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -1,0 +1,254 @@
+import React, { useState, useMemo } from 'react';
+import { Search, Sparkles, Plus } from 'lucide-react';
+import { Haptics, ImpactStyle } from '@capacitor/haptics';
+import { Capacitor } from '@capacitor/core';
+import BoostsIcon from 'learn-card-base/svgs/wallet/BoostsIcon';
+import {
+    BadgePreset,
+    getSocialBadgePresets,
+    VIBE_COLORS,
+    resolveBadgeStyle,
+} from '../boostAFriend.helpers';
+import { LCAStylesPackRegistryEntry, BadgeGroup } from 'learn-card-base';
+
+interface BadgePickerProps {
+    onSelect: (badge: BadgePreset, vibeColor: string) => void;
+    onBack: () => void;
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined;
+    badgeGroups: BadgeGroup[] | undefined;
+    categoryFallback: string;
+}
+
+export const BadgePicker: React.FC<BadgePickerProps> = ({
+    onSelect,
+    onBack,
+    stylePacks,
+    badgeGroups,
+    categoryFallback,
+}) => {
+    const [search, setSearch] = useState('');
+    const presets = useMemo(() => getSocialBadgePresets(), []);
+
+    const filteredPresets = useMemo(() => {
+        if (!search) return presets;
+        const lower = search.toLowerCase();
+        return presets.filter(p => p.title.toLowerCase().includes(lower));
+    }, [presets, search]);
+
+    const handleSelect = (badge: BadgePreset, color: string) => {
+        if (Capacitor.isNativePlatform()) {
+            try {
+                Haptics.impact({ style: ImpactStyle.Light });
+            } catch {
+                // Haptics are best-effort; a device without support must not block selection.
+            }
+        }
+        onSelect(badge, color);
+    };
+
+    const handleSurpriseMe = () => {
+        const randomPreset = presets[Math.floor(Math.random() * presets.length)];
+        const randomColor = VIBE_COLORS[Math.floor(Math.random() * VIBE_COLORS.length)];
+        handleSelect(randomPreset, randomColor);
+    };
+
+    const handleCustom = () => {
+        if (!search) return;
+        const randomColor = VIBE_COLORS[Math.floor(Math.random() * VIBE_COLORS.length)];
+        handleSelect({ title: search, type: `ext:${search.replace(/\s+/g, '')}` }, randomColor);
+    };
+
+    const groupedPresets = useMemo(() => {
+        if (search) return null;
+
+        const groups: { group: BadgeGroup; presets: BadgePreset[] }[] = [];
+        const usedTypes = new Set<string>();
+
+        if (badgeGroups) {
+            for (const group of badgeGroups) {
+                const groupPresets = presets.filter(p => group.types.includes(p.type));
+                if (groupPresets.length > 0) {
+                    groups.push({ group, presets: groupPresets });
+                    groupPresets.forEach(p => usedTypes.add(p.type));
+                }
+            }
+        }
+
+        const remainingPresets = presets.filter(p => !usedTypes.has(p.type));
+        if (remainingPresets.length > 0) {
+            groups.push({
+                group: { id: 'more', label: 'More Badges', types: [] },
+                presets: remainingPresets,
+            });
+        }
+
+        return groups;
+    }, [presets, badgeGroups, search]);
+
+    return (
+        <div className="flex flex-col h-full animate-fade-in-up">
+            <div className="flex items-center justify-between mb-6 shrink-0">
+                <div>
+                    <h1 className="text-2xl font-semibold text-grayscale-900">Pick a Badge</h1>
+                    <p className="text-sm text-grayscale-600 mt-1">
+                        Send a fun badge to a friend to show appreciation.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-colors"
+                >
+                    Cancel
+                </button>
+            </div>
+
+            <div className="relative mb-6 shrink-0">
+                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                <input
+                    type="text"
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder="Search or create custom..."
+                    className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
+                />
+            </div>
+
+            <div className="flex gap-3 mb-6 overflow-x-auto pb-2 scrollbar-hide shrink-0">
+                <button
+                    type="button"
+                    onClick={handleSurpriseMe}
+                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-100 text-grayscale-900 font-medium text-sm hover:bg-grayscale-200 transition-colors whitespace-nowrap"
+                >
+                    <Sparkles className="w-4 h-4 text-amber-500" />
+                    Surprise me
+                </button>
+                {search && !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
+                    <button
+                        type="button"
+                        onClick={handleCustom}
+                        className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
+                    >
+                        <Plus className="w-4 h-4" />
+                        Create "{search}"
+                    </button>
+                )}
+            </div>
+
+            <div className="flex-1 overflow-y-auto pb-20 -mx-4 px-4 sm:mx-0 sm:px-0">
+                {search ? (
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                        {filteredPresets.map((preset, index) => {
+                            const color = VIBE_COLORS[index % VIBE_COLORS.length];
+                            return (
+                                <BadgeTile
+                                    key={preset.title}
+                                    preset={preset}
+                                    color={color}
+                                    onSelect={() => handleSelect(preset, color)}
+                                    stylePacks={stylePacks}
+                                    categoryFallback={categoryFallback}
+                                    index={index}
+                                />
+                            );
+                        })}
+                        {filteredPresets.length === 0 && (
+                            <div className="col-span-full text-center py-10 text-grayscale-500">
+                                No badges found.
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <div className="space-y-8">
+                        {groupedPresets?.map((groupData, groupIndex) => (
+                            <div key={groupData.group.id} className="space-y-3">
+                                <div className="px-1">
+                                    <h2 className="text-lg sm:text-xl font-semibold text-grayscale-900">
+                                        {groupData.group.label}
+                                    </h2>
+                                    {groupData.group.description && (
+                                        <p className="text-sm text-grayscale-500 mt-0.5">
+                                            {groupData.group.description}
+                                        </p>
+                                    )}
+                                </div>
+                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide">
+                                    {groupData.presets.map((preset, index) => {
+                                        const color =
+                                            VIBE_COLORS[
+                                                (groupIndex * 10 + index) % VIBE_COLORS.length
+                                            ];
+                                        return (
+                                            <div
+                                                key={preset.title}
+                                                className="snap-start shrink-0 w-32 sm:w-auto"
+                                            >
+                                                <BadgeTile
+                                                    preset={preset}
+                                                    color={color}
+                                                    onSelect={() => handleSelect(preset, color)}
+                                                    stylePacks={stylePacks}
+                                                    categoryFallback={categoryFallback}
+                                                    index={index}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+const BadgeTile: React.FC<{
+    preset: BadgePreset;
+    color: string;
+    onSelect: () => void;
+    stylePacks: LCAStylesPackRegistryEntry[] | undefined;
+    categoryFallback: string;
+    index: number;
+}> = ({ preset, color, onSelect, stylePacks, categoryFallback, index }) => {
+    const [imgError, setImgError] = useState(false);
+    const { imageUrl, backgroundColor } = resolveBadgeStyle(preset, stylePacks, categoryFallback);
+    const tileColor = backgroundColor || color;
+
+    const isRealImage = imageUrl && imageUrl !== categoryFallback && !imgError;
+
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            className="group w-full aspect-square relative overflow-hidden rounded-2xl sm:rounded-3xl border border-grayscale-200 shadow-sm hover:shadow-md transition-all duration-300 text-left motion-safe:hover:-translate-y-0.5 active:scale-[0.97] motion-safe:animate-pop-in"
+            style={{ animationDelay: `${Math.min(index * 50, 500)}ms` }}
+        >
+            {isRealImage ? (
+                <img
+                    src={imageUrl}
+                    alt={preset.title}
+                    className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 motion-safe:group-hover:scale-105"
+                    onError={() => setImgError(true)}
+                />
+            ) : (
+                <div
+                    className="absolute inset-0 w-full h-full flex items-center justify-center transition-transform duration-300 motion-safe:group-hover:scale-105"
+                    style={{
+                        background: `linear-gradient(135deg, ${tileColor}CC 0%, ${tileColor}77 100%)`,
+                        color: '#FFFFFF',
+                    }}
+                >
+                    <BoostsIcon className="w-12 h-12 sm:w-16 sm:h-16 opacity-90" />
+                </div>
+            )}
+
+            <div className="absolute inset-x-0 bottom-0 pt-12 pb-3 px-3 sm:px-4 bg-gradient-to-t from-black/70 via-black/25 to-transparent flex items-end">
+                <span className="text-sm sm:text-base font-semibold text-white line-clamp-1 w-full drop-shadow-sm">
+                    {preset.title}
+                </span>
+            </div>
+        </button>
+    );
+};

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -286,7 +286,7 @@ const BadgeTile: React.FC<{
                 }`}
             >
                 <span
-                    className={`text-sm font-semibold text-white line-clamp-1 w-full ${
+                    className={`text-sm font-semibold text-white line-clamp-2 break-normal w-full leading-tight ${
                         isRealImage ? 'drop-shadow-md' : ''
                     }`}
                 >

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -97,146 +97,147 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     }, [presets, badgeGroups, search]);
 
     return (
-        <div
-            className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0 animate-fade-in-up"
-            onScroll={handleScroll}
-        >
-            <div
-                className={`sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 transition-all duration-300 motion-reduce:transition-none ${
-                    isCollapsed ? 'pb-3 mb-4 sm:pb-4 sm:mb-6' : 'pb-4 mb-6'
-                }`}
-            >
-                <div className="relative">
-                    <button
-                        type="button"
-                        onClick={onBack}
-                        className={`absolute right-0 z-10 text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-all duration-300 motion-reduce:transition-none ${
-                            isCollapsed ? 'top-4 sm:top-1' : 'top-1'
-                        }`}
-                    >
-                        Cancel
-                    </button>
-
-                    <div
-                        className={`transition-all duration-300 motion-reduce:transition-none overflow-hidden pr-14 ${
-                            isCollapsed
-                                ? 'max-h-0 opacity-0 mb-0 sm:max-h-none sm:opacity-100 sm:mb-3'
-                                : 'max-h-24 opacity-100 mb-3 sm:max-h-none sm:opacity-100 sm:mb-3'
-                        }`}
-                    >
-                        <h1 className="text-xl font-semibold text-grayscale-900">Pick a Badge</h1>
-                        <p className="text-sm text-grayscale-600 mt-0.5">
-                            Send a fun badge to a friend to show appreciation.
-                        </p>
-                    </div>
-
-                    <div
-                        className={`relative transition-all duration-300 motion-reduce:transition-none ${
-                            isCollapsed ? 'pr-14 sm:pr-0 mb-0 sm:mb-4' : 'mb-4'
-                        }`}
-                    >
-                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
-                        <input
-                            type="text"
-                            value={search}
-                            onChange={e => setSearch(e.target.value)}
-                            placeholder="Search or create custom..."
-                            className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
-                        />
-                    </div>
-                </div>
-
+        <div className="flex flex-col h-full animate-fade-in-up">
+            <div className="flex-1 overflow-y-auto pb-20 -mx-4 sm:mx-0" onScroll={handleScroll}>
                 <div
-                    className={`flex gap-3 overflow-x-auto scrollbar-hide transition-all duration-300 motion-reduce:transition-none ${
-                        isCollapsed
-                            ? 'max-h-0 opacity-0 pb-0 sm:max-h-none sm:opacity-100 sm:pb-1'
-                            : 'max-h-16 opacity-100 pb-1 sm:max-h-none sm:opacity-100 sm:pb-1'
+                    className={`sticky sm:static top-0 z-20 bg-white/70 sm:bg-transparent backdrop-blur-xl sm:backdrop-blur-none border-b sm:border-0 border-grayscale-200/60 px-6 sm:px-0 pt-[calc(env(safe-area-inset-top)+1rem)] sm:pt-6 transition-all duration-300 motion-reduce:transition-none ${
+                        isCollapsed ? 'pb-3 mb-4 sm:pb-4 sm:mb-6' : 'pb-4 mb-6'
                     }`}
                 >
-                    <button
-                        type="button"
-                        onClick={handleSurpriseMe}
-                        className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                    >
-                        <Sparkles className="w-4 h-4 text-amber-300" />
-                        Surprise me
-                    </button>
-                    {search &&
-                        !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
-                            <button
-                                type="button"
-                                onClick={handleCustom}
-                                className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
-                            >
-                                <Plus className="w-4 h-4" />
-                                Create "{search}"
-                            </button>
-                        )}
-                </div>
-            </div>
+                    <div className="relative">
+                        <button
+                            type="button"
+                            onClick={onBack}
+                            className={`absolute right-0 z-10 text-sm font-medium text-grayscale-600 hover:text-grayscale-900 transition-all duration-300 motion-reduce:transition-none ${
+                                isCollapsed ? 'top-4 sm:top-1' : 'top-1'
+                            }`}
+                        >
+                            Cancel
+                        </button>
 
-            <div className="px-0">
-                {search ? (
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 px-6 sm:px-0">
-                        {filteredPresets.map((preset, index) => {
-                            const color = VIBE_COLORS[index % VIBE_COLORS.length];
-                            return (
-                                <BadgeTile
-                                    key={preset.title}
-                                    preset={preset}
-                                    color={color}
-                                    onSelect={() => handleSelect(preset, color)}
-                                    stylePacks={stylePacks}
-                                    index={index}
-                                />
-                            );
-                        })}
-                        {filteredPresets.length === 0 && (
-                            <div className="col-span-full text-center py-10 text-grayscale-500">
-                                No badges found.
-                            </div>
-                        )}
+                        <div
+                            className={`transition-all duration-300 motion-reduce:transition-none overflow-hidden pr-14 ${
+                                isCollapsed
+                                    ? 'max-h-0 opacity-0 mb-0 sm:max-h-none sm:opacity-100 sm:mb-3'
+                                    : 'max-h-24 opacity-100 mb-3 sm:max-h-none sm:opacity-100 sm:mb-3'
+                            }`}
+                        >
+                            <h1 className="text-xl font-semibold text-grayscale-900">
+                                Pick a Badge
+                            </h1>
+                            <p className="text-sm text-grayscale-600 mt-0.5">
+                                Send a fun badge to a friend to show appreciation.
+                            </p>
+                        </div>
+
+                        <div
+                            className={`relative transition-all duration-300 motion-reduce:transition-none ${
+                                isCollapsed ? 'pr-14 sm:pr-0 mb-0 sm:mb-4' : 'mb-4'
+                            }`}
+                        >
+                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                            <input
+                                type="text"
+                                value={search}
+                                onChange={e => setSearch(e.target.value)}
+                                placeholder="Search or create custom..."
+                                className="w-full py-3.5 pl-12 pr-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white/80 transition-all"
+                            />
+                        </div>
                     </div>
-                ) : (
-                    <div className="space-y-8">
-                        {groupedPresets?.map((groupData, groupIndex) => (
-                            <div key={groupData.group.id} className="space-y-3">
-                                <div className="px-6 sm:px-1">
-                                    <h2 className="text-lg sm:text-xl font-semibold text-grayscale-900">
-                                        {groupData.group.label}
-                                    </h2>
-                                    {groupData.group.description && (
-                                        <p className="text-sm text-grayscale-500 mt-0.5">
-                                            {groupData.group.description}
-                                        </p>
-                                    )}
-                                </div>
-                                <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide px-6 sm:px-0 scroll-pl-6 sm:scroll-pl-0">
-                                    {groupData.presets.map((preset, index) => {
-                                        const color =
-                                            VIBE_COLORS[
-                                                (groupIndex * 10 + index) % VIBE_COLORS.length
-                                            ];
-                                        return (
-                                            <div
-                                                key={preset.title}
-                                                className="snap-start shrink-0 w-32 sm:w-auto"
-                                            >
-                                                <BadgeTile
-                                                    preset={preset}
-                                                    color={color}
-                                                    onSelect={() => handleSelect(preset, color)}
-                                                    stylePacks={stylePacks}
-                                                    index={index}
-                                                />
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        ))}
+
+                    <div
+                        className={`flex gap-3 overflow-x-auto scrollbar-hide transition-all duration-300 motion-reduce:transition-none ${
+                            isCollapsed
+                                ? 'max-h-0 opacity-0 pb-0 sm:max-h-none sm:opacity-100 sm:pb-1'
+                                : 'max-h-16 opacity-100 pb-1 sm:max-h-none sm:opacity-100 sm:pb-1'
+                        }`}
+                    >
+                        <button
+                            type="button"
+                            onClick={handleSurpriseMe}
+                            className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-grayscale-900 text-white font-medium text-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                        >
+                            <Sparkles className="w-4 h-4 text-amber-300" />
+                            Surprise me
+                        </button>
+                        {search &&
+                            !presets.some(p => p.title.toLowerCase() === search.toLowerCase()) && (
+                                <button
+                                    type="button"
+                                    onClick={handleCustom}
+                                    className="flex items-center gap-2 py-2.5 px-4 rounded-full bg-emerald-50 text-emerald-700 font-medium text-sm hover:bg-emerald-100 transition-colors whitespace-nowrap"
+                                >
+                                    <Plus className="w-4 h-4" />
+                                    Create "{search}"
+                                </button>
+                            )}
                     </div>
-                )}
+                </div>
+
+                <div className="px-0">
+                    {search ? (
+                        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 px-6 sm:px-0">
+                            {filteredPresets.map((preset, index) => {
+                                const color = VIBE_COLORS[index % VIBE_COLORS.length];
+                                return (
+                                    <BadgeTile
+                                        key={preset.title}
+                                        preset={preset}
+                                        color={color}
+                                        onSelect={() => handleSelect(preset, color)}
+                                        stylePacks={stylePacks}
+                                        index={index}
+                                    />
+                                );
+                            })}
+                            {filteredPresets.length === 0 && (
+                                <div className="col-span-full text-center py-10 text-grayscale-500">
+                                    No badges found.
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="space-y-8">
+                            {groupedPresets?.map((groupData, groupIndex) => (
+                                <div key={groupData.group.id} className="space-y-3">
+                                    <div className="px-6 sm:px-1">
+                                        <h2 className="text-lg sm:text-xl font-semibold text-grayscale-900">
+                                            {groupData.group.label}
+                                        </h2>
+                                        {groupData.group.description && (
+                                            <p className="text-sm text-grayscale-500 mt-0.5">
+                                                {groupData.group.description}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 overflow-x-auto sm:overflow-x-visible snap-x snap-mandatory pb-4 sm:pb-0 scrollbar-hide px-6 sm:px-0 scroll-pl-6 sm:scroll-pl-0">
+                                        {groupData.presets.map((preset, index) => {
+                                            const color =
+                                                VIBE_COLORS[
+                                                    (groupIndex * 10 + index) % VIBE_COLORS.length
+                                                ];
+                                            return (
+                                                <div
+                                                    key={preset.title}
+                                                    className="snap-start shrink-0 w-32 sm:w-auto"
+                                                >
+                                                    <BadgeTile
+                                                        preset={preset}
+                                                        color={color}
+                                                        onSelect={() => handleSelect(preset, color)}
+                                                        stylePacks={stylePacks}
+                                                        index={index}
+                                                    />
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BadgePicker.tsx
@@ -4,7 +4,7 @@ import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { Capacitor } from '@capacitor/core';
 import {
     BadgePreset,
-    getSocialBadgePresets,
+    getStylePackPresets,
     VIBE_COLORS,
     resolveBadgeStyle,
 } from '../boostAFriend.helpers';
@@ -24,7 +24,7 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     badgeGroups,
 }) => {
     const [search, setSearch] = useState('');
-    const presets = useMemo(() => getSocialBadgePresets(), []);
+    const presets = useMemo(() => getStylePackPresets(stylePacks), [stylePacks]);
 
     const filteredPresets = useMemo(() => {
         if (!search) return presets;
@@ -66,7 +66,10 @@ export const BadgePicker: React.FC<BadgePickerProps> = ({
     const handleCustom = () => {
         const trimmedSearch = search.trim();
         const randomColor = VIBE_COLORS[Math.floor(Math.random() * VIBE_COLORS.length)];
-        handleSelect({ title: trimmedSearch, type: 'ext:Custom' }, randomColor);
+        handleSelect(
+            { title: trimmedSearch, type: 'ext:Custom', category: 'Social Badge' },
+            randomColor
+        );
     };
 
     const groupedPresets = useMemo(() => {

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BoostRecipientPicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BoostRecipientPicker.tsx
@@ -1,0 +1,377 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Search, X, Mail, Loader2, Calendar, Check } from 'lucide-react';
+import { useGetSearchProfiles, useGetConnections } from 'learn-card-base';
+import useDebounce from '../../../hooks/useDebounce';
+import {
+    RecipientMode,
+    Recipient,
+    LinkOptions,
+    isEmail,
+} from '../../issue/components/recipientTypes';
+
+const INPUT_CLASS =
+    'w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all';
+const LABEL_CLASS = 'block text-xs font-medium text-grayscale-700 mb-1.5';
+
+const Avatar: React.FC<{
+    image?: string;
+    name: string;
+    sizeClass: string;
+    fallbackClass: string;
+}> = ({ image, name, sizeClass, fallbackClass }) => {
+    const [errored, setErrored] = useState(false);
+    const initial = (name || '?').charAt(0).toUpperCase();
+
+    if (image && !errored) {
+        return (
+            <img
+                src={image}
+                alt={name}
+                onError={() => setErrored(true)}
+                className={`${sizeClass} rounded-full object-cover bg-grayscale-100`}
+            />
+        );
+    }
+
+    return (
+        <div
+            className={`${sizeClass} rounded-full flex items-center justify-center font-bold ${fallbackClass}`}
+        >
+            {initial}
+        </div>
+    );
+};
+
+interface BoostRecipientPickerProps {
+    mode: RecipientMode;
+    onModeChange: (mode: RecipientMode) => void;
+    recipients: Recipient[];
+    onRecipientsChange: (recipients: Recipient[]) => void;
+    linkOptions: LinkOptions;
+    onLinkOptionsChange: (options: LinkOptions) => void;
+}
+
+export const BoostRecipientPicker: React.FC<BoostRecipientPickerProps> = ({
+    mode,
+    onModeChange,
+    recipients,
+    onRecipientsChange,
+    linkOptions,
+    onLinkOptionsChange,
+}) => {
+    const [query, setQuery] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
+
+    const updateDebounced = useDebounce(() => setDebouncedQuery(query), 300);
+    useEffect(() => {
+        updateDebounced();
+        return () => updateDebounced.cancel?.();
+    }, [query, updateDebounced]);
+
+    const { data: searchResults, isLoading: isSearching } = useGetSearchProfiles(debouncedQuery);
+    const { data: connectionsData, isLoading: isConnectionsLoading } = useGetConnections();
+
+    const handleToggleRecipient = (recipient: Recipient) => {
+        const isSelected = recipients.some(
+            r =>
+                (r.kind === 'profile' &&
+                    recipient.kind === 'profile' &&
+                    r.profileId === recipient.profileId) ||
+                (r.kind === 'email' && recipient.kind === 'email' && r.email === recipient.email)
+        );
+
+        if (isSelected) {
+            onRecipientsChange(
+                recipients.filter(
+                    r =>
+                        !(
+                            (r.kind === 'profile' &&
+                                recipient.kind === 'profile' &&
+                                r.profileId === recipient.profileId) ||
+                            (r.kind === 'email' &&
+                                recipient.kind === 'email' &&
+                                r.email === recipient.email)
+                        )
+                )
+            );
+        } else {
+            onRecipientsChange([...recipients, recipient]);
+        }
+    };
+
+    const handleRemoveRecipient = (index: number) => {
+        const newRecipients = [...recipients];
+        newRecipients.splice(index, 1);
+        onRecipientsChange(newRecipients);
+    };
+
+    const isValidEmail = isEmail(query);
+
+    const displayList = useMemo(() => {
+        if (debouncedQuery.length > 0) {
+            return searchResults || [];
+        }
+        return connectionsData || [];
+    }, [debouncedQuery, searchResults, connectionsData]);
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex gap-1 sm:gap-2 bg-grayscale-100 p-1 rounded-full mb-6 shrink-0">
+                <button
+                    type="button"
+                    onClick={() => onModeChange('people')}
+                    className={`flex-1 py-2.5 px-3 rounded-full font-medium text-sm whitespace-nowrap transition-colors ${
+                        mode === 'people'
+                            ? 'bg-grayscale-900 text-white shadow-sm'
+                            : 'text-grayscale-700 hover:bg-grayscale-200'
+                    }`}
+                >
+                    Friend
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onModeChange('self')}
+                    className={`flex-1 py-2.5 px-3 rounded-full font-medium text-sm whitespace-nowrap transition-colors ${
+                        mode === 'self'
+                            ? 'bg-grayscale-900 text-white shadow-sm'
+                            : 'text-grayscale-700 hover:bg-grayscale-200'
+                    }`}
+                >
+                    Just me
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onModeChange('link')}
+                    className={`flex-1 py-2.5 px-3 rounded-full font-medium text-sm whitespace-nowrap transition-colors ${
+                        mode === 'link'
+                            ? 'bg-grayscale-900 text-white shadow-sm'
+                            : 'text-grayscale-700 hover:bg-grayscale-200'
+                    }`}
+                >
+                    Share link
+                </button>
+            </div>
+
+            {mode === 'people' && (
+                <div className="flex flex-col flex-1 min-h-0 animate-fade-in-up">
+                    {recipients.length > 0 && (
+                        <div className="flex flex-wrap gap-2 mb-4 shrink-0">
+                            {recipients.map((recipient, index) => (
+                                <span
+                                    key={index}
+                                    className="flex items-center gap-1.5 py-1.5 pl-2 pr-3 rounded-full bg-grayscale-900 text-white text-sm"
+                                >
+                                    {recipient.kind === 'profile' ? (
+                                        <Avatar
+                                            image={recipient.image}
+                                            name={recipient.displayName}
+                                            sizeClass="w-5 h-5"
+                                            fallbackClass="bg-grayscale-700 text-white text-[10px]"
+                                        />
+                                    ) : (
+                                        <Mail className="w-4 h-4 text-grayscale-400" />
+                                    )}
+                                    <span className="truncate max-w-[180px]">
+                                        {recipient.kind === 'profile'
+                                            ? recipient.displayName
+                                            : recipient.email}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleRemoveRecipient(index)}
+                                        className="text-white/70 hover:text-white transition-colors shrink-0 ml-1"
+                                        aria-label="Remove recipient"
+                                    >
+                                        <X className="w-3.5 h-3.5" />
+                                    </button>
+                                </span>
+                            ))}
+                        </div>
+                    )}
+
+                    <div className="relative mb-4 shrink-0">
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400" />
+                        <input
+                            type="text"
+                            value={query}
+                            onChange={e => setQuery(e.target.value)}
+                            placeholder="Search people..."
+                            spellCheck={false}
+                            autoCapitalize="none"
+                            autoCorrect="off"
+                            className="w-full py-3.5 pl-12 pr-10 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
+                        />
+                        {query && (
+                            <button
+                                type="button"
+                                onClick={() => setQuery('')}
+                                className="absolute right-4 top-1/2 -translate-y-1/2 text-grayscale-400 hover:text-grayscale-700 transition-colors"
+                                aria-label="Clear search"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto scrollbar-hide -mx-2 px-2">
+                        {isSearching || isConnectionsLoading ? (
+                            <div className="flex items-center justify-center p-8 text-grayscale-500">
+                                <Loader2 className="w-6 h-6 animate-spin" />
+                            </div>
+                        ) : (
+                            <div className="space-y-1 pb-4">
+                                {displayList.map(profile => {
+                                    const isSelected = recipients.some(
+                                        r =>
+                                            r.kind === 'profile' &&
+                                            r.profileId === profile.profileId
+                                    );
+                                    return (
+                                        <button
+                                            key={profile.profileId}
+                                            type="button"
+                                            onClick={() =>
+                                                handleToggleRecipient({
+                                                    kind: 'profile',
+                                                    profileId: profile.profileId,
+                                                    displayName:
+                                                        profile.displayName || profile.profileId,
+                                                    image: profile.image,
+                                                    did: profile.did,
+                                                })
+                                            }
+                                            className={`w-full flex items-center gap-3 p-3 rounded-2xl transition-all text-left ${
+                                                isSelected
+                                                    ? 'bg-emerald-50 ring-1 ring-emerald-200'
+                                                    : 'hover:bg-grayscale-10'
+                                            }`}
+                                        >
+                                            <Avatar
+                                                image={profile.image}
+                                                name={profile.displayName || profile.profileId}
+                                                sizeClass="w-10 h-10"
+                                                fallbackClass="bg-grayscale-200 text-grayscale-600"
+                                            />
+                                            <div className="flex flex-col min-w-0 flex-1">
+                                                <span className="text-base font-medium text-grayscale-900 truncate">
+                                                    {profile.displayName || profile.profileId}
+                                                </span>
+                                                {profile.profileId &&
+                                                    profile.profileId !== profile.displayName && (
+                                                        <span className="text-sm text-grayscale-500 truncate">
+                                                            @{profile.profileId}
+                                                        </span>
+                                                    )}
+                                            </div>
+                                            {isSelected && (
+                                                <div className="w-6 h-6 rounded-full bg-emerald-500 flex items-center justify-center shrink-0">
+                                                    <Check className="w-3.5 h-3.5 text-white" />
+                                                </div>
+                                            )}
+                                        </button>
+                                    );
+                                })}
+
+                                {isValidEmail &&
+                                    !displayList.some(
+                                        p => p.profileId === query || p.displayName === query
+                                    ) && (
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                handleToggleRecipient({
+                                                    kind: 'email',
+                                                    email: query,
+                                                });
+                                                setQuery('');
+                                            }}
+                                            className="w-full flex items-center gap-3 p-3 rounded-2xl hover:bg-grayscale-10 transition-all text-left"
+                                        >
+                                            <div className="w-10 h-10 rounded-full bg-emerald-50 flex items-center justify-center text-emerald-600 shrink-0">
+                                                <Mail className="w-5 h-5" />
+                                            </div>
+                                            <div className="flex flex-col min-w-0 flex-1">
+                                                <span className="text-base font-medium text-grayscale-900 truncate">
+                                                    Send to {query}
+                                                </span>
+                                                <span className="text-sm text-grayscale-500 truncate">
+                                                    They'll get an email to claim it
+                                                </span>
+                                            </div>
+                                        </button>
+                                    )}
+
+                                {displayList.length === 0 && !isValidEmail && (
+                                    <div className="p-8 text-center text-sm text-grayscale-500">
+                                        {debouncedQuery.length > 0
+                                            ? 'No results found. Enter a valid email to send an invite.'
+                                            : 'Search for someone by name, @username, or email.'}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {mode === 'self' && (
+                <div className="flex-1 flex flex-col items-center justify-center text-center animate-fade-in-up pb-10">
+                    <div className="w-16 h-16 bg-grayscale-100 rounded-full flex items-center justify-center mb-4">
+                        <Check className="w-8 h-8 text-grayscale-900" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-grayscale-900 mb-2">
+                        Add to Passport
+                    </h3>
+                    <p className="text-sm text-grayscale-600 max-w-[240px]">
+                        This badge will be added directly to your own Passport.
+                    </p>
+                </div>
+            )}
+
+            {mode === 'link' && (
+                <div className="flex-1 animate-fade-in-up">
+                    <p className="text-sm text-grayscale-600 mb-6">
+                        Anyone with the link can claim this badge.
+                    </p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <label className={LABEL_CLASS}>Expires (optional)</label>
+                            <div className="relative">
+                                <input
+                                    type="date"
+                                    value={linkOptions.expiresAt || ''}
+                                    onChange={e =>
+                                        onLinkOptionsChange({
+                                            ...linkOptions,
+                                            expiresAt: e.target.value,
+                                        })
+                                    }
+                                    className={`${INPUT_CLASS} appearance-none pr-10 [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:inset-0 [&::-webkit-calendar-picker-indicator]:w-full [&::-webkit-calendar-picker-indicator]:h-full [&::-webkit-calendar-picker-indicator]:cursor-pointer`}
+                                />
+                                <Calendar className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-grayscale-400 pointer-events-none" />
+                            </div>
+                        </div>
+                        <div>
+                            <label className={LABEL_CLASS}>Max claims (optional)</label>
+                            <input
+                                type="number"
+                                min="1"
+                                value={linkOptions.maxClaims || ''}
+                                onChange={e =>
+                                    onLinkOptionsChange({
+                                        ...linkOptions,
+                                        maxClaims: e.target.value
+                                            ? parseInt(e.target.value, 10)
+                                            : undefined,
+                                    })
+                                }
+                                placeholder="Unlimited"
+                                className={INPUT_CLASS}
+                            />
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/apps/learn-card-app/src/pages/boostAFriend/components/BoostRecipientPicker.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/components/BoostRecipientPicker.tsx
@@ -116,7 +116,7 @@ export const BoostRecipientPicker: React.FC<BoostRecipientPickerProps> = ({
 
     return (
         <div className="flex flex-col h-full">
-            <div className="flex gap-1 sm:gap-2 bg-grayscale-100 p-1 rounded-full mb-6 shrink-0">
+            <div className="flex gap-1 sm:gap-2 bg-grayscale-200 p-1 rounded-full mb-6 shrink-0">
                 <button
                     type="button"
                     onClick={() => onModeChange('people')}

--- a/apps/learn-card-app/src/pages/dashboard/components/DashboardHeaderCard.tsx
+++ b/apps/learn-card-app/src/pages/dashboard/components/DashboardHeaderCard.tsx
@@ -56,17 +56,29 @@ const DashboardHeaderCard: React.FC<DashboardHeaderCardProps> = ({
     const descriptor = resolveDescriptor(professionalTitle, shortBio);
     const roleFallback = profileRole?.trim() ? capitalize(profileRole) : null;
 
-    const avatar = profileImage ? (
-        <img
-            src={profileImage}
-            alt={displayName || 'Profile'}
-            className="w-16 h-16 rounded-full object-cover border-2 border-white shadow-soft-bottom"
-        />
-    ) : (
+    const [imageFailed, setImageFailed] = React.useState(false);
+
+    React.useEffect(() => {
+        setImageFailed(false);
+    }, [profileImage]);
+
+    const initialsAvatar = (
         <div className="w-16 h-16 rounded-full bg-grayscale-100 border-2 border-white shadow-soft-bottom flex items-center justify-center text-grayscale-700 font-semibold text-lg">
             {initials}
         </div>
     );
+
+    const avatar =
+        profileImage && !imageFailed ? (
+            <img
+                src={profileImage}
+                alt={displayName || 'Profile'}
+                onError={() => setImageFailed(true)}
+                className="w-16 h-16 rounded-full object-cover border-2 border-white shadow-soft-bottom bg-grayscale-100"
+            />
+        ) : (
+            initialsAvatar
+        );
 
     return (
         <section className="relative bg-white rounded-[20px] shadow-soft-bottom border border-grayscale-200 animate-fade-in-up overflow-hidden">

--- a/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
+++ b/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
@@ -136,6 +136,74 @@ const CATEGORY_OPTIONS: { value: string; displayText: string; description: strin
 
 const HEX_INPUT_REGEX = /[^0-9a-fA-F]/g;
 
+const ColorField: React.FC<{
+    label: string;
+    value?: string;
+    placeholder?: string;
+    hint?: string;
+    onChange: (hex: string | undefined) => void;
+}> = ({ label, value, placeholder = '353E64', hint, onChange }) => {
+    const [text, setText] = useState((value ?? '').replace(/^#/, ''));
+    useEffect(() => setText((value ?? '').replace(/^#/, '')), [value]);
+
+    const handleHex = (raw: string) => {
+        const cleaned = raw.replace(HEX_INPUT_REGEX, '').slice(0, 8).toUpperCase();
+        setText(cleaned);
+        if ([3, 6, 8].includes(cleaned.length)) onChange(`#${cleaned}`);
+        else if (cleaned.length === 0) onChange(undefined);
+    };
+
+    const swatch = /^#[0-9a-fA-F]{6}$/.test(value ?? '') ? (value as string) : '#FFFFFF';
+
+    return (
+        <div>
+            <label className={LABEL_CLASS}>{label}</label>
+            <div className="flex items-center gap-3">
+                <label className="relative h-11 w-11 shrink-0 rounded-xl border border-grayscale-300 overflow-hidden cursor-pointer shadow-sm hover:ring-2 hover:ring-emerald-500 transition-all">
+                    <span
+                        className="absolute inset-0"
+                        style={{ backgroundColor: value ?? '#FFFFFF' }}
+                    />
+                    <input
+                        type="color"
+                        value={swatch}
+                        onChange={e => onChange(e.target.value)}
+                        className="absolute inset-0 opacity-0 cursor-pointer"
+                    />
+                </label>
+                <div className="relative flex-1">
+                    <span className="absolute left-4 top-1/2 -translate-y-1/2 text-grayscale-400 text-base pointer-events-none select-none">
+                        #
+                    </span>
+                    <input
+                        type="text"
+                        value={text}
+                        onChange={e => handleHex(e.target.value)}
+                        placeholder={placeholder}
+                        maxLength={8}
+                        spellCheck={false}
+                        className="w-full py-3 pl-8 pr-10 border border-grayscale-300 rounded-xl text-base text-grayscale-900 uppercase tracking-wide placeholder:text-grayscale-400 placeholder:normal-case focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
+                    />
+                    {text && (
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setText('');
+                                onChange(undefined);
+                            }}
+                            aria-label={`Clear ${label.toLowerCase()}`}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-grayscale-400 hover:text-grayscale-700 transition-colors"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
+                    )}
+                </div>
+            </div>
+            {hint && <p className="mt-1.5 text-xs text-grayscale-400 leading-relaxed">{hint}</p>}
+        </div>
+    );
+};
+
 interface IssuePaletteProps {
     selectedType: CredentialTypeEntry | null;
     template: OBv3CredentialTemplate | null;
@@ -227,30 +295,6 @@ export const IssuePalette: React.FC<IssuePaletteProps> = ({
         resizeBeforeUploading: true,
         onUpload: (url: string) => setHints({ backgroundImage: url }),
     });
-
-    // Buffer the hex text locally: buildLcTags drops invalid-length hex, so binding the input straight to the tag would erase digits mid-typing.
-    const [colorText, setColorText] = useState((hints.backgroundColor ?? '').replace(/^#/, ''));
-    useEffect(() => {
-        setColorText((hints.backgroundColor ?? '').replace(/^#/, ''));
-    }, [hints.backgroundColor]);
-
-    const handleHexChange = (raw: string) => {
-        const cleaned = raw.replace(HEX_INPUT_REGEX, '').slice(0, 8).toUpperCase();
-        setColorText(cleaned);
-        if ([3, 6, 8].includes(cleaned.length)) setHints({ backgroundColor: `#${cleaned}` });
-        else if (cleaned.length === 0) setHints({ backgroundColor: undefined });
-    };
-
-    const handleSwatchChange = (value: string) => setHints({ backgroundColor: value });
-
-    const handleClearColor = () => {
-        setColorText('');
-        setHints({ backgroundColor: undefined });
-    };
-
-    const swatchValue = /^#[0-9a-fA-F]{6}$/.test(hints.backgroundColor ?? '')
-        ? (hints.backgroundColor as string)
-        : '#FFFFFF';
 
     const name = ach?.name?.value ?? '';
     const nameInvalid = nameTouched && !ach?.name?.isDynamic && !name.trim();
@@ -494,52 +538,18 @@ export const IssuePalette: React.FC<IssuePaletteProps> = ({
                                         />
                                     </div>
 
-                                    <div>
-                                        <label className={LABEL_CLASS}>Background color</label>
-                                        <div className="flex items-center gap-3">
-                                            <label className="relative h-11 w-11 shrink-0 rounded-xl border border-grayscale-300 overflow-hidden cursor-pointer shadow-sm hover:ring-2 hover:ring-emerald-500 transition-all">
-                                                <span
-                                                    className="absolute inset-0"
-                                                    style={{
-                                                        backgroundColor:
-                                                            hints.backgroundColor ?? '#FFFFFF',
-                                                    }}
-                                                />
-                                                <input
-                                                    type="color"
-                                                    value={swatchValue}
-                                                    onChange={e =>
-                                                        handleSwatchChange(e.target.value)
-                                                    }
-                                                    className="absolute inset-0 opacity-0 cursor-pointer"
-                                                />
-                                            </label>
-                                            <div className="relative flex-1">
-                                                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-grayscale-400 text-base pointer-events-none select-none">
-                                                    #
-                                                </span>
-                                                <input
-                                                    type="text"
-                                                    value={colorText}
-                                                    onChange={e => handleHexChange(e.target.value)}
-                                                    placeholder="353E64"
-                                                    maxLength={8}
-                                                    spellCheck={false}
-                                                    className="w-full py-3 pl-8 pr-10 border border-grayscale-300 rounded-xl text-base text-grayscale-900 uppercase tracking-wide placeholder:text-grayscale-400 placeholder:normal-case focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
-                                                />
-                                                {colorText && (
-                                                    <button
-                                                        type="button"
-                                                        onClick={handleClearColor}
-                                                        aria-label="Clear color"
-                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-grayscale-400 hover:text-grayscale-700 transition-colors"
-                                                    >
-                                                        <X className="w-4 h-4" />
-                                                    </button>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <ColorField
+                                        label="Background color"
+                                        value={hints.backgroundColor}
+                                        onChange={c => setHints({ backgroundColor: c })}
+                                    />
+
+                                    <ColorField
+                                        label="Accent color (badge ring)"
+                                        value={hints.accentColor}
+                                        hint="Colors the badge ring. Defaults to the category color if unset."
+                                        onChange={c => setHints({ accentColor: c })}
+                                    />
 
                                     <div>
                                         <label className={LABEL_CLASS}>Background image</label>

--- a/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
+++ b/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
@@ -1,7 +1,14 @@
-import React, { useCallback, useState } from 'react';
-import { ImagePlus, Loader2, SlidersHorizontal, ChevronDown } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ImagePlus, Loader2, SlidersHorizontal, ChevronDown, X } from 'lucide-react';
 
-import { useFilestack } from 'learn-card-base';
+import {
+    useFilestack,
+    SelectInput,
+    parseLcTags,
+    buildLcTags,
+    DisplayTypeEnum,
+} from 'learn-card-base';
+import type { LcDisplayHints } from 'learn-card-base';
 import { isPlausibleRecipient } from './recipientValidation';
 import { RecipientPicker } from './RecipientPicker';
 import { RecipientMode, Recipient, LinkOptions } from './recipientTypes';
@@ -31,6 +38,103 @@ const INPUT_CLASS =
     'w-full py-3 px-4 border border-grayscale-300 rounded-xl text-base text-grayscale-900 placeholder:text-grayscale-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all';
 const LABEL_CLASS = 'block text-xs font-medium text-grayscale-700 mb-1.5';
 const CARD_CLASS = 'bg-white border border-grayscale-200 rounded-[20px] p-5';
+
+const DISPLAY_TYPE_OPTIONS: {
+    value: DisplayTypeEnum;
+    displayText: string;
+    description: string;
+}[] = [
+    {
+        value: DisplayTypeEnum.Badge,
+        displayText: 'Badge',
+        description: 'A circular emblem with a ribbon. Best for social badges and achievements.',
+    },
+    {
+        value: DisplayTypeEnum.Certificate,
+        displayText: 'Certificate',
+        description: 'A formal, document-style frame. Good for completions and certifications.',
+    },
+    {
+        value: DisplayTypeEnum.Award,
+        displayText: 'Award',
+        description: 'A trophy-style ribbon that emphasizes recognition and honors.',
+    },
+    {
+        value: DisplayTypeEnum.ID,
+        displayText: 'ID card',
+        description: 'A wallet-style ID layout with photo and issuer. Great for memberships.',
+    },
+    {
+        value: DisplayTypeEnum.Course,
+        displayText: 'Course',
+        description: 'Tuned for courses, classes, and learning programs.',
+    },
+    {
+        value: DisplayTypeEnum.Media,
+        displayText: 'Media',
+        description: 'A rich tile that showcases an image or video front-and-center.',
+    },
+];
+
+const CATEGORY_OPTIONS: { value: string; displayText: string; description: string }[] = [
+    {
+        value: 'Achievement',
+        displayText: 'Achievement',
+        description: 'Awards, certificates, and accomplishments.',
+    },
+    {
+        value: 'Social Badge',
+        displayText: 'Social Badge',
+        description: 'Community and social recognition badges.',
+    },
+    {
+        value: 'ID',
+        displayText: 'ID',
+        description: 'Identity cards and official credentials.',
+    },
+    {
+        value: 'Membership',
+        displayText: 'Membership',
+        description: 'Group, club, or organization membership.',
+    },
+    {
+        value: 'Work History',
+        displayText: 'Work History',
+        description: 'Jobs, internships, and professional experience.',
+    },
+    {
+        value: 'Learning History',
+        displayText: 'Learning History',
+        description: 'Courses, classes, and learning programs.',
+    },
+    {
+        value: 'Course',
+        displayText: 'Course',
+        description: 'A single course or class.',
+    },
+    {
+        value: 'Skill',
+        displayText: 'Skill',
+        description: 'Demonstrated skills and competencies.',
+    },
+    {
+        value: 'Accomplishment',
+        displayText: 'Accomplishment',
+        description: 'Portfolio pieces and personal accomplishments.',
+    },
+    {
+        value: 'Accommodation',
+        displayText: 'Accommodation',
+        description: 'Support needs and accommodations.',
+    },
+    {
+        value: 'Family',
+        displayText: 'Family',
+        description: 'Family and relationship credentials.',
+    },
+];
+
+const HEX_INPUT_REGEX = /[^0-9a-fA-F]/g;
 
 interface IssuePaletteProps {
     selectedType: CredentialTypeEntry | null;
@@ -106,6 +210,47 @@ export const IssuePalette: React.FC<IssuePaletteProps> = ({
         resizeBeforeUploading: true,
         onUpload: (url: string) => patchAchievement({ image: staticField(url) }),
     });
+
+    // Display hints are a projection of the OBv3 `achievement.tag` array (`lc:` convention); non-`lc:` tags are preserved on write.
+    const hints = parseLcTags(ach?.tag);
+
+    const setHints = useCallback(
+        (patch: Partial<LcDisplayHints>) => {
+            const nonLcTags = (ach?.tag ?? []).filter(t => !t.toLowerCase().startsWith('lc:'));
+            patchAchievement({ tag: [...nonLcTags, ...buildLcTags({ ...hints, ...patch })] });
+        },
+        [ach, hints, patchAchievement]
+    );
+
+    const { handleFileSelect: handleBgSelect, isLoading: bgUploading } = useFilestack({
+        fileType: 'image/*',
+        resizeBeforeUploading: true,
+        onUpload: (url: string) => setHints({ backgroundImage: url }),
+    });
+
+    // Buffer the hex text locally: buildLcTags drops invalid-length hex, so binding the input straight to the tag would erase digits mid-typing.
+    const [colorText, setColorText] = useState((hints.backgroundColor ?? '').replace(/^#/, ''));
+    useEffect(() => {
+        setColorText((hints.backgroundColor ?? '').replace(/^#/, ''));
+    }, [hints.backgroundColor]);
+
+    const handleHexChange = (raw: string) => {
+        const cleaned = raw.replace(HEX_INPUT_REGEX, '').slice(0, 8).toUpperCase();
+        setColorText(cleaned);
+        if ([3, 6, 8].includes(cleaned.length)) setHints({ backgroundColor: `#${cleaned}` });
+        else if (cleaned.length === 0) setHints({ backgroundColor: undefined });
+    };
+
+    const handleSwatchChange = (value: string) => setHints({ backgroundColor: value });
+
+    const handleClearColor = () => {
+        setColorText('');
+        setHints({ backgroundColor: undefined });
+    };
+
+    const swatchValue = /^#[0-9a-fA-F]{6}$/.test(hints.backgroundColor ?? '')
+        ? (hints.backgroundColor as string)
+        : '#FFFFFF';
 
     const name = ach?.name?.value ?? '';
     const nameInvalid = nameTouched && !ach?.name?.isDynamic && !name.trim();
@@ -295,6 +440,144 @@ export const IssuePalette: React.FC<IssuePaletteProps> = ({
                                     </span>
                                     section.
                                 </p>
+
+                                <div className="pt-4 mt-4 border-t border-grayscale-200 space-y-4">
+                                    <h4 className="text-sm font-semibold text-grayscale-900">
+                                        Display (optional)
+                                    </h4>
+                                    <p className="text-xs text-grayscale-400 leading-relaxed">
+                                        Fine-tune how this credential looks. Wallets that don’t
+                                        support these hints simply ignore them.
+                                    </p>
+
+                                    <div>
+                                        <label className={LABEL_CLASS}>Category</label>
+                                        <SelectInput
+                                            value={hints.category ?? null}
+                                            onChange={value =>
+                                                setHints({
+                                                    category: (value as string) || undefined,
+                                                })
+                                            }
+                                            allowDeselect
+                                            placeholder="Automatic (based on type)"
+                                            options={CATEGORY_OPTIONS}
+                                        />
+                                    </div>
+
+                                    <div>
+                                        <label className={LABEL_CLASS}>Subtype label</label>
+                                        <input
+                                            type="text"
+                                            value={hints.subtype ?? ''}
+                                            onChange={e =>
+                                                setHints({ subtype: e.target.value || undefined })
+                                            }
+                                            placeholder="e.g. Trailblazer"
+                                            className={INPUT_CLASS}
+                                        />
+                                    </div>
+
+                                    <div>
+                                        <label className={LABEL_CLASS}>Display style</label>
+                                        <SelectInput
+                                            value={hints.displayType ?? null}
+                                            onChange={value =>
+                                                setHints({
+                                                    displayType:
+                                                        (value as DisplayTypeEnum) || undefined,
+                                                })
+                                            }
+                                            allowDeselect
+                                            placeholder="Automatic (based on type)"
+                                            options={DISPLAY_TYPE_OPTIONS}
+                                        />
+                                    </div>
+
+                                    <div>
+                                        <label className={LABEL_CLASS}>Background color</label>
+                                        <div className="flex items-center gap-3">
+                                            <label className="relative h-11 w-11 shrink-0 rounded-xl border border-grayscale-300 overflow-hidden cursor-pointer shadow-sm hover:ring-2 hover:ring-emerald-500 transition-all">
+                                                <span
+                                                    className="absolute inset-0"
+                                                    style={{
+                                                        backgroundColor:
+                                                            hints.backgroundColor ?? '#FFFFFF',
+                                                    }}
+                                                />
+                                                <input
+                                                    type="color"
+                                                    value={swatchValue}
+                                                    onChange={e =>
+                                                        handleSwatchChange(e.target.value)
+                                                    }
+                                                    className="absolute inset-0 opacity-0 cursor-pointer"
+                                                />
+                                            </label>
+                                            <div className="relative flex-1">
+                                                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-grayscale-400 text-base pointer-events-none select-none">
+                                                    #
+                                                </span>
+                                                <input
+                                                    type="text"
+                                                    value={colorText}
+                                                    onChange={e => handleHexChange(e.target.value)}
+                                                    placeholder="353E64"
+                                                    maxLength={8}
+                                                    spellCheck={false}
+                                                    className="w-full py-3 pl-8 pr-10 border border-grayscale-300 rounded-xl text-base text-grayscale-900 uppercase tracking-wide placeholder:text-grayscale-400 placeholder:normal-case focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white transition-all"
+                                                />
+                                                {colorText && (
+                                                    <button
+                                                        type="button"
+                                                        onClick={handleClearColor}
+                                                        aria-label="Clear color"
+                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-grayscale-400 hover:text-grayscale-700 transition-colors"
+                                                    >
+                                                        <X className="w-4 h-4" />
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div>
+                                        <label className={LABEL_CLASS}>Background image</label>
+                                        {hints.backgroundImage && (
+                                            <div className="mb-2 flex items-center gap-3">
+                                                <img
+                                                    src={hints.backgroundImage}
+                                                    alt="Background preview"
+                                                    className="h-12 w-12 rounded-xl object-cover border border-grayscale-200"
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        setHints({ backgroundImage: undefined })
+                                                    }
+                                                    className="text-sm text-grayscale-600 hover:text-grayscale-900 transition-colors"
+                                                >
+                                                    Remove
+                                                </button>
+                                            </div>
+                                        )}
+                                        <button
+                                            type="button"
+                                            onClick={e => handleBgSelect(e as any)}
+                                            disabled={bgUploading}
+                                            className="w-full py-3 px-4 rounded-xl border border-grayscale-300 text-grayscale-700 font-medium text-sm hover:bg-grayscale-10 transition-colors flex items-center justify-center gap-2 disabled:opacity-40"
+                                        >
+                                            {bgUploading ? (
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                            ) : (
+                                                <ImagePlus className="w-4 h-4" />
+                                            )}
+                                            {hints.backgroundImage
+                                                ? 'Change background image'
+                                                : 'Add a background image'}
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
                         )}
                     </section>

--- a/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
+++ b/apps/learn-card-app/src/pages/issue/components/IssuePalette.tsx
@@ -78,59 +78,39 @@ const DISPLAY_TYPE_OPTIONS: {
 
 const CATEGORY_OPTIONS: { value: string; displayText: string; description: string }[] = [
     {
+        value: 'Social Badge',
+        displayText: 'Badge',
+        description: 'Community and social recognition badges.',
+    },
+    {
         value: 'Achievement',
         displayText: 'Achievement',
         description: 'Awards, certificates, and accomplishments.',
     },
     {
-        value: 'Social Badge',
-        displayText: 'Social Badge',
-        description: 'Community and social recognition badges.',
+        value: 'Learning History',
+        displayText: 'Course',
+        description: 'Courses, classes, and learning programs.',
+    },
+    {
+        value: 'Accomplishment',
+        displayText: 'Portfolio',
+        description: 'Portfolio pieces and personal work.',
+    },
+    {
+        value: 'Accommodation',
+        displayText: 'Assistance',
+        description: 'Support needs and accommodations.',
+    },
+    {
+        value: 'Work History',
+        displayText: 'Experience',
+        description: 'Jobs, internships, and professional experience.',
     },
     {
         value: 'ID',
         displayText: 'ID',
         description: 'Identity cards and official credentials.',
-    },
-    {
-        value: 'Membership',
-        displayText: 'Membership',
-        description: 'Group, club, or organization membership.',
-    },
-    {
-        value: 'Work History',
-        displayText: 'Work History',
-        description: 'Jobs, internships, and professional experience.',
-    },
-    {
-        value: 'Learning History',
-        displayText: 'Learning History',
-        description: 'Courses, classes, and learning programs.',
-    },
-    {
-        value: 'Course',
-        displayText: 'Course',
-        description: 'A single course or class.',
-    },
-    {
-        value: 'Skill',
-        displayText: 'Skill',
-        description: 'Demonstrated skills and competencies.',
-    },
-    {
-        value: 'Accomplishment',
-        displayText: 'Accomplishment',
-        description: 'Portfolio pieces and personal accomplishments.',
-    },
-    {
-        value: 'Accommodation',
-        displayText: 'Accommodation',
-        description: 'Support needs and accommodations.',
-    },
-    {
-        value: 'Family',
-        displayText: 'Family',
-        description: 'Family and relationship credentials.',
     },
 ];
 

--- a/apps/learn-card-app/src/pages/issue/components/recipientTypes.ts
+++ b/apps/learn-card-app/src/pages/issue/components/recipientTypes.ts
@@ -18,3 +18,21 @@ export const recipientKey = (recipient: Recipient): string =>
 
 export const recipientLabel = (recipient: Recipient): string =>
     recipient.kind === 'profile' ? recipient.displayName : recipient.email;
+
+export const prettifyEmailName = (email: string): string => {
+    const local = email.split('@')[0]?.split('+')[0] ?? '';
+    const words = local.replace(/[._-]+/g, ' ').trim();
+    if (!words) return email;
+    return words.replace(/\b\w/g, char => char.toUpperCase());
+};
+
+export const recipientDisplayName = (recipient: Recipient): string =>
+    recipient.kind === 'profile' ? recipient.displayName : prettifyEmailName(recipient.email);
+
+export const summarizeRecipients = (recipients: Recipient[]): string => {
+    const names = recipients.map(recipientDisplayName).filter(Boolean);
+    if (names.length === 0) return 'the recipient';
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return `${names[0]} and ${names[1]}`;
+    return `${names[0]}, ${names[1]} and ${names.length - 2} others`;
+};

--- a/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
+++ b/apps/learn-card-app/src/pages/myApps/MyAppsLanding.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { IonPage, IonContent } from '@ionic/react';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { useDeviceTypeByWidth } from 'learn-card-base';
 
 import Search from 'learn-card-base/svgs/Search';
@@ -40,6 +41,15 @@ const MyAppsLanding: React.FC = () => {
     const { apps: moreApps, isSuggested, isLoading: isLoadingMore } = useMoreApps();
     const [searchInput, setSearchInput] = useState('');
     const pathwaysEnabled = usePathwaysEnabled();
+    const flags = useFlags();
+
+    const openBoostAFriend = useMemo(
+        () => () => {
+            if (flags?.boostAFriendV2 === true) history.push('/boost-a-friend');
+            else openBoost();
+        },
+        [flags?.boostAFriendV2, history, openBoost]
+    );
 
     const shortcuts = useMemo(
         () =>
@@ -61,8 +71,8 @@ const MyAppsLanding: React.FC = () => {
     }, [hasDeepLink, search, history]);
 
     const helpers = useMemo(
-        () => ({ push: (path: string) => history.push(path), openBoost }),
-        [history, openBoost]
+        () => ({ push: (path: string) => history.push(path), openBoost, openBoostAFriend }),
+        [history, openBoost, openBoostAFriend]
     );
 
     const query = searchInput.trim().toLowerCase();

--- a/apps/learn-card-app/src/pages/myApps/learnCardAppShortcuts.tsx
+++ b/apps/learn-card-app/src/pages/myApps/learnCardAppShortcuts.tsx
@@ -17,6 +17,7 @@ import DataSharingTileIcon from './icons/DataSharingTileIcon';
 export type ShortcutActionHelpers = {
     push: (path: string) => void;
     openBoost: () => void;
+    openBoostAFriend: () => void;
 };
 
 export type LearnCardAppShortcut = {
@@ -120,6 +121,6 @@ export const LEARNCARD_APP_SHORTCUTS: LearnCardAppShortcut[] = [
         gradientFrom: '#93C5FD',
         gradientTo: '#3B82F6',
         Icon: BoostsIconWithShape,
-        getAction: h => () => h.openBoost(),
+        getAction: h => () => h.openBoostAFriend(),
     },
 ];

--- a/apps/learn-card-app/src/registries/badge-groups/badge-summit.json
+++ b/apps/learn-card-app/src/registries/badge-groups/badge-summit.json
@@ -1,0 +1,38 @@
+[
+    {
+        "id": "summit-social",
+        "label": "Summit Social",
+        "description": "For the people who make the community feel alive.",
+        "order": 7,
+        "types": [
+            "ext:VibeCurator",
+            "ext:ChaosCoordinator",
+            "ext:HypeArchitect",
+            "ext:LoreKeeper",
+            "ext:SideQuestSpecialist",
+            "ext:QuietGenius",
+            "ext:CommunityHelper",
+            "ext:FoodSniper",
+            "ext:VisualStoryteller",
+            "ext:LogicMaster"
+        ]
+    },
+    {
+        "id": "summit-standards",
+        "label": "Standards & Interop",
+        "description": "For the ones who keep credentials clean, aligned, and verifiable.",
+        "order": 8,
+        "types": [
+            "ext:SchemaWhisperer",
+            "ext:AlignmentWizard",
+            "ext:CLRCartographer",
+            "ext:VerifiableVibes",
+            "ext:BadgeGoblin",
+            "ext:MetadataMystic",
+            "ext:InteropDiplomat",
+            "ext:BackpackElder",
+            "ext:IssuerTherapist",
+            "ext:SpecGremlin"
+        ]
+    }
+]

--- a/apps/learn-card-app/src/registries/badge-groups/badge-summit.json
+++ b/apps/learn-card-app/src/registries/badge-groups/badge-summit.json
@@ -3,7 +3,7 @@
         "id": "summit-social",
         "label": "Summit Social",
         "description": "For the people who make the community feel alive.",
-        "order": 7,
+        "order": -2,
         "types": [
             "ext:VibeCurator",
             "ext:ChaosCoordinator",
@@ -21,7 +21,7 @@
         "id": "summit-standards",
         "label": "Standards & Interop",
         "description": "For the ones who keep credentials clean, aligned, and verifiable.",
-        "order": 8,
+        "order": -1,
         "types": [
             "ext:SchemaWhisperer",
             "ext:AlignmentWizard",

--- a/apps/learn-card-app/src/registries/badge-groups/learncard.json
+++ b/apps/learn-card-app/src/registries/badge-groups/learncard.json
@@ -1,0 +1,91 @@
+[
+    {
+        "id": "leaders",
+        "label": "Leaders & Changemakers",
+        "description": "For the ones who move everyone forward.",
+        "order": 1,
+        "types": [
+            "ext:Leader",
+            "ext:Trailblazer",
+            "ext:Catalyst",
+            "ext:ChangeMaker",
+            "ext:Ambassador",
+            "ext:Organizer",
+            "ext:Moderator"
+        ]
+    },
+    {
+        "id": "mastery",
+        "label": "Brains & Mastery",
+        "description": "For deep skill and know-how.",
+        "order": 2,
+        "types": [
+            "ext:Expert",
+            "ext:Maven",
+            "ext:Sage",
+            "ext:Aficionado",
+            "ext:Connoisseur",
+            "ext:Perfectionist",
+            "ext:Psychic",
+            "ext:Magician"
+        ]
+    },
+    {
+        "id": "heart",
+        "label": "Heart & Team",
+        "description": "For the glue that holds people together.",
+        "order": 3,
+        "types": [
+            "ext:Connector",
+            "ext:TeamPlayer",
+            "ext:Enabler",
+            "ext:Charmer",
+            "ext:Enthusiast",
+            "ext:Promoter"
+        ]
+    },
+    {
+        "id": "bold",
+        "label": "Bold & Adventurous",
+        "description": "For the fearless and the first.",
+        "order": 4,
+        "types": [
+            "ext:Risktaker",
+            "ext:Maverick",
+            "ext:Cowboy",
+            "ext:Wanderer",
+            "ext:Opportunist",
+            "ext:Challenger",
+            "ext:ChallengeMaker"
+        ]
+    },
+    {
+        "id": "culture",
+        "label": "Culture & Cool",
+        "description": "For taste, trends, and star power.",
+        "order": 5,
+        "types": [
+            "ext:CoolCat",
+            "ext:Tastemaker",
+            "ext:Trendsetter",
+            "ext:Influencer",
+            "ext:Star",
+            "ext:HotShot",
+            "ext:Informer",
+            "ext:Propagator"
+        ]
+    },
+    {
+        "id": "fun",
+        "label": "Fun & Energy",
+        "description": "For the life of the party.",
+        "order": 6,
+        "types": [
+            "ext:PartyAnimal",
+            "ext:PartyPlanner",
+            "ext:Entertainer",
+            "ext:TroubleMaker",
+            "ext:Doer"
+        ]
+    }
+]

--- a/apps/learn-card-app/src/registries/style-packs/badge-summit.json
+++ b/apps/learn-card-app/src/registries/style-packs/badge-summit.json
@@ -1,0 +1,182 @@
+[
+    {
+        "category": "Social Badge",
+        "type": "ext:VibeCurator",
+        "title": "Vibe Curator",
+        "url": "",
+        "backgroundColor": "#8B5CF6",
+        "description": "Reserved for the community members who know exactly how to make a room feel better, warmer, stranger, or more alive.",
+        "criteria": "Award this to the person who brings the perfect music, mood, lighting, playlist, or general atmosphere to any gathering."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:ChaosCoordinator",
+        "title": "Chaos Coordinator",
+        "url": "",
+        "backgroundColor": "#EF4444",
+        "description": "For the person who somehow turns confusion, missed messages, late arrivals, and half-formed plans into an actual functioning experience.",
+        "criteria": "Award this to the person who saves the day when the group chat becomes a disaster and everyone else has emotionally resigned."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:HypeArchitect",
+        "title": "Hype Architect",
+        "url": "",
+        "backgroundColor": "#F97316",
+        "description": "Reserved for the rare friend who makes other people feel braver, cooler, funnier, and more capable than they did five minutes ago.",
+        "criteria": "Award this to someone who consistently celebrates others, boosts confidence, and brings main-character energy to their peers."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:LoreKeeper",
+        "title": "Lore Keeper",
+        "url": "",
+        "backgroundColor": "#A16207",
+        "description": "For the community member who remembers every inside joke, legendary night, strange detail, and oddly important piece of group history.",
+        "criteria": "Award this to the person who preserves the stories, explains the references, and keeps the mythology of the group alive."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:SideQuestSpecialist",
+        "title": "Side Quest Specialist",
+        "url": "",
+        "backgroundColor": "#0EA5E9",
+        "description": "Reserved for the person who can turn a normal day into an unexpected adventure with one suspiciously casual suggestion.",
+        "criteria": "Award this to someone known for spontaneous detours, weird little missions, hidden gems, and unusually successful side quests."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:QuietGenius",
+        "title": "Quiet Genius",
+        "url": "",
+        "backgroundColor": "#0D9488",
+        "description": "For the person who may not always take the spotlight, but regularly drops the exact idea, fix, or observation everyone needed.",
+        "criteria": "Award this to the person whose thoughtful contributions, subtle brilliance, or perfectly timed insight make the whole team better."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:CommunityHelper",
+        "title": "Community Helper",
+        "url": "",
+        "backgroundColor": "#16A34A",
+        "description": "Reserved for the community members who show up when someone needs a hand, a pointer, a fix, or just a little extra kindness.",
+        "criteria": "Award this to the person who helped another community member solve a problem, feel welcome, find their way, or get unstuck."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:FoodSniper",
+        "title": "Food Sniper",
+        "url": "",
+        "backgroundColor": "#EA580C",
+        "description": "Reserved for the community members with impeccable taste and a talent for discovering the best culinary spots.",
+        "criteria": "Award this to the person known for providing the ultimate restaurant recommendations or leading the team to the best local eats."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:VisualStoryteller",
+        "title": "Visual Storyteller",
+        "url": "",
+        "backgroundColor": "#EC4899",
+        "description": "For the community member who turns ideas, data, moments, and messy concepts into visuals that people can actually feel and understand.",
+        "criteria": "Award this to someone who contributes strong creative assets, presentation design, diagrams, images, brand moments, or visual explanations."
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:LogicMaster",
+        "title": "Logic Master",
+        "url": "",
+        "backgroundColor": "#2563EB",
+        "description": "Reserved for the person who brings structure to complexity, catches the hidden flaw, and makes the whole system make sense.",
+        "criteria": "Award this to someone who contributes technical thinking, clear reasoning, elegant problem-solving, or the decisive \u201cwait, actually\u2026\u201d that saves the project."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:SchemaWhisperer",
+        "title": "Schema Whisperer",
+        "url": "",
+        "backgroundColor": "#7C3AED",
+        "description": "Reserved for the community member who can stare into a tangled credential payload and somehow emerge with elegance, order, and valid JSON-LD.",
+        "criteria": "Award this to the person who helps make badge data cleaner, more interoperable, and less likely to summon ancient standards demons."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:AlignmentWizard",
+        "title": "Alignment Wizard",
+        "url": "",
+        "backgroundColor": "#9333EA",
+        "description": "For the person who can connect a badge to a skill, a skill to a framework, a framework to a job, and somehow make it all seem obvious.",
+        "criteria": "Award this to someone known for mapping competencies, standards, occupations, and learning outcomes into something humans can actually use."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:CLRCartographer",
+        "title": "CLR Cartographer",
+        "url": "",
+        "backgroundColor": "#0369A1",
+        "description": "Reserved for the brave soul who helps communities navigate the wild territory between transcripts, credentials, skills, evidence, and learner records.",
+        "criteria": "Award this to the person who makes Comprehensive Learner Records feel less like a maze and more like a map."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:VerifiableVibes",
+        "title": "Verifiable Vibes",
+        "url": "",
+        "backgroundColor": "#10B981",
+        "description": "For the community member who believes trust is beautiful, signatures are poetry, and verification should work before anyone starts the demo.",
+        "criteria": "Award this to someone who helps ensure badges can be issued, held, shared, checked, and trusted without theatrical hand-waving."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:BadgeGoblin",
+        "title": "Badge Goblin",
+        "url": "",
+        "backgroundColor": "#059669",
+        "description": "Reserved for the person who wants everything to be a badge, and is usually, annoyingly, kind of right.",
+        "criteria": "Award this to someone who keeps finding delightful, useful, or deeply unnecessary things that deserve to be credentialed."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:MetadataMystic",
+        "title": "Metadata Mystic",
+        "url": "",
+        "backgroundColor": "#6D28D9",
+        "description": "For the person who understands that the visible badge is only the charm on the necklace. The real magic is in the structured data underneath.",
+        "criteria": "Award this to someone who improves descriptions, evidence, criteria, tags, alignments, issuers, expiration, revocation, or any other sacred metadata field."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:InteropDiplomat",
+        "title": "Interop Diplomat",
+        "url": "",
+        "backgroundColor": "#0284C7",
+        "description": "Reserved for the patient negotiator who can bring platforms, vendors, wallets, registries, and institutions into the same room without causing a standards incident.",
+        "criteria": "Award this to the person who advances interoperability through grace, persistence, and the occasional heroic spreadsheet."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:BackpackElder",
+        "title": "Backpack Elder",
+        "url": "",
+        "backgroundColor": "#B45309",
+        "description": "For the community member who remembers where the badges came from, why they mattered, and which conversations everyone keeps accidentally rediscovering.",
+        "criteria": "Award this to someone who carries the lore of Open Badges and helps newer people understand the movement, not just the spec."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:IssuerTherapist",
+        "title": "Issuer Therapist",
+        "url": "",
+        "backgroundColor": "#DB2777",
+        "description": "Reserved for the person who gently helps organizations admit that their badge criteria are unclear, their evidence is vibes, and their taxonomy needs love.",
+        "criteria": "Award this to someone who helps issuers design better badges with clearer value, stronger evidence, and fewer existential credentialing crises."
+    },
+    {
+        "category": "Standards Badge",
+        "type": "ext:SpecGremlin",
+        "title": "Spec Gremlin",
+        "url": "",
+        "backgroundColor": "#B91C1C",
+        "description": "For the person who reads the implementation notes, finds the edge case, asks the terrifying question, and saves everyone six months of pain.",
+        "criteria": "Award this to someone who catches ambiguity, breaks assumptions, stress-tests the standard, or says, \u201cTechnically\u2026\u201d and is unfortunately correct."
+    }
+]

--- a/apps/learn-card-app/src/registries/style-packs/learncard.json
+++ b/apps/learn-card-app/src/registries/style-packs/learncard.json
@@ -1,0 +1,138 @@
+[
+    {
+        "category": "Social Badge",
+        "type": "ext:Risktaker",
+        "url": "https://cdn.filestackcontent.com/GmNl1EYPQeWLCPhpKS9D"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Opportunist",
+        "url": "https://cdn.filestackcontent.com/t7BU7LuZSmi5uNwDUDy3"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:CoolCat",
+        "url": "https://cdn.filestackcontent.com/BCZrDyomT7Chlne1B28W",
+        "backgroundColor": "#3B82F6"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Trailblazer",
+        "url": "",
+        "backgroundColor": "#F97316"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Influencer",
+        "url": "https://cdn.filestackcontent.com/WUoRlusiRvyBs4fy2y6J"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Connector",
+        "url": "",
+        "backgroundColor": "#14B8A6"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Trendsetter",
+        "url": "https://cdn.filestackcontent.com/7mNLp36cSSimbR5a5Lic",
+        "backgroundColor": "#EC4899"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Organizer",
+        "url": "https://cdn.filestackcontent.com/sRYquW19RnSlXODmuthA"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Moderator",
+        "url": "https://cdn.filestackcontent.com/X0toRKeQQPGskU0N3kGB"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Leader",
+        "url": "https://cdn.filestackcontent.com/6Rtth3teTCicM9UIv83b"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Expert",
+        "url": "https://cdn.filestackcontent.com/VqN7IypPT8KMgwD2D78f"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Aficionado",
+        "url": "https://cdn.filestackcontent.com/mIc6BwQp2EwgUZBbupOQ"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Psychic",
+        "url": "https://cdn.filestackcontent.com/G3OyDxxQZa7Sp1fsGORw"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Magician",
+        "url": "https://cdn.filestackcontent.com/1GzSdpMHTAGM8468NTLT"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Charmer",
+        "url": "https://cdn.filestackcontent.com/1EonaJRZQKGbxXD2xmdj"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Cowboy",
+        "url": "https://cdn.filestackcontent.com/ehgl8oE9SkCFPI9oewbQ"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Perfectionist",
+        "url": "https://cdn.filestackcontent.com/qRGarg0zRW2PvSr6o88s"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Wanderer",
+        "url": "https://cdn.filestackcontent.com/QSnVUU41R8uYnautSNpm"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:TeamPlayer",
+        "url": "https://cdn.filestackcontent.com/tfJtucJvTMm0Xa5rADRd"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Star",
+        "url": "https://cdn.filestackcontent.com/cZxXOvbRdSPie9qf375w",
+        "backgroundColor": "#F59E0B"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:PartyAnimal",
+        "url": "https://cdn.filestackcontent.com/sVQOeGwIQLCLo2C6TyXg"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:TroubleMaker",
+        "url": "https://cdn.filestackcontent.com/UnXueEbdQ8iJf4qJXWAI"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Doer",
+        "url": "https://cdn.filestackcontent.com/8SX7AUhSTIS7FwmgYrF4"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Entertainer",
+        "url": "https://cdn.filestackcontent.com/nP48IO1TQ7ar5OHng7Fs"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Connoisseur",
+        "url": "https://cdn.filestackcontent.com/cIxsWyHSzqmb5L24MnYq"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:ChangeMaker",
+        "url": "",
+        "backgroundColor": "#10B981"
+    }
+]

--- a/apps/learn-card-app/src/registries/style-packs/learncard.json
+++ b/apps/learn-card-app/src/registries/style-packs/learncard.json
@@ -2,12 +2,14 @@
     {
         "category": "Social Badge",
         "type": "ext:Risktaker",
-        "url": "https://cdn.filestackcontent.com/GmNl1EYPQeWLCPhpKS9D"
+        "url": "https://cdn.filestackcontent.com/GmNl1EYPQeWLCPhpKS9D",
+        "backgroundColor": "#EF4444"
     },
     {
         "category": "Social Badge",
         "type": "ext:Opportunist",
-        "url": "https://cdn.filestackcontent.com/t7BU7LuZSmi5uNwDUDy3"
+        "url": "https://cdn.filestackcontent.com/t7BU7LuZSmi5uNwDUDy3",
+        "backgroundColor": "#EAB308"
     },
     {
         "category": "Social Badge",
@@ -24,7 +26,8 @@
     {
         "category": "Social Badge",
         "type": "ext:Influencer",
-        "url": "https://cdn.filestackcontent.com/WUoRlusiRvyBs4fy2y6J"
+        "url": "https://cdn.filestackcontent.com/WUoRlusiRvyBs4fy2y6J",
+        "backgroundColor": "#8B5CF6"
     },
     {
         "category": "Social Badge",
@@ -41,62 +44,74 @@
     {
         "category": "Social Badge",
         "type": "ext:Organizer",
-        "url": "https://cdn.filestackcontent.com/sRYquW19RnSlXODmuthA"
+        "url": "https://cdn.filestackcontent.com/sRYquW19RnSlXODmuthA",
+        "backgroundColor": "#0EA5E9"
     },
     {
         "category": "Social Badge",
         "type": "ext:Moderator",
-        "url": "https://cdn.filestackcontent.com/X0toRKeQQPGskU0N3kGB"
+        "url": "https://cdn.filestackcontent.com/X0toRKeQQPGskU0N3kGB",
+        "backgroundColor": "#0D9488"
     },
     {
         "category": "Social Badge",
         "type": "ext:Leader",
-        "url": "https://cdn.filestackcontent.com/6Rtth3teTCicM9UIv83b"
+        "url": "https://cdn.filestackcontent.com/6Rtth3teTCicM9UIv83b",
+        "backgroundColor": "#2563EB"
     },
     {
         "category": "Social Badge",
         "type": "ext:Expert",
-        "url": "https://cdn.filestackcontent.com/VqN7IypPT8KMgwD2D78f"
+        "url": "https://cdn.filestackcontent.com/VqN7IypPT8KMgwD2D78f",
+        "backgroundColor": "#7C3AED"
     },
     {
         "category": "Social Badge",
         "type": "ext:Aficionado",
-        "url": "https://cdn.filestackcontent.com/mIc6BwQp2EwgUZBbupOQ"
+        "url": "https://cdn.filestackcontent.com/mIc6BwQp2EwgUZBbupOQ",
+        "backgroundColor": "#DB2777"
     },
     {
         "category": "Social Badge",
         "type": "ext:Psychic",
-        "url": "https://cdn.filestackcontent.com/G3OyDxxQZa7Sp1fsGORw"
+        "url": "https://cdn.filestackcontent.com/G3OyDxxQZa7Sp1fsGORw",
+        "backgroundColor": "#9333EA"
     },
     {
         "category": "Social Badge",
         "type": "ext:Magician",
-        "url": "https://cdn.filestackcontent.com/1GzSdpMHTAGM8468NTLT"
+        "url": "https://cdn.filestackcontent.com/1GzSdpMHTAGM8468NTLT",
+        "backgroundColor": "#6D28D9"
     },
     {
         "category": "Social Badge",
         "type": "ext:Charmer",
-        "url": "https://cdn.filestackcontent.com/1EonaJRZQKGbxXD2xmdj"
+        "url": "https://cdn.filestackcontent.com/1EonaJRZQKGbxXD2xmdj",
+        "backgroundColor": "#F472B6"
     },
     {
         "category": "Social Badge",
         "type": "ext:Cowboy",
-        "url": "https://cdn.filestackcontent.com/ehgl8oE9SkCFPI9oewbQ"
+        "url": "https://cdn.filestackcontent.com/ehgl8oE9SkCFPI9oewbQ",
+        "backgroundColor": "#B45309"
     },
     {
         "category": "Social Badge",
         "type": "ext:Perfectionist",
-        "url": "https://cdn.filestackcontent.com/qRGarg0zRW2PvSr6o88s"
+        "url": "https://cdn.filestackcontent.com/qRGarg0zRW2PvSr6o88s",
+        "backgroundColor": "#059669"
     },
     {
         "category": "Social Badge",
         "type": "ext:Wanderer",
-        "url": "https://cdn.filestackcontent.com/QSnVUU41R8uYnautSNpm"
+        "url": "https://cdn.filestackcontent.com/QSnVUU41R8uYnautSNpm",
+        "backgroundColor": "#0891B2"
     },
     {
         "category": "Social Badge",
         "type": "ext:TeamPlayer",
-        "url": "https://cdn.filestackcontent.com/tfJtucJvTMm0Xa5rADRd"
+        "url": "https://cdn.filestackcontent.com/tfJtucJvTMm0Xa5rADRd",
+        "backgroundColor": "#16A34A"
     },
     {
         "category": "Social Badge",
@@ -107,27 +122,32 @@
     {
         "category": "Social Badge",
         "type": "ext:PartyAnimal",
-        "url": "https://cdn.filestackcontent.com/sVQOeGwIQLCLo2C6TyXg"
+        "url": "https://cdn.filestackcontent.com/sVQOeGwIQLCLo2C6TyXg",
+        "backgroundColor": "#E11D48"
     },
     {
         "category": "Social Badge",
         "type": "ext:TroubleMaker",
-        "url": "https://cdn.filestackcontent.com/UnXueEbdQ8iJf4qJXWAI"
+        "url": "https://cdn.filestackcontent.com/UnXueEbdQ8iJf4qJXWAI",
+        "backgroundColor": "#DC2626"
     },
     {
         "category": "Social Badge",
         "type": "ext:Doer",
-        "url": "https://cdn.filestackcontent.com/8SX7AUhSTIS7FwmgYrF4"
+        "url": "https://cdn.filestackcontent.com/8SX7AUhSTIS7FwmgYrF4",
+        "backgroundColor": "#EA580C"
     },
     {
         "category": "Social Badge",
         "type": "ext:Entertainer",
-        "url": "https://cdn.filestackcontent.com/nP48IO1TQ7ar5OHng7Fs"
+        "url": "https://cdn.filestackcontent.com/nP48IO1TQ7ar5OHng7Fs",
+        "backgroundColor": "#C026D3"
     },
     {
         "category": "Social Badge",
         "type": "ext:Connoisseur",
-        "url": "https://cdn.filestackcontent.com/cIxsWyHSzqmb5L24MnYq"
+        "url": "https://cdn.filestackcontent.com/cIxsWyHSzqmb5L24MnYq",
+        "backgroundColor": "#A16207"
     },
     {
         "category": "Social Badge",
@@ -138,76 +158,91 @@
     {
         "category": "Social Badge",
         "type": "ext:Ambassador",
-        "url": "https://cdn.filestackcontent.com/xJkEdiJpTNygR0lDr5FO"
+        "url": "https://cdn.filestackcontent.com/xJkEdiJpTNygR0lDr5FO",
+        "backgroundColor": "#0284C7"
     },
     {
         "category": "Social Badge",
         "type": "ext:Catalyst",
-        "url": "https://cdn.filestackcontent.com/KwQaPi0gS96De50CZ2b1"
+        "url": "https://cdn.filestackcontent.com/KwQaPi0gS96De50CZ2b1",
+        "backgroundColor": "#A855F7"
     },
     {
         "category": "Social Badge",
         "type": "ext:ChallengeMaker",
-        "url": "https://cdn.filestackcontent.com/2eMAX1kKTeGajsKsj2JK"
+        "url": "https://cdn.filestackcontent.com/2eMAX1kKTeGajsKsj2JK",
+        "backgroundColor": "#B91C1C"
     },
     {
         "category": "Social Badge",
         "type": "ext:Challenger",
-        "url": "https://cdn.filestackcontent.com/buHdErlfQMSUPcfWtvuW"
+        "url": "https://cdn.filestackcontent.com/buHdErlfQMSUPcfWtvuW",
+        "backgroundColor": "#C2410C"
     },
     {
         "category": "Social Badge",
         "type": "ext:Enabler",
-        "url": "https://cdn.filestackcontent.com/GhCazGwjTBmLdYZitnGv"
+        "url": "https://cdn.filestackcontent.com/GhCazGwjTBmLdYZitnGv",
+        "backgroundColor": "#2DD4BF"
     },
     {
         "category": "Social Badge",
         "type": "ext:Enthusiast",
-        "url": "https://cdn.filestackcontent.com/Kd7Xac9VQKSMDcBMt2db"
+        "url": "https://cdn.filestackcontent.com/Kd7Xac9VQKSMDcBMt2db",
+        "backgroundColor": "#F43F5E"
     },
     {
         "category": "Social Badge",
         "type": "ext:HotShot",
-        "url": "https://cdn.filestackcontent.com/nRf4UswXS3CK3uJuNhAL"
+        "url": "https://cdn.filestackcontent.com/nRf4UswXS3CK3uJuNhAL",
+        "backgroundColor": "#FB923C"
     },
     {
         "category": "Social Badge",
         "type": "ext:Informer",
-        "url": "https://cdn.filestackcontent.com/iKlFIG7XQquBg6Tv2kX8"
+        "url": "https://cdn.filestackcontent.com/iKlFIG7XQquBg6Tv2kX8",
+        "backgroundColor": "#38BDF8"
     },
     {
         "category": "Social Badge",
         "type": "ext:Maven",
-        "url": "https://cdn.filestackcontent.com/ZxTE4EaBQIaVwIWaMCU8"
+        "url": "https://cdn.filestackcontent.com/ZxTE4EaBQIaVwIWaMCU8",
+        "backgroundColor": "#7E22CE"
     },
     {
         "category": "Social Badge",
         "type": "ext:Maverick",
-        "url": "https://cdn.filestackcontent.com/L4A3VUJSROG2i8Q27JNQ"
+        "url": "https://cdn.filestackcontent.com/L4A3VUJSROG2i8Q27JNQ",
+        "backgroundColor": "#991B1B"
     },
     {
         "category": "Social Badge",
         "type": "ext:PartyPlanner",
-        "url": "https://cdn.filestackcontent.com/eIlTJ6KQouftIobNJIFw"
+        "url": "https://cdn.filestackcontent.com/eIlTJ6KQouftIobNJIFw",
+        "backgroundColor": "#BE185D"
     },
     {
         "category": "Social Badge",
         "type": "ext:Promoter",
-        "url": "https://cdn.filestackcontent.com/LLdN9m9qToK18LaquIBs"
+        "url": "https://cdn.filestackcontent.com/LLdN9m9qToK18LaquIBs",
+        "backgroundColor": "#FBBF24"
     },
     {
         "category": "Social Badge",
         "type": "ext:Propagator",
-        "url": "https://cdn.filestackcontent.com/NIscu9pOQ6So1xJMsy2y"
+        "url": "https://cdn.filestackcontent.com/NIscu9pOQ6So1xJMsy2y",
+        "backgroundColor": "#22C55E"
     },
     {
         "category": "Social Badge",
         "type": "ext:Sage",
-        "url": "https://cdn.filestackcontent.com/emac9VJT1yNN1BExQxa7"
+        "url": "https://cdn.filestackcontent.com/emac9VJT1yNN1BExQxa7",
+        "backgroundColor": "#0369A1"
     },
     {
         "category": "Social Badge",
         "type": "ext:Tastemaker",
-        "url": "https://cdn.filestackcontent.com/KpTCUDLsTYiAmhVCClDx"
+        "url": "https://cdn.filestackcontent.com/KpTCUDLsTYiAmhVCClDx",
+        "backgroundColor": "#FB7185"
     }
 ]

--- a/apps/learn-card-app/src/registries/style-packs/learncard.json
+++ b/apps/learn-card-app/src/registries/style-packs/learncard.json
@@ -18,7 +18,7 @@
     {
         "category": "Social Badge",
         "type": "ext:Trailblazer",
-        "url": "",
+        "url": "https://cdn.filestackcontent.com/j24CZf4T8qU1gKCA8M1H",
         "backgroundColor": "#F97316"
     },
     {
@@ -29,7 +29,7 @@
     {
         "category": "Social Badge",
         "type": "ext:Connector",
-        "url": "",
+        "url": "https://cdn.filestackcontent.com/mhN7hkORBGzYuZGA3xRg",
         "backgroundColor": "#14B8A6"
     },
     {
@@ -132,7 +132,82 @@
     {
         "category": "Social Badge",
         "type": "ext:ChangeMaker",
-        "url": "",
+        "url": "https://cdn.filestackcontent.com/QcA0gdlFSH2ytJCGFT6U",
         "backgroundColor": "#10B981"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Ambassador",
+        "url": "https://cdn.filestackcontent.com/xJkEdiJpTNygR0lDr5FO"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Catalyst",
+        "url": "https://cdn.filestackcontent.com/KwQaPi0gS96De50CZ2b1"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:ChallengeMaker",
+        "url": "https://cdn.filestackcontent.com/2eMAX1kKTeGajsKsj2JK"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Challenger",
+        "url": "https://cdn.filestackcontent.com/buHdErlfQMSUPcfWtvuW"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Enabler",
+        "url": "https://cdn.filestackcontent.com/GhCazGwjTBmLdYZitnGv"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Enthusiast",
+        "url": "https://cdn.filestackcontent.com/Kd7Xac9VQKSMDcBMt2db"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:HotShot",
+        "url": "https://cdn.filestackcontent.com/nRf4UswXS3CK3uJuNhAL"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Informer",
+        "url": "https://cdn.filestackcontent.com/iKlFIG7XQquBg6Tv2kX8"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Maven",
+        "url": "https://cdn.filestackcontent.com/ZxTE4EaBQIaVwIWaMCU8"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Maverick",
+        "url": "https://cdn.filestackcontent.com/L4A3VUJSROG2i8Q27JNQ"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:PartyPlanner",
+        "url": "https://cdn.filestackcontent.com/eIlTJ6KQouftIobNJIFw"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Promoter",
+        "url": "https://cdn.filestackcontent.com/LLdN9m9qToK18LaquIBs"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Propagator",
+        "url": "https://cdn.filestackcontent.com/NIscu9pOQ6So1xJMsy2y"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Sage",
+        "url": "https://cdn.filestackcontent.com/emac9VJT1yNN1BExQxa7"
+    },
+    {
+        "category": "Social Badge",
+        "type": "ext:Tastemaker",
+        "url": "https://cdn.filestackcontent.com/KpTCUDLsTYiAmhVCClDx"
     }
 ]

--- a/apps/learn-card-app/src/registries/useBadgeGroups.ts
+++ b/apps/learn-card-app/src/registries/useBadgeGroups.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { BadgeGroup, useTenantConfig } from 'learn-card-base';
+
+const bundledBadgeGroupModules = import.meta.glob<BadgeGroup[]>('./badge-groups/*.json', {
+    eager: true,
+    import: 'default',
+});
+
+const getBundledBadgeGroups = (name: string): BadgeGroup[] =>
+    bundledBadgeGroupModules[`./badge-groups/${name}.json`] ?? [];
+
+export const mergeBadgeGroups = (sources: BadgeGroup[][]): BadgeGroup[] => {
+    const merged = new Map<string, BadgeGroup>();
+
+    for (const source of sources) {
+        if (!Array.isArray(source)) continue;
+        for (const group of source) {
+            if (!group?.id) continue;
+            const prev = merged.get(group.id);
+            merged.set(group.id, { ...(prev ?? {}), ...group });
+        }
+    }
+
+    return [...merged.values()].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+};
+
+const fetchBadgeGroupUrl = async (url: string): Promise<BadgeGroup[]> => {
+    const data = await (await fetch(url)).json();
+    return Array.isArray(data) ? data : [];
+};
+
+export const useBadgeGroups = () => {
+    const { registries } = useTenantConfig();
+    const badgeGroupUrls = registries?.badgeGroupUrls ?? [];
+    const badgeGroupAssets = registries?.badgeGroupAssets ?? [];
+
+    return useQuery<BadgeGroup[]>({
+        queryKey: ['badgeGroups', badgeGroupUrls, badgeGroupAssets],
+        initialData: [],
+        queryFn: async () => {
+            const remote = await Promise.all(
+                badgeGroupUrls.map(url => fetchBadgeGroupUrl(url).catch(() => []))
+            );
+            const bundled = badgeGroupAssets.map(getBundledBadgeGroups);
+
+            return mergeBadgeGroups([...remote, ...bundled]);
+        },
+    });
+};

--- a/apps/learn-card-app/src/registries/useStylePackRegistry.ts
+++ b/apps/learn-card-app/src/registries/useStylePackRegistry.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import { LCAStylesPackRegistryEntry, useTenantConfig } from 'learn-card-base';
+
+const bundledStylePackModules = import.meta.glob<LCAStylesPackRegistryEntry[]>(
+    './style-packs/*.json',
+    { eager: true, import: 'default' }
+);
+
+const getBundledStylePack = (name: string): LCAStylesPackRegistryEntry[] =>
+    bundledStylePackModules[`./style-packs/${name}.json`] ?? [];
+
+const entryKey = (entry: LCAStylesPackRegistryEntry) => `${entry.category}::${entry.type}`;
+
+const definedFields = (
+    entry: Partial<LCAStylesPackRegistryEntry>
+): Partial<LCAStylesPackRegistryEntry> =>
+    Object.fromEntries(
+        Object.entries(entry).filter(([, value]) => value !== undefined && value !== '')
+    );
+
+export const mergeStylePackEntries = (
+    sources: LCAStylesPackRegistryEntry[][]
+): LCAStylesPackRegistryEntry[] => {
+    const merged = new Map<string, LCAStylesPackRegistryEntry>();
+
+    for (const source of sources) {
+        if (!Array.isArray(source)) continue;
+        for (const entry of source) {
+            if (!entry?.category || !entry?.type) continue;
+            const key = entryKey(entry);
+            const prev = merged.get(key);
+            merged.set(key, { ...(prev ?? entry), ...definedFields(entry) });
+        }
+    }
+
+    return [...merged.values()];
+};
+
+const fetchStylePackUrl = async (url: string): Promise<LCAStylesPackRegistryEntry[]> => {
+    const data = await (await fetch(url)).json();
+    return Array.isArray(data) ? data : [];
+};
+
+export const useStylePackRegistry = () => {
+    const { registries } = useTenantConfig();
+    const stylePackUrls = registries?.stylePackUrls ?? [];
+    const stylePackAssets = registries?.stylePackAssets ?? [];
+
+    return useQuery<LCAStylesPackRegistryEntry[]>({
+        queryKey: ['stylePackRegistry', stylePackUrls, stylePackAssets],
+        initialData: [],
+        queryFn: async () => {
+            const remote = await Promise.all(
+                stylePackUrls.map(url => fetchStylePackUrl(url).catch(() => []))
+            );
+            const bundled = stylePackAssets.map(getBundledStylePack);
+
+            return mergeStylePackEntries([...remote, ...bundled]);
+        },
+    });
+};

--- a/apps/learn-card-app/src/stores/passportPageStore.ts
+++ b/apps/learn-card-app/src/stores/passportPageStore.ts
@@ -19,20 +19,9 @@ export const passportPageStore = createStore('passportPageStore')<{
 ).extendActions(set => ({
     setViewMode: (viewMode: PassportPageViewMode) => {
         set.viewMode(viewMode);
-        if (viewMode === PassportPageViewMode.grid) {
-            set.credentialViewMode(BoostPageViewMode.Card);
-        } else {
-            set.credentialViewMode(BoostPageViewMode.List);
-        }
     },
     setCredentialViewMode: (credentialViewMode: BoostPageViewModeType) => {
         set.credentialViewMode(credentialViewMode);
-
-        if (credentialViewMode === BoostPageViewMode.Card) {
-            set.viewMode(PassportPageViewMode.grid);
-        } else {
-            set.viewMode(PassportPageViewMode.list);
-        }
     },
 }));
 

--- a/apps/learn-card-app/src/theme/helpers/loadJsonTheme.ts
+++ b/apps/learn-card-app/src/theme/helpers/loadJsonTheme.ts
@@ -29,7 +29,11 @@ import {
 // ─── Raw JSON shape (inferred from the Zod source of truth) ─────────────
 
 import type { ThemeJsonConfig } from '../validators/themeJson.validators';
-import { emitConfigDebugEvent, emitConfigWarning, emitConfigSuccess } from '../../components/debug/configDebugEvents';
+import {
+    emitConfigDebugEvent,
+    emitConfigWarning,
+    emitConfigSuccess,
+} from '../../components/debug/configDebugEvents';
 import {
     ALL_CATEGORIES,
     CATEGORY_KEY_TO_VALUE,
@@ -39,15 +43,15 @@ import {
 
 // ─── Glob imports (resolved at build time by Vite) ───────────────────────
 
-const themeJsonModules = import.meta.glob<ThemeJsonConfig>(
-    '../schemas/*/theme.json',
-    { eager: true, import: 'default' },
-);
+const themeJsonModules = import.meta.glob<ThemeJsonConfig>('../schemas/*/theme.json', {
+    eager: true,
+    import: 'default',
+});
 
-const themeAssetModules = import.meta.glob<string>(
-    '../schemas/*/assets/*',
-    { eager: true, import: 'default' },
-);
+const themeAssetModules = import.meta.glob<string>('../schemas/*/assets/*', {
+    eager: true,
+    import: 'default',
+});
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 // Pure expansion utilities live in ./themeExpansion.ts for testability.
@@ -64,9 +68,17 @@ const resolveAsset = (themeId: string, relativePath: string): string => {
     const fallbackKey = `../schemas/colorful/assets/${fileName}`;
 
     if (!themeAssetModules[globKey] && themeAssetModules[fallbackKey]) {
-        emitConfigWarning('theme:asset_fallback', `Asset "${fileName}" missing from "${themeId}", using colorful fallback`, { themeId, fileName, globKey, fallbackKey });
+        emitConfigWarning(
+            'theme:asset_fallback',
+            `Asset "${fileName}" missing from "${themeId}", using colorful fallback`,
+            { themeId, fileName, globKey, fallbackKey }
+        );
     } else if (!themeAssetModules[globKey] && !themeAssetModules[fallbackKey]) {
-        emitConfigWarning('theme:asset_fallback', `Asset "${fileName}" not found in "${themeId}" or colorful fallback`, { themeId, fileName });
+        emitConfigWarning(
+            'theme:asset_fallback',
+            `Asset "${fileName}" not found in "${themeId}" or colorful fallback`,
+            { themeId, fileName }
+        );
     }
 
     return themeAssetModules[globKey] ?? themeAssetModules[fallbackKey] ?? relativePath;
@@ -100,10 +112,7 @@ const rawConfigs = getRawConfigs();
  * Recursively resolve a theme's `extends` chain, deep-merging parent → child.
  * Detects cycles.
  */
-const resolveExtends = (
-    id: string,
-    seen: Set<string> = new Set(),
-): ThemeJsonConfig => {
+const resolveExtends = (id: string, seen: Set<string> = new Set()): ThemeJsonConfig => {
     if (resolvedCache.has(id)) return resolvedCache.get(id)!;
 
     const config = rawConfigs.get(id);
@@ -125,7 +134,7 @@ const resolveExtends = (
 
         resolved = deepMerge(
             parent as unknown as Record<string, unknown>,
-            config as unknown as Record<string, unknown>,
+            config as unknown as Record<string, unknown>
         ) as unknown as ThemeJsonConfig;
 
         // Child's id and displayName always win
@@ -165,7 +174,7 @@ const CATEGORY_TO_PALETTE_KEY: Partial<Record<CredentialCategoryEnum, string>> =
  */
 const wrapIconWithPalette = (
     Component: React.ComponentType<Record<string, unknown>>,
-    palette: Partial<IconPalette>,
+    palette: Partial<IconPalette>
 ): React.ComponentType<Record<string, unknown>> => {
     const Wrapped: React.FC<Record<string, unknown>> = props =>
         React.createElement(Component, { ...props, palette });
@@ -202,8 +211,19 @@ const buildTheme = (config: ThemeJsonConfig): Theme => {
     const iconSetName = config.iconSet ?? 'colorful';
     const iconSet = resolveIconSet(iconSetName);
 
-    // Resolve view mode
-    const viewMode = config.defaults?.viewMode === 'grid' ? ViewMode.Grid : ViewMode.List;
+    // Resolve view modes (legacy `viewMode` seeds both when the newer fields are absent)
+    const legacyViewMode = config.defaults?.viewMode;
+
+    const passportViewMode =
+        (config.defaults?.passportViewMode ?? legacyViewMode) === 'grid'
+            ? ViewMode.Grid
+            : ViewMode.List;
+
+    const credentialViewMode =
+        (config.defaults?.credentialViewMode ?? (legacyViewMode === 'list' ? 'list' : 'card')) ===
+        'list'
+            ? 'list'
+            : 'card';
 
     // Resolve image assets
     const switcherIcon = resolveAsset(config.id, './assets/switcher-icon.png');
@@ -214,7 +234,9 @@ const buildTheme = (config: ThemeJsonConfig): Theme => {
     const styles = config.styles ?? {};
 
     // Build resolved icon palettes: start from compiled defaults, merge theme overrides
-    const resolvedIconPalettes: Record<string, Required<IconPalette>> = { ...WALLET_ICON_PALETTE_DEFAULTS };
+    const resolvedIconPalettes: Record<string, Required<IconPalette>> = {
+        ...WALLET_ICON_PALETTE_DEFAULTS,
+    };
 
     if (config.iconPalettes) {
         for (const [key, overrides] of Object.entries(config.iconPalettes)) {
@@ -247,21 +269,21 @@ const buildTheme = (config: ThemeJsonConfig): Theme => {
             if (catIcons.Icon) {
                 wrapped.Icon = wrapIconWithPalette(
                     catIcons.Icon as React.ComponentType<Record<string, unknown>>,
-                    palette,
+                    palette
                 ) as CategoryIcons['Icon'];
             }
 
             if (catIcons.IconWithShape) {
                 wrapped.IconWithShape = wrapIconWithPalette(
                     catIcons.IconWithShape as React.ComponentType<Record<string, unknown>>,
-                    palette,
+                    palette
                 ) as CategoryIcons['IconWithShape'];
             }
 
             if (catIcons.IconWithLightShape) {
                 wrapped.IconWithLightShape = wrapIconWithPalette(
                     catIcons.IconWithLightShape as React.ComponentType<Record<string, unknown>>,
-                    palette,
+                    palette
                 ) as CategoryIcons['IconWithLightShape'];
             }
 
@@ -278,7 +300,9 @@ const buildTheme = (config: ThemeJsonConfig): Theme => {
         iconPalettes: resolvedIconPalettes,
         styles,
         defaults: {
-            viewMode,
+            viewMode: passportViewMode,
+            passportViewMode,
+            credentialViewMode,
             switcherIcon,
             buildMyLCIcon,
             resumeBuilderIcon,
@@ -303,13 +327,25 @@ export const loadAllJsonThemes = (): Theme[] => {
 
             themes.push(buildTheme(resolved));
 
-            emitConfigSuccess('theme:loaded', `Theme "${id}" loaded${resolved.extends ? ` (extends ${resolved.extends})` : ''}`, { themeId: id, extends: resolved.extends, displayName: resolved.displayName });
+            emitConfigSuccess(
+                'theme:loaded',
+                `Theme "${id}" loaded${resolved.extends ? ` (extends ${resolved.extends})` : ''}`,
+                { themeId: id, extends: resolved.extends, displayName: resolved.displayName }
+            );
         } catch (err) {
-            emitConfigWarning('theme:loaded', `Failed to load theme "${id}": ${err instanceof Error ? err.message : String(err)}`, { themeId: id, error: err instanceof Error ? err.message : String(err) });
+            emitConfigWarning(
+                'theme:loaded',
+                `Failed to load theme "${id}": ${err instanceof Error ? err.message : String(err)}`,
+                { themeId: id, error: err instanceof Error ? err.message : String(err) }
+            );
         }
     }
 
-    emitConfigDebugEvent('theme:store_init', `${themes.length} theme(s) loaded: ${themes.map(t => t.id).join(', ')}`, { data: { count: themes.length, themeIds: themes.map(t => t.id) } });
+    emitConfigDebugEvent(
+        'theme:store_init',
+        `${themes.length} theme(s) loaded: ${themes.map(t => t.id).join(', ')}`,
+        { data: { count: themes.length, themeIds: themes.map(t => t.id) } }
+    );
 
     return themes;
 };

--- a/apps/learn-card-app/src/theme/hooks/useTheme.tsx
+++ b/apps/learn-card-app/src/theme/hooks/useTheme.tsx
@@ -1,7 +1,12 @@
 // src/theme/hooks/useTheme.tsx
 import { useEffect } from 'react';
 
-import { CredentialCategoryEnum, useGetPreferencesForDid, useIsLoggedIn } from 'learn-card-base';
+import {
+    BoostPageViewMode,
+    CredentialCategoryEnum,
+    useGetPreferencesForDid,
+    useIsLoggedIn,
+} from 'learn-card-base';
 
 import { getDefaultTheme, resolveThemeForTenant, themeStore } from '../store/themeStore';
 
@@ -30,7 +35,13 @@ export const syncThemeDefaults = (theme: string): void => {
     const { defaults } = schema;
 
     passportPageStore.set.setViewMode(
-        defaults.viewMode === ViewMode.List ? PassportPageViewMode.list : PassportPageViewMode.grid
+        defaults.passportViewMode === ViewMode.List
+            ? PassportPageViewMode.list
+            : PassportPageViewMode.grid
+    );
+
+    passportPageStore.set.setCredentialViewMode(
+        defaults.credentialViewMode === 'list' ? BoostPageViewMode.List : BoostPageViewMode.Card
     );
 };
 

--- a/apps/learn-card-app/src/theme/schemas/colorful/theme.json
+++ b/apps/learn-card-app/src/theme/schemas/colorful/theme.json
@@ -3,7 +3,8 @@
     "displayName": "Colorful",
     "iconSet": "colorful",
     "defaults": {
-        "viewMode": "grid"
+        "passportViewMode": "list",
+        "credentialViewMode": "card"
     },
     "colors": {
         "categories": {

--- a/apps/learn-card-app/src/theme/validators/theme.validators.ts
+++ b/apps/learn-card-app/src/theme/validators/theme.validators.ts
@@ -25,6 +25,12 @@ export type ThemeCategory = z.infer<typeof ThemeCategoriesSchema>;
 export const ThemeDefaultsSchema = z
     .object({
         viewMode: z.nativeEnum(ViewMode).describe('View Modes for Credential Lists'),
+        passportViewMode: z
+            .nativeEnum(ViewMode)
+            .describe('Default layout for the Passport overview page'),
+        credentialViewMode: z
+            .enum(['card', 'list'])
+            .describe('Default layout for individual wallet/category pages'),
         switcherIcon: z.string().describe('Theme Switcher Icon'),
         buildMyLCIcon: z.string().describe('Build My LearnCard Icon'),
         resumeBuilderIcon: z.string().describe('Resume Builder Icon'),
@@ -67,7 +73,10 @@ export const ThemeSchema = z
         displayName: z.string().describe('Display name for UI'),
         colors: ThemeColorsSchema.describe('Color mappings by category + launchPad'),
         icons: ThemeIconsSchema.describe('Icon mappings by category + launchPad'),
-        iconPalettes: z.record(z.string(), IconPaletteSchema).optional().describe('Per-category icon color palettes'),
+        iconPalettes: z
+            .record(z.string(), IconPaletteSchema)
+            .optional()
+            .describe('Per-category icon color palettes'),
         categories: z.array(ThemeCategoriesSchema).describe('Theme credential categories'),
         sideMenuRootLinks: z.array(SideMenuLinkSchema).describe('Theme side menu root links'),
         sideMenuSecondaryLinks: z

--- a/apps/learn-card-app/src/theme/validators/themeJson.validators.ts
+++ b/apps/learn-card-app/src/theme/validators/themeJson.validators.ts
@@ -18,72 +18,84 @@ const categoryColorJsonSchema = z.record(z.string(), z.string());
 
 const launchPadColorJsonSchema = z.record(z.string(), z.unknown());
 
-const themeJsonColorsSchema = z.object({
-    /** Uniform base applied to every credential category (formal-style). */
-    categoryBase: categoryColorJsonSchema.optional(),
+const themeJsonColorsSchema = z
+    .object({
+        /** Uniform base applied to every credential category (formal-style). */
+        categoryBase: categoryColorJsonSchema.optional(),
 
-    /** Per-category overrides. Merged on top of categoryBase if both exist. */
-    categories: z.record(z.string(), categoryColorJsonSchema).optional(),
+        /** Per-category overrides. Merged on top of categoryBase if both exist. */
+        categories: z.record(z.string(), categoryColorJsonSchema).optional(),
 
-    launchPad: launchPadColorJsonSchema.optional(),
-    sideMenu: z.record(z.string(), z.string()).optional(),
-    navbar: z.record(z.string(), z.string()).optional(),
-    introSlides: z.record(z.string(), z.unknown()).optional(),
+        launchPad: launchPadColorJsonSchema.optional(),
+        sideMenu: z.record(z.string(), z.string()).optional(),
+        navbar: z.record(z.string(), z.string()).optional(),
+        introSlides: z.record(z.string(), z.unknown()).optional(),
 
-    /** Shorthand: a single placeholder applied to every category + defaults. */
-    placeholderBase: z.record(z.string(), z.unknown()).optional(),
+        /** Shorthand: a single placeholder applied to every category + defaults. */
+        placeholderBase: z.record(z.string(), z.unknown()).optional(),
 
-    /** Explicit per-category placeholders (colorful-style). */
-    placeholders: z.record(z.string(), z.unknown()).optional(),
+        /** Explicit per-category placeholders (colorful-style). */
+        placeholders: z.record(z.string(), z.unknown()).optional(),
 
-    defaults: z.record(z.string(), z.unknown()).optional(),
-}).passthrough();
+        defaults: z.record(z.string(), z.unknown()).optional(),
+    })
+    .passthrough();
 
 export type ThemeJsonColors = z.infer<typeof themeJsonColorsSchema>;
 
 // ── Icon palette sub-schema ──────────────────────────────────────────────
 
-const iconPaletteJsonSchema = z.object({
-    primary: z.string(),
-    primaryLight: z.string().optional(),
-    accent: z.string().optional(),
-    stroke: z.string().optional(),
-}).partial();
+const iconPaletteJsonSchema = z
+    .object({
+        primary: z.string(),
+        primaryLight: z.string().optional(),
+        accent: z.string().optional(),
+        stroke: z.string().optional(),
+    })
+    .partial();
 
 // ── Root theme.json schema ───────────────────────────────────────────────
 
-export const ThemeJsonSchema = z.object({
-    /** Theme ID — must match the containing directory name. */
-    id: z.string(),
+export const ThemeJsonSchema = z
+    .object({
+        /** Theme ID — must match the containing directory name. */
+        id: z.string(),
 
-    /** Human-readable name shown in the ThemeSelector UI. */
-    displayName: z.string(),
+        /** Human-readable name shown in the ThemeSelector UI. */
+        displayName: z.string(),
 
-    /** Parent theme ID. All unset fields inherit from the parent. */
-    extends: z.string().optional(),
+        /** Parent theme ID. All unset fields inherit from the parent. */
+        extends: z.string().optional(),
 
-    /** Icon set name (key into ICON_SETS). Defaults to parent's set. */
-    iconSet: z.string().optional(),
+        /** Icon set name (key into ICON_SETS). Defaults to parent's set. */
+        iconSet: z.string().optional(),
 
-    /** Per-category icon color overrides. */
-    iconPalettes: z.record(z.string(), iconPaletteJsonSchema).optional(),
+        /** Per-category icon color overrides. */
+        iconPalettes: z.record(z.string(), iconPaletteJsonSchema).optional(),
 
-    /** Default view mode and layout settings. */
-    defaults: z.object({
-        viewMode: z.enum(['list', 'grid']).optional(),
-    }).passthrough().optional(),
+        /** Default view mode and layout settings. */
+        defaults: z
+            .object({
+                /** @deprecated Legacy single flag; falls back to seed both surfaces when the newer fields are absent. */
+                viewMode: z.enum(['list', 'grid']).optional(),
+                /** Default layout for the Passport overview page (WalletPage). */
+                passportViewMode: z.enum(['list', 'grid']).optional(),
+                /** Default layout for individual wallet/category pages (CredentialPage). */
+                credentialViewMode: z.enum(['card', 'list']).optional(),
+            })
+            .passthrough()
+            .optional(),
 
-    /** Color definitions for all UI surfaces. */
-    colors: themeJsonColorsSchema.optional(),
+        /** Color definitions for all UI surfaces. */
+        colors: themeJsonColorsSchema.optional(),
 
-    /** Tailwind utility class overrides for specific components. */
-    styles: z.record(z.string(), z.unknown()).optional(),
-}).passthrough();
+        /** Tailwind utility class overrides for specific components. */
+        styles: z.record(z.string(), z.unknown()).optional(),
+    })
+    .passthrough();
 
 export type ThemeJsonConfig = z.infer<typeof ThemeJsonSchema>;
 
-export const validateThemeJson = (data: unknown): ThemeJsonConfig =>
-    ThemeJsonSchema.parse(data);
+export const validateThemeJson = (data: unknown): ThemeJsonConfig => ThemeJsonSchema.parse(data);
 
-export const safeValidateThemeJson = (data: unknown) =>
-    ThemeJsonSchema.safeParse(data);
+export const safeValidateThemeJson = (data: unknown) => ThemeJsonSchema.safeParse(data);

--- a/apps/scouts/src/components/boost/boost-options/boostOptions.ts
+++ b/apps/scouts/src/components/boost/boost-options/boostOptions.ts
@@ -166,7 +166,7 @@ export const CATEGORY_TO_SUBCATEGORY_LIST: {
             type: AchievementTypes.Award,
         },
         {
-            title: 'Online Badge',
+            title: 'Badge',
             type: AchievementTypes.Badge,
         },
         {

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -125,6 +125,7 @@
     -   [Credential Lifecycle](core-concepts/credentials-and-data/credential-lifecycle.md)
     -   [Credential Status & Bitstring Status Lists](core-concepts/credentials-and-data/credential-status-and-bitstring-status-lists.md)
     -   [Schemas, Types, & Categories](core-concepts/credentials-and-data/achievement-types-and-categories.md)
+    -   [Display Hint Tags (`lc:` convention)](core-concepts/credentials-and-data/display-hint-tags.md)
     -   [Building Verifiable Credentials](core-concepts/credentials-and-data/building-verifiable-credentials.md)
     -   [Boost Credentials](core-concepts/credentials-and-data/boost-credentials.md)
     -   [Getting Started with Boosts](core-concepts/credentials-and-data/getting-started-with-boosts.md)

--- a/docs/core-concepts/credentials-and-data/display-hint-tags.md
+++ b/docs/core-concepts/credentials-and-data/display-hint-tags.md
@@ -39,13 +39,14 @@ lc:<key>:<value>
 
 ## Recognized keys
 
-| Tag                     | Meaning                                                                                              | Value format                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `lc:subtype:<Label>`    | Human-facing subtype label, shown in place of the coarse category. Decoupled from `achievementType`. | Free text, e.g. `Trailblazer`, `Event`                          |
-| `lc:displayType:<type>` | Preferred visual layout                                                                              | One of `badge`, `certificate`, `id`, `course`, `award`, `media` |
-| `lc:bgColor:<hex>`      | Background color                                                                                     | Hex, with or without leading `#` (`353E64` or `#353E64`)        |
-| `lc:bgImage:<url>`      | Background image                                                                                     | An `https` URL                                                  |
-| `lc:accentColor:<hex>`  | Accent color (reserved)                                                                              | Hex, with or without leading `#`                                |
+| Tag                     | Meaning                                                                                              | Value format                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `lc:category:<name>`    | Credential category. Only accepted if it matches a known LearnCard category.                         | One of the known credential categories (e.g. `Achievement`, `ID`) |
+| `lc:subtype:<Label>`    | Human-facing subtype label, shown in place of the coarse category. Decoupled from `achievementType`. | Free text, e.g. `Trailblazer`, `Event`                            |
+| `lc:displayType:<type>` | Preferred visual layout                                                                              | One of `badge`, `certificate`, `id`, `course`, `award`, `media`   |
+| `lc:bgColor:<hex>`      | Background color                                                                                     | Hex, with or without leading `#` (`353E64` or `#353E64`)          |
+| `lc:bgImage:<url>`      | Background image                                                                                     | An `https` URL                                                    |
+| `lc:accentColor:<hex>`  | Accent color used for the badge ring and accent text                                                 | Hex, with or without leading `#`                                  |
 
 ## Why `subtype` is decoupled from `achievementType`
 
@@ -62,7 +63,7 @@ When a wallet resolves a credential's display type, hints are weighted in this o
 3. The credential's `achievementType`.
 4. The credential's category.
 
-Background color and image resolve to the legacy `display` object first, then fall back to the corresponding `lc:` tag.
+Background color, background image, and accent color resolve the same way: the legacy `display` object wins, then the corresponding `lc:` tag is used as a fallback.
 
 ## Backwards compatibility
 

--- a/docs/core-concepts/credentials-and-data/display-hint-tags.md
+++ b/docs/core-concepts/credentials-and-data/display-hint-tags.md
@@ -1,0 +1,71 @@
+---
+description: A standards-pure convention for carrying display hints on Open Badges v3 credentials using the native `tag` field.
+---
+
+# Display Hint Tags (`lc:` convention)
+
+LearnCard credentials are **standards-pure** Open Badges v3 / W3C Verifiable Credentials. To let a wallet render a credential more richly — a background color, a certificate-style layout, a friendly subtype label — without adding bespoke fields or custom JSON-LD `@context` terms, LearnCard uses a small, namespaced convention that rides inside the credential's existing, spec-defined `tag` array.
+
+Because these are ordinary tags, any wallet that doesn't understand them simply ignores them. There is **zero interoperability cost** and **zero spec violation**. If other wallets choose to adopt the convention, it becomes a de-facto display micro-standard.
+
+## Where the tags live
+
+Open Badges v3 defines an optional `tag` property on the `Achievement` as an array of strings. Display hints go there:
+
+```json
+{
+    "credentialSubject": {
+        "achievement": {
+            "type": ["Achievement"],
+            "achievementType": "Achievement",
+            "name": "Trailblazer",
+            "tag": ["lc:subtype:Trailblazer", "lc:displayType:certificate", "lc:bgColor:353E64"]
+        }
+    }
+}
+```
+
+## Format
+
+Each hint is a single string of the form:
+
+```
+lc:<key>:<value>
+```
+
+-   The `lc` namespace and the `<key>` are matched **case-insensitively**.
+-   Only the **first two colons** are structural. Everything after the second colon is the value, verbatim — so values may themselves contain colons (e.g. a URL).
+-   Every recognized tag is a **hint, never a requirement**. Unknown keys are ignored, and malformed values (a bad hex color, an unknown display type, a non-`https` URL) are dropped rather than causing an error.
+
+## Recognized keys
+
+| Tag                     | Meaning                                                                                              | Value format                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `lc:subtype:<Label>`    | Human-facing subtype label, shown in place of the coarse category. Decoupled from `achievementType`. | Free text, e.g. `Trailblazer`, `Event`                          |
+| `lc:displayType:<type>` | Preferred visual layout                                                                              | One of `badge`, `certificate`, `id`, `course`, `award`, `media` |
+| `lc:bgColor:<hex>`      | Background color                                                                                     | Hex, with or without leading `#` (`353E64` or `#353E64`)        |
+| `lc:bgImage:<url>`      | Background image                                                                                     | An `https` URL                                                  |
+| `lc:accentColor:<hex>`  | Accent color (reserved)                                                                              | Hex, with or without leading `#`                                |
+
+## Why `subtype` is decoupled from `achievementType`
+
+Earlier LearnCard credentials expressed a badge's flavor by pushing values like `ext:Trailblazer` into the OBv3 `achievementType`. That is spec-legal (the `ext:` prefix is the OBv3 extension convention) but coarse: `achievementType` is meant to describe the _kind_ of achievement, not its brand or theme.
+
+With this convention, `achievementType` stays a clean, interoperable spec value (e.g. `Achievement`) and the richer, human-facing label lives in `lc:subtype`. Wallets that understand the convention show the subtype; everyone else still reads a valid, standard credential.
+
+## Precedence
+
+When a wallet resolves a credential's display type, hints are weighted in this order (highest first):
+
+1. An explicit legacy `display.displayType` object (for backwards compatibility with older LearnCard credentials).
+2. An `lc:displayType:*` tag.
+3. The credential's `achievementType`.
+4. The credential's category.
+
+Background color and image resolve to the legacy `display` object first, then fall back to the corresponding `lc:` tag.
+
+## Backwards compatibility
+
+-   Credentials **without** any `lc:` tags behave exactly as before.
+-   Older credentials that used the internal `display` object continue to render from it; the object wins over the tags.
+-   Newly issued LearnCard credentials use tags only, keeping the issued credential fully interoperable.

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialBadge.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialBadge.tsx
@@ -275,9 +275,20 @@ export const CredentialBadge: React.FC<CredentialBadgeProps> = ({
                         className={`absolute flex items-center justify-center left-[37%] bottom-[-12%] ${badgeRibbonContainerCustomClass}`}
                     >
                         <Ribbon className={badgeRibbonCustomClass} />
-                        <IconComponentOverride
-                            className={`absolute text-${_colorOverride} h-[30px] mb-3 ${badgeRibbonIconCustomClass}`}
-                        />
+                        {accentColor ? (
+                            <span
+                                className="absolute mb-3 flex items-center justify-center"
+                                style={{ color: accentColor }}
+                            >
+                                <IconComponentOverride
+                                    className={`h-[30px] ${badgeRibbonIconCustomClass}`}
+                                />
+                            </span>
+                        ) : (
+                            <IconComponentOverride
+                                className={`absolute text-${_colorOverride} h-[30px] mb-3 ${badgeRibbonIconCustomClass}`}
+                            />
+                        )}
                     </div>
                 </div>
             )}

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialBadge.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialBadge.tsx
@@ -26,6 +26,8 @@ import { BoostCategoryOptionsEnum, boostCategoryMetadata } from 'learn-card-base
 type CredentialBadgeProps = {
     boostType?: BoostCategoryOptionsEnum;
     achievementType: string;
+    subtype?: string;
+    accentColor?: string;
     fallbackCircleText?: string;
     badgeThumbnail: string;
     showBackgroundImage: boolean;
@@ -52,6 +54,8 @@ type CredentialBadgeProps = {
 export const CredentialBadge: React.FC<CredentialBadgeProps> = ({
     boostType,
     achievementType,
+    subtype,
+    accentColor,
     fallbackCircleText,
     badgeThumbnail,
     showBackgroundImage = false,
@@ -104,11 +108,13 @@ export const CredentialBadge: React.FC<CredentialBadgeProps> = ({
         _subColorOverride = 'bg-lime-500';
     }
 
-    let badgeCircleText = getAchievementTypeDisplayText(
-        achievementType,
-        boostType ?? defaultBoostType,
-        fallbackCircleText
-    );
+    let badgeCircleText =
+        subtype ||
+        getAchievementTypeDisplayText(
+            achievementType,
+            boostType ?? defaultBoostType,
+            fallbackCircleText
+        );
 
     // check what display type to render
     const isBadgeDisplayType = displayType === 'badge';
@@ -243,6 +249,7 @@ export const CredentialBadge: React.FC<CredentialBadgeProps> = ({
             ) : (
                 <div
                     className={`relative z-50 flex items-center justify-center rounded-full border-white border-solid border-4 ${borderStyle} ${displayTypeStyles}`}
+                    style={accentColor ? { backgroundColor: accentColor } : undefined}
                 >
                     <div
                         className={`relative flex items-center justify-center w-[60%] h-[60%] rounded-full border-white border-solid border-4 ${borderStyle} ${_subColorOverride} overflow-hidden object-contain bg-${subColor} ${badgeThumbnailContainerClass}`}

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
@@ -24,6 +24,7 @@ import { BoostCategoryOptionsEnum, boostCategoryMetadata, getBoostMetadata } fro
 type CredentialBadgeProps = {
     boostType?: BoostCategoryOptionsEnum;
     achievementType: string;
+    accentColor?: string;
     fallbackCircleText?: string;
     badgeThumbnail: string;
     showBackgroundImage: boolean;
@@ -50,6 +51,7 @@ type CredentialBadgeProps = {
 export const CredentialBadgeNew: React.FC<CredentialBadgeProps> = ({
     boostType,
     achievementType,
+    accentColor,
     fallbackCircleText,
     badgeThumbnail,
     showBackgroundImage = false,
@@ -230,6 +232,7 @@ export const CredentialBadgeNew: React.FC<CredentialBadgeProps> = ({
             ) : (
                 <div
                     className={`relative z-50 flex items-center justify-center rounded-full border-white border-solid border-4 ${borderStyle} ${displayTypeStyles}`}
+                    style={accentColor ? { backgroundColor: accentColor } : undefined}
                 >
                     <div
                         className={`relative flex items-center justify-center w-[60%] h-[60%] rounded-full border-white border-solid border-4 ${borderStyle} ${_subColorOverride} overflow-hidden object-contain bg-${subColor} ${badgeThumbnailContainerClass}`}

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialBadgeNew.tsx
@@ -258,9 +258,20 @@ export const CredentialBadgeNew: React.FC<CredentialBadgeProps> = ({
                         className={`absolute flex items-center justify-center left-[37%] bottom-[-12%] ${badgeRibbonContainerCustomClass}`}
                     >
                         <Ribbon className={badgeRibbonCustomClass} />
-                        <IconComponentOverride
-                            className={`absolute text-${_colorOverride} h-[18px] mb-3 ${badgeRibbonIconCustomClass}`}
-                        />
+                        {accentColor ? (
+                            <span
+                                className="absolute mb-3 flex items-center justify-center"
+                                style={{ color: accentColor }}
+                            >
+                                <IconComponentOverride
+                                    className={`h-[18px] ${badgeRibbonIconCustomClass}`}
+                                />
+                            </span>
+                        ) : (
+                            <IconComponentOverride
+                                className={`absolute text-${_colorOverride} h-[18px] mb-3 ${badgeRibbonIconCustomClass}`}
+                            />
+                        )}
                     </div>
                 </div>
             )}

--- a/packages/learn-card-base/src/components/CredentialBadge/CredentialVerificationDisplay.tsx
+++ b/packages/learn-card-base/src/components/CredentialBadge/CredentialVerificationDisplay.tsx
@@ -42,6 +42,7 @@ type CredentialVerificationDisplayProps = {
     unknownVerifierTitle?: string;
     issuerDisplayName?: string;
     issuerPopoverEnabled?: boolean;
+    trustedOnly?: boolean;
 };
 
 export const CredentialVerificationDisplay: React.FC<CredentialVerificationDisplayProps> = ({
@@ -53,6 +54,7 @@ export const CredentialVerificationDisplay: React.FC<CredentialVerificationDispl
     unknownVerifierTitle,
     issuerDisplayName,
     issuerPopoverEnabled = true,
+    trustedOnly = false,
 }) => {
     const popoverId = useId().replace(/:/g, '');
     const profileID =
@@ -102,6 +104,12 @@ export const CredentialVerificationDisplay: React.FC<CredentialVerificationDispl
     } else {
         verifierState = isAppIssuer ? VERIFIER_STATES.appIssuer : VERIFIER_STATES.unknownVerifier;
     }
+    const isTrustedVerifier =
+        verifierState === VERIFIER_STATES.trustedVerifier ||
+        verifierState === VERIFIER_STATES.appIssuer;
+
+    if (trustedOnly && !isTrustedVerifier) return <></>;
+
     const popoverTriggerId = `credential-issuer-trigger-${popoverId}`;
     const verifierStateLabel = unknownVerifierTitle ?? verifierState;
     const renderBadge = (badgeClassName = className, badgeIconClassName = iconClassName) => {

--- a/packages/learn-card-base/src/components/IssueVC/constants.ts
+++ b/packages/learn-card-base/src/components/IssueVC/constants.ts
@@ -342,7 +342,7 @@ export const CATEGORY_TO_TEMPLATE_LIST = {
             type: AchievementTypes.Award,
         },
         {
-            title: 'Online Badge',
+            title: 'Badge',
             type: AchievementTypes.Badge,
         },
     ],

--- a/packages/learn-card-base/src/components/boost/BoostListItem.tsx
+++ b/packages/learn-card-base/src/components/boost/BoostListItem.tsx
@@ -46,6 +46,7 @@ type BoostListItemProps = {
     unknownVerifierTitle?: string;
     relativeDate?: boolean;
     compact?: boolean;
+    trustedVerifierOnly?: boolean;
 };
 
 const DEFAULT_BG_COLOR = 'bg-white';
@@ -68,6 +69,7 @@ const BoostListItem: React.FC<BoostListItemProps> = ({
     unknownVerifierTitle,
     relativeDate = false,
     compact = false,
+    trustedVerifierOnly = false,
 }) => {
     const newCreds = newCredsStore.use.newCreds();
     const newCredsForCategory = newCreds?.[categoryType as CredentialCategory] ?? [];
@@ -276,6 +278,7 @@ const BoostListItem: React.FC<BoostListItemProps> = ({
                             credential={credential}
                             iconClassName={verificationIconClass}
                             unknownVerifierTitle={unknownVerifierTitle}
+                            trustedOnly={trustedVerifierOnly}
                         />
                     )}
                     {compact ? (

--- a/packages/learn-card-base/src/components/boost/boostOptions/boostOptions.ts
+++ b/packages/learn-card-base/src/components/boost/boostOptions/boostOptions.ts
@@ -39,7 +39,6 @@ export const CATEGORY_TO_SUBCATEGORY_LIST: {
 
         { title: 'Generic', type: AchievementTypes.Achievement },
         { title: 'Formal Award', type: AchievementTypes.Award },
-        { title: 'Online Badge', type: AchievementTypes.Badge },
         { title: 'Community Service', type: AchievementTypes.CommunityService },
 
         // extended ( Achievement ) category types
@@ -129,6 +128,7 @@ export const CATEGORY_TO_SUBCATEGORY_LIST: {
         { title: 'Board', type: AchievementTypes.Board },
     ],
     [BoostCategoryOptionsEnum.socialBadge]: [
+        { title: 'Badge', type: AchievementTypes.Badge },
         { title: 'Risk Taker', type: AchievementTypes.RiskTaker },
         { title: 'Opportunist', type: AchievementTypes.Opportunist },
         { title: 'Cool Cat', type: AchievementTypes.CoolCat },

--- a/packages/learn-card-base/src/components/form-inputs/SelectInput.tsx
+++ b/packages/learn-card-base/src/components/form-inputs/SelectInput.tsx
@@ -37,14 +37,24 @@ const SelectInput: React.FC<SelectInputProps> = ({
 
     const selectedOption = options.find(o => o.value === value);
 
+    const hasDescriptions = options.some(o => o.description);
+
     const openSelectModal = () => {
         if (disabled) return;
 
         newModal(
-            <div className="text-grayscale-900 flex flex-col py-[10px]">
+            <div
+                className={`text-grayscale-900 flex flex-col max-h-[70vh] overflow-y-auto ${
+                    hasDescriptions ? 'py-[8px] px-[6px] gap-[2px]' : 'py-[10px]'
+                }`}
+            >
                 {allowDeselect && value !== null && value !== undefined && (
                     <button
-                        className="py-[10px] text-grayscale-500 italic"
+                        className={`text-grayscale-500 italic ${
+                            hasDescriptions
+                                ? 'py-[10px] px-[16px] text-left rounded-[12px] hover:bg-grayscale-10 transition-colors'
+                                : 'py-[10px]'
+                        }`}
                         onClick={() => {
                             onChange(null);
                             closeModal();
@@ -92,7 +102,7 @@ const SelectInput: React.FC<SelectInputProps> = ({
                     )
                 )}
             </div>,
-            { sectionClassName: '!max-w-[300px]' }
+            { sectionClassName: hasDescriptions ? '!max-w-[400px] !w-[90%]' : '!max-w-[300px]' }
         );
     };
 

--- a/packages/learn-card-base/src/components/form-inputs/SelectInput.tsx
+++ b/packages/learn-card-base/src/components/form-inputs/SelectInput.tsx
@@ -8,6 +8,7 @@ type SelectOption = {
     value: string | number;
     displayText?: string;
     selectedText?: string;
+    description?: string;
 };
 
 type SelectInputProps = {
@@ -52,18 +53,44 @@ const SelectInput: React.FC<SelectInputProps> = ({
                         Clear selection
                     </button>
                 )}
-                {options.map(o => (
-                    <button
-                        key={o.value}
-                        className={`py-[10px] ${o.value === value ? 'font-[700]' : ''}`}
-                        onClick={() => {
-                            onChange(o.value);
-                            closeModal();
-                        }}
-                    >
-                        {o.displayText ?? o.value}
-                    </button>
-                ))}
+                {options.map(o =>
+                    o.description ? (
+                        <button
+                            key={o.value}
+                            className={`flex flex-col gap-[2px] text-left px-[16px] py-[12px] rounded-[12px] transition-colors hover:bg-grayscale-10 ${
+                                o.value === value ? 'bg-grayscale-100' : ''
+                            }`}
+                            onClick={() => {
+                                onChange(o.value);
+                                closeModal();
+                            }}
+                        >
+                            <span
+                                className={`${
+                                    o.value === value
+                                        ? 'font-[700] text-grayscale-900'
+                                        : 'font-[600] text-grayscale-800'
+                                }`}
+                            >
+                                {o.displayText ?? o.value}
+                            </span>
+                            <span className="text-[13px] leading-[130%] text-grayscale-500">
+                                {o.description}
+                            </span>
+                        </button>
+                    ) : (
+                        <button
+                            key={o.value}
+                            className={`py-[10px] ${o.value === value ? 'font-[700]' : ''}`}
+                            onClick={() => {
+                                onChange(o.value);
+                                closeModal();
+                            }}
+                        >
+                            {o.displayText ?? o.value}
+                        </button>
+                    )
+                )}
             </div>,
             { sectionClassName: '!max-w-[300px]' }
         );

--- a/packages/learn-card-base/src/components/vcmodal/VCDisplayCardWrapper2.tsx
+++ b/packages/learn-card-base/src/components/vcmodal/VCDisplayCardWrapper2.tsx
@@ -182,6 +182,10 @@ export const VCDisplayCardWrapper2: React.FC<VCDisplayCardWrapper2Props> = ({
 
         // VC Display Metadata
         displayType,
+        subtype,
+        accentColor,
+        backgroundColor,
+        backgroundImage,
         idFontColor,
         idAccentColor,
         idDisplayBackgroundImage,
@@ -285,9 +289,11 @@ export const VCDisplayCardWrapper2: React.FC<VCDisplayCardWrapper2Props> = ({
             display: {
                 ...(credential.display ?? {}),
                 displayType: String(displayType).toLowerCase(),
+                ...(backgroundColor ? { backgroundColor } : {}),
+                ...(backgroundImage ? { backgroundImage } : {}),
             },
         };
-    }, [credential, displayType]);
+    }, [credential, displayType, backgroundColor, backgroundImage]);
 
     const subtitleDisplayType = achievementType ? formattedAchievementType : displayType;
 
@@ -339,6 +345,8 @@ export const VCDisplayCardWrapper2: React.FC<VCDisplayCardWrapper2Props> = ({
                     ) : (
                         <CredentialBadge
                             achievementType={achievementType}
+                            subtype={subtype}
+                            accentColor={accentColor}
                             fallbackCircleText={overrideCardTitle || title}
                             boostType={category}
                             badgeThumbnail={overrideCardImageUrl || badgeThumbnail!}

--- a/packages/learn-card-base/src/components/wrappers/BoostGenericCardWrapper.tsx
+++ b/packages/learn-card-base/src/components/wrappers/BoostGenericCardWrapper.tsx
@@ -48,6 +48,7 @@ type BoostGenericCardWrapperProps = {
     relativeDate?: boolean;
     compact?: boolean;
     isCLR?: boolean;
+    trustedVerifierOnly?: boolean;
 };
 
 export const BoostGenericCardWrapper: React.FC<BoostGenericCardWrapperProps> = ({
@@ -84,6 +85,7 @@ export const BoostGenericCardWrapper: React.FC<BoostGenericCardWrapperProps> = (
     relativeDate,
     compact,
     isCLR,
+    trustedVerifierOnly,
 }) => {
     if (boostPageViewMode === BoostPageViewMode.List) {
         return (
@@ -104,6 +106,7 @@ export const BoostGenericCardWrapper: React.FC<BoostGenericCardWrapperProps> = (
                 unknownVerifierTitle={unknownVerifierTitle}
                 relativeDate={relativeDate}
                 compact={compact}
+                trustedVerifierOnly={trustedVerifierOnly}
             />
         );
     }
@@ -136,6 +139,7 @@ export const BoostGenericCardWrapper: React.FC<BoostGenericCardWrapperProps> = (
                         iconClassName="!w-[15px] !h-[15px]"
                         showText={!!unknownVerifierTitle}
                         unknownVerifierTitle={unknownVerifierTitle}
+                        trustedOnly={trustedVerifierOnly}
                     />
                 )
             }

--- a/packages/learn-card-base/src/config/tenantConfigSchema.ts
+++ b/packages/learn-card-base/src/config/tenantConfigSchema.ts
@@ -250,6 +250,21 @@ export const tenantEcosystemConfigSchema = z
     })
     .passthrough();
 
+/**
+ * External data registries a tenant pulls in. `stylePackUrls` are remote JSON
+ * files (LCAStylesPackRegistryEntry[]); `stylePackAssets` are names of bundled
+ * JSON files shipped with the app (apps/learn-card-app/src/registries/style-packs/<name>.json).
+ * All sources merge left→right, deduped by category+type, later source wins per field.
+ */
+export const tenantRegistriesConfigSchema = z
+    .object({
+        stylePackUrls: z.array(z.string()).default([]),
+        stylePackAssets: z.array(z.string()).default([]),
+        badgeGroupUrls: z.array(z.string()).default([]),
+        badgeGroupAssets: z.array(z.string()).default([]),
+    })
+    .passthrough();
+
 // -----------------------------------------------------------------
 // Schema version — bump when making breaking changes to the config shape.
 // Used by resolveTenantConfig() to invalidate stale caches.
@@ -278,6 +293,7 @@ export const tenantConfigSchema = z
         email: tenantEmailConfigSchema.optional(),
         native: tenantNativeConfigSchema.optional(),
         ecosystem: tenantEcosystemConfigSchema.optional(),
+        registries: tenantRegistriesConfigSchema.default({}),
     })
     .passthrough();
 

--- a/packages/learn-card-base/src/config/tenantDefaults.ts
+++ b/packages/learn-card-base/src/config/tenantDefaults.ts
@@ -112,9 +112,9 @@ export const DEFAULT_LEARNCARD_TENANT_CONFIG: TenantConfig = {
         stylePackUrls: [
             'https://raw.githubusercontent.com/WeLibraryOS/metaversity-registry/main/lca-style-packs-registry.json',
         ],
-        stylePackAssets: ['learncard'],
+        stylePackAssets: ['badge-summit', 'learncard'],
         badgeGroupUrls: [],
-        badgeGroupAssets: ['learncard'],
+        badgeGroupAssets: ['badge-summit', 'learncard'],
     },
 
     links: {

--- a/packages/learn-card-base/src/config/tenantDefaults.ts
+++ b/packages/learn-card-base/src/config/tenantDefaults.ts
@@ -112,9 +112,9 @@ export const DEFAULT_LEARNCARD_TENANT_CONFIG: TenantConfig = {
         stylePackUrls: [
             'https://raw.githubusercontent.com/WeLibraryOS/metaversity-registry/main/lca-style-packs-registry.json',
         ],
-        stylePackAssets: ['badge-summit', 'learncard'],
+        stylePackAssets: ['learncard'],
         badgeGroupUrls: [],
-        badgeGroupAssets: ['badge-summit', 'learncard'],
+        badgeGroupAssets: ['learncard'],
     },
 
     links: {

--- a/packages/learn-card-base/src/config/tenantDefaults.ts
+++ b/packages/learn-card-base/src/config/tenantDefaults.ts
@@ -108,6 +108,15 @@ export const DEFAULT_LEARNCARD_TENANT_CONFIG: TenantConfig = {
         posthogHost: undefined,
     },
 
+    registries: {
+        stylePackUrls: [
+            'https://raw.githubusercontent.com/WeLibraryOS/metaversity-registry/main/lca-style-packs-registry.json',
+        ],
+        stylePackAssets: ['learncard'],
+        badgeGroupUrls: [],
+        badgeGroupAssets: ['learncard'],
+    },
+
     links: {
         appStoreUrl: 'https://apps.apple.com/us/app/learncard/id1635841898',
         playStoreUrl: 'https://play.google.com/store/apps/details?id=com.learncard.app',

--- a/packages/learn-card-base/src/helpers/__tests__/displayTags.helpers.test.ts
+++ b/packages/learn-card-base/src/helpers/__tests__/displayTags.helpers.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { DisplayTypeEnum } from '../display-types';
+import { buildLcTags, parseLcTags } from '../displayTags.helpers';
+
+describe('parseLcTags', () => {
+    it('returns an empty object for undefined / non-array input', () => {
+        expect(parseLcTags(undefined)).toEqual({});
+        expect(parseLcTags(null as unknown as string[])).toEqual({});
+        expect(parseLcTags('lc:subtype:Event' as unknown as string[])).toEqual({});
+    });
+
+    it('parses each recognized key', () => {
+        expect(
+            parseLcTags([
+                'lc:subtype:Trailblazer',
+                'lc:displayType:certificate',
+                'lc:bgColor:353E64',
+                'lc:bgImage:https://example.com/bg.png',
+                'lc:accentColor:#FF0000',
+            ])
+        ).toEqual({
+            subtype: 'Trailblazer',
+            displayType: DisplayTypeEnum.Certificate,
+            backgroundColor: '#353E64',
+            backgroundImage: 'https://example.com/bg.png',
+            accentColor: '#FF0000',
+        });
+    });
+
+    it('ignores non-lc namespaces and unknown keys', () => {
+        expect(parseLcTags(['ext:Trailblazer', 'skill:coding', 'lc:unknown:foo'])).toEqual({});
+    });
+
+    it('matches namespace and key case-insensitively but preserves value case', () => {
+        expect(parseLcTags(['LC:SubType:CoolCat'])).toEqual({ subtype: 'CoolCat' });
+    });
+
+    it('preserves colons in values (only first two colons are structural)', () => {
+        expect(parseLcTags(['lc:bgImage:https://a.com/x:y.png'])).toEqual({
+            backgroundImage: 'https://a.com/x:y.png',
+        });
+    });
+
+    it('ignores an invalid display type', () => {
+        expect(parseLcTags(['lc:displayType:hologram'])).toEqual({});
+    });
+
+    it('accepts hex colors with or without a leading hash and normalizes to hash', () => {
+        expect(parseLcTags(['lc:bgColor:fff'])).toEqual({ backgroundColor: '#fff' });
+        expect(parseLcTags(['lc:bgColor:#AABBCC'])).toEqual({ backgroundColor: '#AABBCC' });
+    });
+
+    it('ignores invalid hex colors', () => {
+        expect(parseLcTags(['lc:bgColor:notacolor'])).toEqual({});
+        expect(parseLcTags(['lc:bgColor:12345'])).toEqual({});
+    });
+
+    it('ignores non-https background images', () => {
+        expect(parseLcTags(['lc:bgImage:http://insecure.com/a.png'])).toEqual({});
+        expect(parseLcTags(['lc:bgImage:not a url'])).toEqual({});
+    });
+
+    it('ignores malformed tags and empty values', () => {
+        expect(parseLcTags(['lc', 'lc:subtype', 'lc:subtype:', ''])).toEqual({});
+    });
+
+    it('lets later tags win for the same key', () => {
+        expect(parseLcTags(['lc:subtype:First', 'lc:subtype:Second'])).toEqual({
+            subtype: 'Second',
+        });
+    });
+});
+
+describe('buildLcTags', () => {
+    it('emits only defined, valid hints', () => {
+        expect(
+            buildLcTags({
+                subtype: 'Trailblazer',
+                displayType: DisplayTypeEnum.Certificate,
+                backgroundColor: '#353E64',
+                backgroundImage: 'https://example.com/bg.png',
+                accentColor: 'FF0000',
+            })
+        ).toEqual([
+            'lc:subtype:Trailblazer',
+            'lc:displayType:certificate',
+            'lc:bgColor:353E64',
+            'lc:bgImage:https://example.com/bg.png',
+            'lc:accentColor:FF0000',
+        ]);
+    });
+
+    it('emits colors without a leading hash', () => {
+        expect(buildLcTags({ backgroundColor: '#abcdef' })).toEqual(['lc:bgColor:abcdef']);
+    });
+
+    it('skips invalid values', () => {
+        expect(
+            buildLcTags({ backgroundColor: 'nope', backgroundImage: 'http://insecure.com/a.png' })
+        ).toEqual([]);
+    });
+
+    it('round-trips through parseLcTags', () => {
+        const hints = {
+            subtype: 'CoolCat',
+            displayType: DisplayTypeEnum.Badge,
+            backgroundColor: '#123456',
+            backgroundImage: 'https://cdn.example.com/a.png',
+            accentColor: '#654321',
+        };
+
+        expect(parseLcTags(buildLcTags(hints))).toEqual(hints);
+    });
+});

--- a/packages/learn-card-base/src/helpers/colorHelpers.ts
+++ b/packages/learn-card-base/src/helpers/colorHelpers.ts
@@ -13,6 +13,68 @@ export const getRandomBaseColor = (): string => {
     return baseColors[Math.floor(Math.random() * baseColors.length)];
 };
 
+const clamp = (n: number, min: number, max: number): number => Math.min(max, Math.max(min, n));
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | undefined => {
+    let h = hex.trim().replace(/^#/, '');
+    if (h.length === 3)
+        h = h
+            .split('')
+            .map(c => c + c)
+            .join('');
+    if (h.length === 8) h = h.slice(0, 6);
+    if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return undefined;
+    const num = parseInt(h, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+};
+
+const rgbToHex = (r: number, g: number, b: number): string =>
+    '#' + [r, g, b].map(x => clamp(Math.round(x), 0, 255).toString(16).padStart(2, '0')).join('');
+
+const rgbToHsl = (r: number, g: number, b: number): [number, number, number] => {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return [0, 0, l];
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h = 0;
+    if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    return [h / 6, s, l];
+};
+
+const hslToRgb = (h: number, s: number, l: number): [number, number, number] => {
+    if (s === 0) return [l * 255, l * 255, l * 255];
+    const hue2rgb = (p: number, q: number, t: number): number => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    return [hue2rgb(p, q, h + 1 / 3) * 255, hue2rgb(p, q, h) * 255, hue2rgb(p, q, h - 1 / 3) * 255];
+};
+
+/** Derive a harmonious badge-ring accent from a background color (same hue, deeper shade). Returns undefined for invalid input. */
+export const deriveAccentColor = (backgroundColor?: string | null): string | undefined => {
+    if (!backgroundColor) return undefined;
+    const rgb = hexToRgb(backgroundColor);
+    if (!rgb) return undefined;
+    const [h, s, l] = rgbToHsl(rgb.r, rgb.g, rgb.b);
+    const targetL = clamp(l <= 0.28 ? l + 0.16 : l - 0.24, 0.16, 0.82);
+    const targetS = clamp(s + 0.12, 0, 1);
+    const [r, g, b] = hslToRgb(h, targetS, targetL);
+    return rgbToHex(r, g, b);
+};
+
 const LIGHT_OR_EMPTY_BG = /^(|bg-white|bg-(grayscale|gray|neutral|stone|zinc|slate)-(50|100|200))$/;
 
 export const ensureVisibleBaseColor = (color?: string | null): string => {

--- a/packages/learn-card-base/src/helpers/credentialHelpers.ts
+++ b/packages/learn-card-base/src/helpers/credentialHelpers.ts
@@ -39,6 +39,7 @@ import { BoostCMSMediaAttachment, BoostEvidenceSpec } from 'learn-card-base/comp
 import { getVideoMetadata } from './video.helpers';
 import { getFileMetadata } from './attachment.helpers';
 import { getLogger } from '../logging/logger';
+import { parseLcTags } from './displayTags.helpers';
 const log = getLogger('credential-helpers');
 
 type CredentialType =
@@ -538,6 +539,11 @@ export const getDefaultCategoryForCredential = (
     options?: { skipValidation?: boolean }
 ): CredentialCategory => {
     const _credential = unwrapBoostCredential(credential);
+
+    // An explicit `lc:category` display-hint tag is a deliberate issuer choice and takes priority over all type inference below.
+    const lcCategory = parseLcTags(getCredentialSubjectAchievement(_credential)?.tag).category;
+    if (lcCategory) return lcCategory as CredentialCategory;
+
     // course meta VC is a metaversity specific case for now
     if (isCourseMetaVC(_credential)) return 'Learning History';
     if (isEntryVC(_credential) && _credential.id.split('|')[0] === 'course') return 'Hidden';

--- a/packages/learn-card-base/src/helpers/credentialHelpers.ts
+++ b/packages/learn-card-base/src/helpers/credentialHelpers.ts
@@ -141,7 +141,7 @@ export const CATEGORY_MAP: Record<
 > = {
     Achievement: 'Achievement',
     Award: 'Achievement',
-    Badge: 'Achievement',
+    Badge: 'Social Badge',
     CommunityService: 'Achievement',
     MovieTicketCredential: 'Achievement',
 

--- a/packages/learn-card-base/src/helpers/credentialHelpers.ts
+++ b/packages/learn-card-base/src/helpers/credentialHelpers.ts
@@ -796,7 +796,7 @@ export const getFallBackImage = (credCategory: string) => {
     if (credCategory === 'Work History')
         return 'https://cdn.filestackcontent.com/5r2T383T0mic3wrSbi3W';
     if (credCategory === 'Social Badge')
-        return 'https://cdn.filestackcontent.com/ynPzjedXTn2JBUNQHeEm';
+        return 'https://cdn.filestackcontent.com/DRPwxXjSWKl6TTkd2OCF';
     if (credCategory === 'Learning History')
         return 'https://cdn.filestackcontent.com/OSTqZlxSCe6B62jwPm7O';
     if (credCategory === 'Accomplishment')

--- a/packages/learn-card-base/src/helpers/display-types.ts
+++ b/packages/learn-card-base/src/helpers/display-types.ts
@@ -1,0 +1,13 @@
+export enum DisplayTypeEnum {
+    Badge = 'badge',
+    Certificate = 'certificate',
+    ID = 'id',
+    Course = 'course',
+    Award = 'award',
+    Media = 'media',
+}
+
+export enum PreviewTypeEnum {
+    Default = 'default',
+    Media = 'media',
+}

--- a/packages/learn-card-base/src/helpers/display.helpers.ts
+++ b/packages/learn-card-base/src/helpers/display.helpers.ts
@@ -14,19 +14,8 @@ import {
 } from '../svgs/attachmentTypes/attachmentIcons';
 import { BoostMediaOptionsEnum } from 'learn-card-base/components/boost/boost';
 
-export enum DisplayTypeEnum {
-    Badge = 'badge',
-    Certificate = 'certificate',
-    ID = 'id',
-    Course = 'course',
-    Award = 'award',
-    Media = 'media',
-}
-
-export enum PreviewTypeEnum {
-    Default = 'default',
-    Media = 'media',
-}
+export { DisplayTypeEnum, PreviewTypeEnum } from './display-types';
+import { DisplayTypeEnum } from './display-types';
 
 /**
  * Map from achievementType directly to its semantically-obvious display type.
@@ -45,8 +34,11 @@ const ACHIEVEMENT_TYPE_TO_DISPLAY_TYPE: Record<string, DisplayTypeEnum> = {
 
 export const getDefaultDisplayType = (
     category: string,
-    achievementType?: string
+    achievementType?: string,
+    displayTypeHint?: DisplayTypeEnum
 ): DisplayTypeEnum => {
+    if (displayTypeHint) return displayTypeHint;
+
     if (achievementType) {
         const directMatch =
             ACHIEVEMENT_TYPE_TO_DISPLAY_TYPE[

--- a/packages/learn-card-base/src/helpers/displayTags.helpers.ts
+++ b/packages/learn-card-base/src/helpers/displayTags.helpers.ts
@@ -1,4 +1,5 @@
 import { DisplayTypeEnum } from './display-types';
+import { CREDENTIAL_CATEGORIES } from '../types/credentials';
 
 /**
  * LearnCard display-tag convention (`lc:` namespace)
@@ -33,6 +34,7 @@ import { DisplayTypeEnum } from './display-types';
 export const LC_TAG_NAMESPACE = 'lc';
 
 export enum LcTagKey {
+    Category = 'category',
     Subtype = 'subtype',
     DisplayType = 'displaytype',
     BgColor = 'bgcolor',
@@ -41,6 +43,7 @@ export enum LcTagKey {
 }
 
 const LC_TAG_CANONICAL_KEY: Record<LcTagKey, string> = {
+    [LcTagKey.Category]: 'category',
     [LcTagKey.Subtype]: 'subtype',
     [LcTagKey.DisplayType]: 'displayType',
     [LcTagKey.BgColor]: 'bgColor',
@@ -49,12 +52,16 @@ const LC_TAG_CANONICAL_KEY: Record<LcTagKey, string> = {
 };
 
 export type LcDisplayHints = {
+    category?: string;
     subtype?: string;
     displayType?: DisplayTypeEnum;
     backgroundColor?: string;
     backgroundImage?: string;
     accentColor?: string;
 };
+
+const isValidCategory = (value: string): boolean =>
+    (CREDENTIAL_CATEGORIES as readonly string[]).includes(value);
 
 const HEX_COLOR_REGEX = /^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
@@ -103,6 +110,11 @@ export const parseLcTags = (tags?: string[]): LcDisplayHints => {
         if (!value) continue;
 
         switch (key) {
+            case LcTagKey.Category: {
+                const candidate = value.trim();
+                if (isValidCategory(candidate)) hints.category = candidate;
+                break;
+            }
             case LcTagKey.Subtype:
                 hints.subtype = value.trim();
                 break;
@@ -144,6 +156,10 @@ export const buildLcTags = (hints: LcDisplayHints): string[] => {
 
     const push = (key: LcTagKey, value: string) =>
         tags.push(`${LC_TAG_NAMESPACE}:${LC_TAG_CANONICAL_KEY[key]}:${value}`);
+
+    if (hints.category?.trim() && isValidCategory(hints.category.trim())) {
+        push(LcTagKey.Category, hints.category.trim());
+    }
 
     if (hints.subtype?.trim()) push(LcTagKey.Subtype, hints.subtype.trim());
 

--- a/packages/learn-card-base/src/helpers/displayTags.helpers.ts
+++ b/packages/learn-card-base/src/helpers/displayTags.helpers.ts
@@ -1,0 +1,169 @@
+import { DisplayTypeEnum } from './display-types';
+
+/**
+ * LearnCard display-tag convention (`lc:` namespace)
+ * --------------------------------------------------
+ * A standards-pure way to carry display *hints* on a credential without any
+ * bespoke fields or custom JSON-LD `@context` terms. Hints ride inside the
+ * OBv3-native `achievement.tag` array (an optional `string[]` already defined
+ * by the Open Badges v3 spec), so they never break interop: wallets that don't
+ * understand them simply ignore unknown tags.
+ *
+ * Format: `lc:<key>:<value>`
+ *   - The key is matched case-insensitively.
+ *   - Only the first two colons are structural — the value is taken verbatim
+ *     after the second colon, so values may themselves contain colons
+ *     (e.g. `lc:bgImage:https://example.com/a.png`).
+ *
+ * Every recognized tag is a HINT, never a requirement:
+ *   - Unknown keys are ignored.
+ *   - Malformed / invalid values (bad hex, non-enum display type, non-https
+ *     url) are ignored rather than throwing.
+ *
+ * Recognized keys:
+ *   - `lc:subtype:<Label>`        Human-facing subtype label, decoupled from the
+ *                                 OBv3 `achievementType` (which stays a clean spec
+ *                                 value). e.g. `lc:subtype:Trailblazer`.
+ *   - `lc:displayType:<enum>`     One of the DisplayTypeEnum values.
+ *   - `lc:bgColor:<hex>`          Background color, with or without leading `#`.
+ *   - `lc:bgImage:<https url>`    Background image url.
+ *   - `lc:accentColor:<hex>`      Accent color, with or without leading `#`.
+ */
+
+export const LC_TAG_NAMESPACE = 'lc';
+
+export enum LcTagKey {
+    Subtype = 'subtype',
+    DisplayType = 'displaytype',
+    BgColor = 'bgcolor',
+    BgImage = 'bgimage',
+    AccentColor = 'accentcolor',
+}
+
+const LC_TAG_CANONICAL_KEY: Record<LcTagKey, string> = {
+    [LcTagKey.Subtype]: 'subtype',
+    [LcTagKey.DisplayType]: 'displayType',
+    [LcTagKey.BgColor]: 'bgColor',
+    [LcTagKey.BgImage]: 'bgImage',
+    [LcTagKey.AccentColor]: 'accentColor',
+};
+
+export type LcDisplayHints = {
+    subtype?: string;
+    displayType?: DisplayTypeEnum;
+    backgroundColor?: string;
+    backgroundImage?: string;
+    accentColor?: string;
+};
+
+const HEX_COLOR_REGEX = /^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+const isValidDisplayType = (value: string): value is DisplayTypeEnum =>
+    (Object.values(DisplayTypeEnum) as string[]).includes(value);
+
+const normalizeHexColor = (value: string): string | undefined => {
+    const trimmed = value.trim();
+    if (!HEX_COLOR_REGEX.test(trimmed)) return undefined;
+    return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+};
+
+const isHttpsUrl = (value: string): boolean => {
+    try {
+        return new URL(value.trim()).protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Parse an OBv3 `achievement.tag` array into structured LearnCard display hints.
+ * Non-`lc:` tags and malformed values are silently ignored. Later tags win over
+ * earlier ones for the same key.
+ */
+export const parseLcTags = (tags?: string[]): LcDisplayHints => {
+    const hints: LcDisplayHints = {};
+
+    if (!Array.isArray(tags)) return hints;
+
+    for (const tag of tags) {
+        if (typeof tag !== 'string') continue;
+
+        const firstColon = tag.indexOf(':');
+        if (firstColon === -1) continue;
+
+        const namespace = tag.slice(0, firstColon);
+        if (namespace.toLowerCase() !== LC_TAG_NAMESPACE) continue;
+
+        const rest = tag.slice(firstColon + 1);
+        const secondColon = rest.indexOf(':');
+        if (secondColon === -1) continue;
+
+        const key = rest.slice(0, secondColon).toLowerCase();
+        const value = rest.slice(secondColon + 1);
+        if (!value) continue;
+
+        switch (key) {
+            case LcTagKey.Subtype:
+                hints.subtype = value.trim();
+                break;
+            case LcTagKey.DisplayType: {
+                const candidate = value.trim().toLowerCase();
+                if (isValidDisplayType(candidate)) hints.displayType = candidate;
+                break;
+            }
+            case LcTagKey.BgColor: {
+                const color = normalizeHexColor(value);
+                if (color) hints.backgroundColor = color;
+                break;
+            }
+            case LcTagKey.BgImage: {
+                if (isHttpsUrl(value)) hints.backgroundImage = value.trim();
+                break;
+            }
+            case LcTagKey.AccentColor: {
+                const color = normalizeHexColor(value);
+                if (color) hints.accentColor = color;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    return hints;
+};
+
+/**
+ * Build an OBv3-compliant `achievement.tag` array from LearnCard display hints,
+ * for use at issuance time. Only defined, valid hints are emitted. Colors are
+ * emitted WITHOUT the leading `#` (the parser accepts both, and bare hex reads
+ * cleaner in a tag list).
+ */
+export const buildLcTags = (hints: LcDisplayHints): string[] => {
+    const tags: string[] = [];
+
+    const push = (key: LcTagKey, value: string) =>
+        tags.push(`${LC_TAG_NAMESPACE}:${LC_TAG_CANONICAL_KEY[key]}:${value}`);
+
+    if (hints.subtype?.trim()) push(LcTagKey.Subtype, hints.subtype.trim());
+
+    if (hints.displayType && isValidDisplayType(hints.displayType)) {
+        push(LcTagKey.DisplayType, hints.displayType);
+    }
+
+    if (hints.backgroundColor) {
+        const color = normalizeHexColor(hints.backgroundColor);
+        if (color) push(LcTagKey.BgColor, color.replace(/^#/, ''));
+    }
+
+    if (hints.backgroundImage && isHttpsUrl(hints.backgroundImage)) {
+        push(LcTagKey.BgImage, hints.backgroundImage.trim());
+    }
+
+    if (hints.accentColor) {
+        const color = normalizeHexColor(hints.accentColor);
+        if (color) push(LcTagKey.AccentColor, color.replace(/^#/, ''));
+    }
+
+    return tags;
+};

--- a/packages/learn-card-base/src/hooks/useGetVCInfo.tsx
+++ b/packages/learn-card-base/src/hooks/useGetVCInfo.tsx
@@ -40,6 +40,7 @@ import {
 } from 'learn-card-base/helpers/credentials/ids';
 import { ellipsisMiddle } from 'learn-card-base/helpers/stringHelpers';
 import { getDefaultDisplayType } from 'learn-card-base/helpers/display.helpers';
+import { parseLcTags } from 'learn-card-base/helpers/displayTags.helpers';
 
 import { useWallet } from 'learn-card-base';
 
@@ -389,9 +390,14 @@ export const useGetVCInfo = (
     // ========================================================================
     // DISPLAY METADATA
     // ========================================================================
+    const lcTagHints = parseLcTags(getCredentialSubjectAchievement(vc)?.tag);
+
     const displayType =
-        vc?.display?.displayType ?? getDefaultDisplayType(categoryType ?? '', achievementType);
+        vc?.display?.displayType ??
+        getDefaultDisplayType(categoryType ?? '', achievementType, lcTagHints.displayType);
     const previewType = vc?.display?.previewType;
+
+    const subtype = lcTagHints.subtype;
 
     // ID card-specific display settings
     const idBackgroundImage = vc?.boostID?.backgroundImage;
@@ -405,8 +411,8 @@ export const useGetVCInfo = (
     );
 
     // Generic display settings
-    const backgroundImage = vc?.display?.backgroundImage;
-    const backgroundColor = vc?.display?.backgroundColor;
+    const backgroundImage = vc?.display?.backgroundImage ?? lcTagHints.backgroundImage;
+    const backgroundColor = vc?.display?.backgroundColor ?? lcTagHints.backgroundColor;
 
     // ========================================================================
     // CLR
@@ -469,7 +475,8 @@ export const useGetVCInfo = (
         results,
         creditsEarned,
         achievementType,
-        formattedAchievementType,
+        subtype,
+        formattedAchievementType: subtype || formattedAchievementType,
         badgeThumbnail,
         isClrCredential,
         linkedCredentialCount,

--- a/packages/learn-card-base/src/hooks/useGetVCInfo.tsx
+++ b/packages/learn-card-base/src/hooks/useGetVCInfo.tsx
@@ -413,6 +413,7 @@ export const useGetVCInfo = (
     // Generic display settings
     const backgroundImage = vc?.display?.backgroundImage ?? lcTagHints.backgroundImage;
     const backgroundColor = vc?.display?.backgroundColor ?? lcTagHints.backgroundColor;
+    const accentColor = vc?.display?.accentColor ?? lcTagHints.accentColor;
 
     // ========================================================================
     // CLR
@@ -476,6 +477,7 @@ export const useGetVCInfo = (
         creditsEarned,
         achievementType,
         subtype,
+        accentColor,
         formattedAchievementType: subtype || formattedAchievementType,
         badgeThumbnail,
         isClrCredential,

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -229,6 +229,7 @@ export * from './helpers/searchHelpers';
 export * from './helpers/urlHelpers';
 export * from './helpers/openAttachmentUrl';
 export * from './helpers/display.helpers';
+export * from './helpers/displayTags.helpers';
 export * from './helpers/youtube.helpers';
 export * from './helpers/vimeo.helpers';
 export * from './helpers/video.helpers';

--- a/packages/learn-card-base/src/types/sync-my-school.ts
+++ b/packages/learn-card-base/src/types/sync-my-school.ts
@@ -55,4 +55,16 @@ export type LCAStylesPackRegistryEntry = {
     category: string;
     type: string;
     url: string;
+    backgroundColor?: string;
+    backgroundImage?: string;
+    title?: string;
+    description?: string;
+};
+
+export type BadgeGroup = {
+    id: string;
+    label: string;
+    description?: string;
+    order?: number;
+    types: string[];
 };

--- a/packages/learn-card-base/src/types/sync-my-school.ts
+++ b/packages/learn-card-base/src/types/sync-my-school.ts
@@ -59,6 +59,7 @@ export type LCAStylesPackRegistryEntry = {
     backgroundImage?: string;
     title?: string;
     description?: string;
+    criteria?: string;
 };
 
 export type BadgeGroup = {


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

Our credentials are standards-pure Open Badges v3, but that left us no clean way to carry display information (a background color, a certificate layout, a friendly subtype label) without inventing bespoke fields or custom JSON-LD context terms.

This PR introduces a small `lc:` tag convention that rides inside the OBv3-native `achievement.tag` array. Wallets that don't understand the tags simply ignore them, so there's zero interop cost. On top of that convention, it adds a richer credential display pipeline, a tenant-configurable style/badge registry, and a new "Boost a Friend" flow for creating and sending a personalized badge in a few taps.

#### 🥴 TL; RL:

Credentials can now carry optional display hints (color, layout, subtype, background image) as plain tags, and there's a new guided flow to design and send a badge to a friend.

#### 💡 Feature Breakdown

**1. `lc:` display-hint tag convention**
- New `parseLcTags` / `buildLcTags` helpers in `packages/learn-card-base/src/helpers/displayTags.helpers.ts`. Format is `lc:<key>:<value>`, case-insensitive key, value taken verbatim after the second colon.
- Recognized keys: `subtype`, `displayType`, `category`, `bgColor`, `bgImage`, `accentColor`. Every hint is optional and malformed values (bad hex, unknown display type, non-https URL) are dropped rather than throwing.
- `DisplayTypeEnum` / `PreviewTypeEnum` moved to their own `display-types.ts` file so the helpers can import them without a circular dependency.
- Display resolution now honors the hints: `getDefaultDisplayType` takes a `displayTypeHint`, and `useGetVCInfo` / the credential badge components fall back to `lc:` tags after the legacy `display` object.
- `deriveAccentColor` in `colorHelpers.ts` generates a harmonious badge ring from a background color.
- Documented in `docs/core-concepts/credentials-and-data/display-hint-tags.md` (added to `docs/SUMMARY.md`).

**2. Boost a Friend flow** (`apps/learn-card-app/src/pages/boostAFriend/`)
- New `/boost-a-friend` route: pick a badge preset → personalize (title, subtype, color, note) → choose recipients (people or share link) → celebrate.
- The "Boost" home shortcut now opens this flow instead of the old boost CMS.

**3. Style pack & badge group registries** (`apps/learn-card-app/src/registries/`)
- `useStylePackRegistry` and `useBadgeGroups` merge bundled JSON assets with remote URLs, configurable per tenant via a new `registries` section in the tenant config.
- Later sources win per field, deduped by category+type (style packs) or id (badge groups).

**4. Supporting UI polish**
- `SelectInput` now supports an optional `description` per option, rendering a richer two-line picker.
- Verification display hides the badge for unverified credentials.

#### 🔍 Types of Changes

-   [x] New feature (non-breaking change which adds functionality)
-   [x] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

Credentials without `lc:` tags behave exactly as before, and older credentials using the internal `display` object still render from it (the object wins over tags).

# Testing

#### 🔬 How Can Someone QA This?

**Display hint tags**
1. Issue a credential with `achievement.tag` values like `["lc:subtype:Trailblazer", "lc:displayType:certificate", "lc:bgColor:353E64"]`.
2. Confirm it renders with the certificate layout and the given background color, and shows "Trailblazer" as the subtype.
3. Add a malformed tag (e.g. `lc:bgColor:nothex`) and confirm it's ignored, not crashing.
4. Open an older credential that has no `lc:` tags and confirm it renders unchanged.
5. Unit tests: `bunx nx test learn-card-base --testFile=src/helpers/__tests__/displayTags.helpers.test.ts`.

**Boost a Friend**
1. From the wallet home, tap the "Boost" shortcut — it should open `/boost-a-friend`.
2. Pick a badge, personalize it, and confirm the live preview updates as you change title/color.
3. Send to a person and to a share link; confirm the recipient receives the boost and the celebrate step shows.

**Registries**
1. Confirm badge presets and style packs load in the Boost a Friend picker (bundled `badge-summit` / `learncard` assets).
2. Optionally point a tenant's `registries.stylePackUrls` at a remote JSON and confirm entries merge in.

#### 📱 🖥 Which devices would you like help testing on?

Chromium, iOS Native

#### 🧪 Code Coverage

Added unit tests for the tag parse/build round-trip and validation (`displayTags.helpers.test.ts`). The Boost a Friend UI and registries are manually tested.

# Documentation

#### 📝 Documentation Checklist

-   [x] **Concept** — Display Hint Tags convention (`docs/core-concepts/credentials-and-data/display-hint-tags.md`)

#### 💭 Documentation Notes

The tag convention is a new mental model for how credentials carry display info, so it gets a core-concepts page. The Boost a Friend flow and registries are internal app features covered by the QA steps above.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement rich display hints for credentials using `lc:` tags in Open Badges v3 specification, enabling standardized rendering of badges with custom colors, layouts, and metadata.

Main changes:
- Add display hint tag parsing/building system (`parseLcTags`, `buildLcTags`) supporting color, layout, and subtype hints
- Create "Boost a Friend" feature allowing users to issue social badges with customizable appearance and recipient modes
- Enhance badge components to support accent colors and background images via display hints and credential properties

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
