### PR TITLE
fix: Tests

### DIFF
--- a/.changeset/warm-years-cut.md
+++ b/.changeset/warm-years-cut.md
@@ -1,0 +1,5 @@
+---
+"learn-card-base": patch
+---
+
+fix: Tests

--- a/packages/learn-card-base/src/hooks/useWallet.ts
+++ b/packages/learn-card-base/src/hooks/useWallet.ts
@@ -77,13 +77,15 @@ Hook that servers as a simple wrapper exposing aspects of core wallet functional
 
 // These modify the storage prototype to allow for storing an object in local storage
 // It is temporary solution that will be removed in the near future
-Storage.prototype.setObject = function (key: string, value: unknown) {
-    this.setItem(key, JSON.stringify(value));
-};
+if (typeof Storage !== 'undefined') {
+    Storage.prototype.setObject = function (key: string, value: unknown) {
+        this.setItem(key, JSON.stringify(value));
+    };
 
-Storage.prototype.getObject = function (key: string) {
-    return JSON.parse(this.getItem(key) ?? '');
-};
+    Storage.prototype.getObject = function (key: string) {
+        return JSON.parse(this.getItem(key) ?? '');
+    };
+}
 
 export const useWallet = () => {
     const isLoggedIn = useIsLoggedIn();

--- a/packages/learn-card-base/src/react-query/mutations/__tests__/pruneConsentFlowDeletedCredentials.test.ts
+++ b/packages/learn-card-base/src/react-query/mutations/__tests__/pruneConsentFlowDeletedCredentials.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import { ConsentFlowTerms } from '@learncard/types';

--- a/packages/learn-card-base/src/stores/aiBoostStore.ts
+++ b/packages/learn-card-base/src/stores/aiBoostStore.ts
@@ -1,5 +1,5 @@
 import { createStore } from '@udecode/zustood';
-import { CredentialCategoryEnum } from 'learn-card-base';
+import { CredentialCategoryEnum } from 'learn-card-base/types/boostAndCredentialMetadata';
 
 export type AIBoostStore = {
     title: string;


### PR DESCRIPTION
# Overview

Fixes the `learn-card-base` unit test suite, which broke after a recent PR added a test that imports from `mutations.ts`. That import pulls the whole `learn-card-base` barrel into a plain Node test environment, and the barrel runs browser-only code at import time — so the suite crashed before any test ran.

The failure surfaced as `ReferenceError: Storage is not defined`, but fixing that revealed two more import-time landmines behind it. This PR clears all three.

## What changed

- **`useWallet.ts`** — The module mutates `Storage.prototype` at the top level. `Storage` only exists in the browser, so this threw in Node. Wrapped it in a `typeof Storage !== 'undefined'` guard.
- **`aiBoostStore.ts`** — Imported `CredentialCategoryEnum` from the `learn-card-base` barrel, creating a circular dependency: the store was evaluated before the enum was defined, so it read as `undefined`. Now imports the enum directly from its source module (`types/boostAndCredentialMetadata`), breaking the cycle.
- **`pruneConsentFlowDeletedCredentials.test.ts`** — Added a `// @vitest-environment happy-dom` directive. This test pulls in the browser-facing barrel (via `mutations.ts`), so it needs a DOM environment for globals like `window` and `Storage`. Scoped to this one file so the rest of the suite stays on Node.

## Why the per-file environment instead of a package-wide one

Switching the whole package to `happy-dom` was the obvious first try, but it changed `Date`/timezone behavior and broke `dateHelpers.test.ts`. Scoping the DOM env to just the affected file keeps every other test on Node, unchanged.

# Testing

Run the `learn-card-base` unit tests:

```
bunx nx test learn-card-base
```

- The `pruneConsentFlowDeletedCredentials` suite should pass (it crashed on import before).
- Everything else should stay green.

Note: `dateHelpers.test.ts` fails locally on `main` too — it's a pre-existing timezone-dependent test (assumes UTC) and is unrelated to this PR.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
