### PR TITLE
Fix New Credential Indicators

### DIFF
--- a/.changeset/some-jobs-attend.md
+++ b/.changeset/some-jobs-attend.md
@@ -1,0 +1,6 @@
+---
+'learn-card-base': patch
+'learn-card-app': patch
+---
+
+Fix new credential indicators

--- a/apps/learn-card-app/src/components/learncard/checklist/DemoSchoolBox.test.tsx
+++ b/apps/learn-card-app/src/components/learncard/checklist/DemoSchoolBox.test.tsx
@@ -173,6 +173,7 @@ describe('DemoSchoolBox legacy demo contract cleanup', () => {
         expect(mocks.deleteCredentialRecord).toHaveBeenCalledWith({
             ...legacyCredential,
             skipPostDeleteCleanup: true,
+            ignoreMissingRemoteRecord: true,
         });
         expect(mocks.deleteCredentialRecord).toHaveBeenCalledTimes(1);
         expect(mocks.removeCreds).toHaveBeenCalledWith([legacyCredentialUri]);

--- a/apps/learn-card-app/src/components/learncard/checklist/DemoSchoolBox.tsx
+++ b/apps/learn-card-app/src/components/learncard/checklist/DemoSchoolBox.tsx
@@ -182,9 +182,12 @@ const DemoSchoolBox: React.FC<DemoSchoolBoxProps> = ({}) => {
                 const deleteResult = await deleteCredentialRecord({
                     ...contractCred,
                     skipPostDeleteCleanup: true,
+                    ignoreMissingRemoteRecord: true,
                 });
 
-                deleteResult.deletedUris.forEach(uri => deletedUris.add(uri));
+                const deletedCredentialUris =
+                    deleteResult?.deletedUris ?? (contractCred.uri ? [contractCred.uri] : []);
+                deletedCredentialUris.forEach(uri => deletedUris.add(uri));
             }
 
             // clear creds from newCredsStore

--- a/apps/learn-card-app/src/pages/wallet/CredentialPage.tsx
+++ b/apps/learn-card-app/src/pages/wallet/CredentialPage.tsx
@@ -131,6 +131,13 @@ const CredentialPage: React.FC<CredentialPageProps> = ({ category }) => {
     const config =
         categoryToConfig[category] ?? categoryToConfig[CredentialCategoryEnum.workHistory];
 
+    useEffect(
+        () => () => {
+            newCredsStore.set.clearNewCreds(config.boostCategory);
+        },
+        [config.boostCategory]
+    );
+
     const _activeTab = query.get('managed')
         ? CredentialListTabEnum.Managed
         : CredentialListTabEnum.Earned;

--- a/packages/learn-card-base/src/react-query/mutations/mutations.ts
+++ b/packages/learn-card-base/src/react-query/mutations/mutations.ts
@@ -168,10 +168,6 @@ export const useDeleteCredentialRecord = () => {
         wallet: Awaited<ReturnType<typeof initWallet>>,
         record: LCR
     ) => {
-        if (record.sharedUris && Object.keys(record.sharedUris).length > 0) {
-            return record;
-        }
-
         try {
             const resolvedRecord = (await wallet.index.LearnCloud.get?.({ uri: record.uri }))?.[0];
 
@@ -206,6 +202,7 @@ export const useDeleteCredentialRecord = () => {
 
     type DeleteCredentialInput = LCR & {
         skipPostDeleteCleanup?: boolean;
+        ignoreMissingRemoteRecord?: boolean;
         onLocalDeleteComplete?: () => void;
         deferPostDeleteCleanup?: boolean;
     };
@@ -230,6 +227,12 @@ export const useDeleteCredentialRecord = () => {
         );
     };
 
+    const isMissingCredentialRecordError = (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return message.includes('Could not delete record');
+    };
+
     return useMutation<
         DeleteCredentialResult,
         Error,
@@ -240,16 +243,23 @@ export const useDeleteCredentialRecord = () => {
             try {
                 log.debug('deleting record (in mutation)', record);
                 const wallet = await initWallet();
+                await wallet.cache.flushIndex();
                 const recordToDelete = await resolveRecordForDeletion(wallet, record);
                 const category = getRecordCategory(record);
                 const deletedUris = getDeletedUrisForCredentialRecord(recordToDelete);
-                // Preemptively empty LC cache
-                await wallet.cache.flushIndex();
 
                 // Direct deletion using the record ID - no need to search for it
                 if (recordToDelete.id) {
-                    // Delete from LearnCloud index
-                    await wallet.index.LearnCloud.remove(recordToDelete.id);
+                    try {
+                        await wallet.index.LearnCloud.remove(recordToDelete.id);
+                    } catch (error) {
+                        if (
+                            !record.ignoreMissingRemoteRecord ||
+                            !isMissingCredentialRecordError(error)
+                        ) {
+                            throw error;
+                        }
+                    }
 
                     // Also try SQLite index for completeness (if available)
                     try {


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
New credential indicators weren't getting cleared. Now they are.

Also hit a bug when deleting the demo school contract (caused by cache and index being out of sync), so I fixed it by making the delete not fail in this case

#### 🥴 TL; RL:
Fix new cred indicators and make delete demo school more robust

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
<!--- Please add QA steps someone can follow in order to verify this works. -->
- Run LCA connected to prod
- Sync demo school
- See new cred indicators
- click on a cred page -> see "X new" in the header
- leave page / go back to passport
- see no new cred indicator dot for that cred type
- go to that same cred page -> see no "X new" in the header
- Delete demo school
  - Confirm all remaining new cred indicators are gone (assuming they were all from the demo school in the first place)
  - Confirm demo school delete succeeds + does indeed delete the demo school creds

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->
Bug fixes

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix new credential indicators by improving credential deletion handling and cleanup when navigating between credential categories.

Main changes:
- Added `ignoreMissingRemoteRecord` flag to handle missing remote records gracefully during deletion
- Implemented cleanup effect in CredentialPage to clear new credentials store on category unmount
- Refactored deletion logic with error handling for missing credentials and cache flushing before deletion

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
