### PR TITLE
Fix super long saves for self assigned skills

### DIFF
--- a/.changeset/six-wolves-burn.md
+++ b/.changeset/six-wolves-burn.md
@@ -1,0 +1,6 @@
+---
+'learn-card-base': patch
+'learn-card-app': patch
+---
+
+Speed up Self Assigned Skills save

--- a/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
@@ -161,7 +161,15 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
                         proficiencyLevel: skill.proficiency,
                     })),
                 })
-                .catch(error => log.error('Error flushing skills save:', error));
+                .catch((error: any) => {
+                    log.error('Error flushing skills save:', error);
+                    // presentToast is a global store setter, safe to call after this
+                    // component has unmounted.
+                    presentToast(
+                        `Error saving skills!${error?.message ? ` ${error.message}` : ''}`,
+                        { type: ToastTypeEnum.Error }
+                    );
+                });
         },
         []
     );
@@ -202,12 +210,12 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
         }, 400);
     };
 
-    const handleAddSkill = async (skill: SkillFrameworkNode, proficiencyLevel: number) => {
+    const handleAddSkill = (skill: SkillFrameworkNode, proficiencyLevel: number) => {
         if (!skill.id) return;
         const resolvedFrameworkId = skill.frameworkId ?? skill.targetFramework ?? frameworkIds[0];
         if (!resolvedFrameworkId) return;
 
-        await persistSkills([
+        persistSkills([
             ...selectedSkills.filter(
                 selected =>
                     !(selected.id === skill.id && selected.frameworkId === resolvedFrameworkId)
@@ -216,12 +224,8 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
         ]);
     };
 
-    const handleEditSkill = async (
-        frameworkId: string,
-        skillId: string,
-        proficiencyLevel: number
-    ) => {
-        await persistSkills(
+    const handleEditSkill = (frameworkId: string, skillId: string, proficiencyLevel: number) => {
+        persistSkills(
             selectedSkills.map(skill =>
                 skill.id === skillId && skill.frameworkId === frameworkId
                     ? { ...skill, proficiency: proficiencyLevel }
@@ -230,8 +234,8 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
         );
     };
 
-    const handleRemoveSkill = async (frameworkId: string, skillId: string) => {
-        await persistSkills(
+    const handleRemoveSkill = (frameworkId: string, skillId: string) => {
+        persistSkills(
             selectedSkills.filter(
                 skill => !(skill.id === skillId && skill.frameworkId === frameworkId)
             )
@@ -692,9 +696,7 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
 
                 <SkillSearchSelector
                     selectedSkills={selectedSkillsBySemanticScore}
-                    onSelectedSkillsChange={async (nextSkills: SelectedSkill[]) => {
-                        await persistSkills(nextSkills);
-                    }}
+                    onSelectedSkillsChange={persistSkills}
                     showSuggestSkill={true}
                     showSearchInput={false}
                     showSelectedSkills={false}

--- a/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
@@ -71,6 +71,7 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
     const skillsSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingSkillsRef = useRef<SelectedSkill[] | null>(null);
     const lastSavedSkillsRef = useRef<SelectedSkill[]>([]);
+    const skillsDirtyRef = useRef(false);
     const skillsSwiperRef = useRef<any>(null);
     const goalsSwiperRef = useRef<any>(null);
     const [skillsAtBeginning, setSkillsAtBeginning] = useState(true);
@@ -129,7 +130,9 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
     }, [hasSearchQuery, selectedSkills, semanticSearchSkillsData?.records]);
 
     useEffect(() => {
-        if (sasBoostSkills) {
+        // Skip syncing server state while a local edit is pending/saving, otherwise
+        // an in-flight refetch can clobber selections the user just made.
+        if (sasBoostSkills && !skillsDirtyRef.current) {
             const nextSkills = sasBoostSkills.map(
                 (s: { id: string; frameworkId?: string; proficiencyLevel: number }) => ({
                     id: s.id,
@@ -166,6 +169,7 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
     const persistSkills = (nextSkills: SelectedSkill[]) => {
         setSelectedSkills(nextSkills);
         pendingSkillsRef.current = nextSkills;
+        skillsDirtyRef.current = true;
         if (skillsSaveTimerRef.current) clearTimeout(skillsSaveTimerRef.current);
 
         skillsSaveTimerRef.current = setTimeout(async () => {
@@ -190,6 +194,10 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
                 });
             } finally {
                 skillsSaveTimerRef.current = null;
+                // Only clear dirty if no newer edit was queued while this save was in flight.
+                if (pendingSkillsRef.current === null) {
+                    skillsDirtyRef.current = false;
+                }
             }
         }, 400);
     };

--- a/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ExplorePathwaysModal.tsx
@@ -68,6 +68,9 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
 
     const [search, setSearch] = useState(initialSearchQuery);
     const [selectedSkills, setSelectedSkills] = useState<SelectedSkill[]>([]);
+    const skillsSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingSkillsRef = useRef<SelectedSkill[] | null>(null);
+    const lastSavedSkillsRef = useRef<SelectedSkill[]>([]);
     const skillsSwiperRef = useRef<any>(null);
     const goalsSwiperRef = useRef<any>(null);
     const [skillsAtBeginning, setSkillsAtBeginning] = useState(true);
@@ -82,6 +85,8 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
         sasBoostData?.uri
     );
     const { mutateAsync: saveSkills, isPending: skillsSaving } = useManageSelfAssignedSkillsBoost();
+    const saveSkillsRef = useRef(saveSkills);
+    saveSkillsRef.current = saveSkills;
 
     const searchQuery = search.trim();
     const hasSearchQuery = Boolean(searchQuery);
@@ -125,37 +130,68 @@ const ExplorePathwaysModal: React.FC<ExplorePathwaysModalProps> = ({
 
     useEffect(() => {
         if (sasBoostSkills) {
-            setSelectedSkills(
-                sasBoostSkills.map(
-                    (s: { id: string; frameworkId?: string; proficiencyLevel: number }) => ({
-                        id: s.id,
-                        frameworkId: s.frameworkId ?? frameworkIds[0] ?? '',
-                        proficiency: s.proficiencyLevel,
-                    })
-                )
+            const nextSkills = sasBoostSkills.map(
+                (s: { id: string; frameworkId?: string; proficiencyLevel: number }) => ({
+                    id: s.id,
+                    frameworkId: s.frameworkId ?? frameworkIds[0] ?? '',
+                    proficiency: s.proficiencyLevel,
+                })
             );
+            setSelectedSkills(nextSkills);
+            lastSavedSkillsRef.current = nextSkills;
         }
     }, [frameworkIds, sasBoostSkills]);
 
-    const persistSkills = async (nextSkills: SelectedSkill[]) => {
-        const previousSkills = selectedSkills;
-        setSelectedSkills(nextSkills);
+    useEffect(
+        () => () => {
+            if (skillsSaveTimerRef.current) clearTimeout(skillsSaveTimerRef.current);
 
-        try {
-            await saveSkills({
-                skills: nextSkills.map(skill => ({
-                    frameworkId: skill.frameworkId,
-                    id: skill.id,
-                    proficiencyLevel: skill.proficiency,
-                })),
-            });
-        } catch (error: any) {
-            log.error('Error creating or updating skills:', error);
-            setSelectedSkills(previousSkills);
-            presentToast(`Error saving skills!${error?.message ? ` ${error?.message}` : ''}`, {
-                type: ToastTypeEnum.Error,
-            });
-        }
+            const pendingSkills = pendingSkillsRef.current;
+            if (!pendingSkills) return;
+
+            pendingSkillsRef.current = null;
+            void saveSkillsRef
+                .current({
+                    skills: pendingSkills.map(skill => ({
+                        frameworkId: skill.frameworkId,
+                        id: skill.id,
+                        proficiencyLevel: skill.proficiency,
+                    })),
+                })
+                .catch(error => log.error('Error flushing skills save:', error));
+        },
+        []
+    );
+
+    const persistSkills = (nextSkills: SelectedSkill[]) => {
+        setSelectedSkills(nextSkills);
+        pendingSkillsRef.current = nextSkills;
+        if (skillsSaveTimerRef.current) clearTimeout(skillsSaveTimerRef.current);
+
+        skillsSaveTimerRef.current = setTimeout(async () => {
+            const skillsToSave = pendingSkillsRef.current;
+            pendingSkillsRef.current = null;
+            if (!skillsToSave) return;
+
+            try {
+                await saveSkillsRef.current({
+                    skills: skillsToSave.map(skill => ({
+                        frameworkId: skill.frameworkId,
+                        id: skill.id,
+                        proficiencyLevel: skill.proficiency,
+                    })),
+                });
+                lastSavedSkillsRef.current = skillsToSave;
+            } catch (error: any) {
+                log.error('Error creating or updating skills:', error);
+                setSelectedSkills(lastSavedSkillsRef.current);
+                presentToast(`Error saving skills!${error?.message ? ` ${error.message}` : ''}`, {
+                    type: ToastTypeEnum.Error,
+                });
+            } finally {
+                skillsSaveTimerRef.current = null;
+            }
+        }, 400);
     };
 
     const handleAddSkill = async (skill: SkillFrameworkNode, proficiencyLevel: number) => {

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/MySkillProfile.tsx
@@ -69,7 +69,13 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
 
     return (
         <div className={`w-full flex items-center justify-center text-left ${className}`}>
-            <div className="w-full bg-white items-center justify-center flex flex-col shadow-bottom-4-4 px-[15px] py-[18px] rounded-[15px]">
+            <div
+                className={`w-full bg-white items-center flex flex-col shadow-bottom-4-4 px-[15px] py-[18px] rounded-[15px] min-h-0 ${
+                    isExpanded
+                        ? 'justify-start h-[calc(100dvh-32px)] overflow-hidden'
+                        : 'justify-center'
+                }`}
+            >
                 <div className="flex flex-col w-full gap-[10px]">
                     <div className="flex gap-[10px] items-center justify-start w-full">
                         <ProfilePicture
@@ -131,12 +137,12 @@ const MySkillProfile: React.FC<MySkillProfileProps> = ({ className = '' }) => {
 
                 {isNativePlatform && (
                     <div
-                        className={`grid w-full transition-[grid-template-rows] duration-300 ease-in-out ${
+                        className={`grid w-full flex-1 min-h-0 transition-[grid-template-rows] duration-300 ease-in-out ${
                             isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
                         }`}
                     >
-                        <div className="overflow-hidden min-h-0">
-                            <div className="pt-[20px] border-t border-grayscale-200 w-full mt-[10px]">
+                        <div className="overflow-hidden min-h-0 flex flex-col">
+                            <div className="pt-[20px] border-t border-grayscale-200 w-full mt-[10px] flex flex-col flex-1 min-h-0">
                                 {steps[currentStep] ?? null}
                             </div>
                         </div>

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileProgressBar.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileProgressBar.tsx
@@ -15,7 +15,10 @@ import {
     SkillProfileRoleExperienceData,
     SKILL_PROFILE_ROLE_EXPERIENCE_KEY,
 } from './SkillProfileStep1';
-import { SkillProfileWorkHistoryData, SKILL_PROFILE_WORK_HISTORY_KEY } from './SkillProfileStep2';
+import {
+    SkillProfileWorkHistoryData,
+    SKILL_PROFILE_WORK_HISTORY_KEY,
+} from './SkillProfileStep2.constants';
 import { SkillProfileSalaryData, SKILL_PROFILE_SALARY_KEY } from './SkillProfileStep3';
 import {
     SkillProfileWorkLifeBalanceData,

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep2.constants.ts
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep2.constants.ts
@@ -1,0 +1,5 @@
+export type SkillProfileWorkHistoryData = {
+    selectedCredentialUris: string[];
+};
+
+export const SKILL_PROFILE_WORK_HISTORY_KEY = 'skill-profile-work-history';

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep2.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep2.tsx
@@ -21,12 +21,10 @@ import {
 import GearPlusIcon from 'learn-card-base/svgs/GearPlusIcon';
 import { useTrackProfileDataAdded } from './useTrackProfileDataAdded';
 import { useSkillProfileStepFunnel } from './useSkillProfileStepFunnel';
-
-export type SkillProfileWorkHistoryData = {
-    selectedCredentialUris: string[];
-};
-
-export const SKILL_PROFILE_WORK_HISTORY_KEY = 'skill-profile-work-history';
+import {
+    SKILL_PROFILE_WORK_HISTORY_KEY,
+    type SkillProfileWorkHistoryData,
+} from './SkillProfileStep2.constants';
 
 import SelectFrameworkToManageModal from 'src/pages/SkillFrameworks/SelectFrameworkToManageModal';
 import BrowseFrameworkPage from 'src/pages/SkillFrameworks/BrowseFrameworkPage';

--- a/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep5.tsx
+++ b/apps/learn-card-app/src/pages/ai-pathways/ai-pathways-skill-profile/SkillProfileStep5.tsx
@@ -138,7 +138,7 @@ const SkillProfileStep5: React.FC<SkillProfileStep5Props> = ({ handleNext, handl
     };
 
     return (
-        <div className="flex flex-col gap-[20px] relative">
+        <div className="flex flex-col flex-1 min-h-0 gap-[20px] relative">
             {isUpdating && (
                 <div className="absolute inset-0 bg-white/70 flex items-center justify-center z-30">
                     <IonSpinner color="dark" name="crescent" />
@@ -151,7 +151,7 @@ const SkillProfileStep5: React.FC<SkillProfileStep5Props> = ({ handleNext, handl
                 </h3>
             </div>
 
-            <div className="px-[3px] max-h-[450px] overflow-y-auto">
+            <div className="px-[3px] flex-1 min-h-0 overflow-y-auto">
                 <SkillSearchSelector
                     selectedSkills={selectedSkills}
                     onSelectedSkillsChange={setSelectedSkills}
@@ -161,7 +161,7 @@ const SkillProfileStep5: React.FC<SkillProfileStep5Props> = ({ handleNext, handl
                 />
             </div>
 
-            <div className="flex gap-[10px] w-full">
+            <div className="flex gap-[10px] w-full mt-auto">
                 <button
                     className="bg-grayscale-50 text-grayscale-800 rounded-full px-[15px] py-[7px] text-[17px] font-bold leading-[24px] tracking-[0.25px] flex-1 border-[1px] border-solid border-grayscale-200 h-[44px]"
                     onClick={handleBack}

--- a/apps/learn-card-app/src/pages/consentFlow/ConsentFlowVerifiableDataConstants.ts
+++ b/apps/learn-card-app/src/pages/consentFlow/ConsentFlowVerifiableDataConstants.ts
@@ -3,7 +3,7 @@ import {
     SKILL_PROFILE_PROFESSIONAL_TITLE_KEY,
     SKILL_PROFILE_ROLE_EXPERIENCE_KEY,
 } from '../ai-pathways/ai-pathways-skill-profile/SkillProfileStep1';
-import { SKILL_PROFILE_WORK_HISTORY_KEY } from '../ai-pathways/ai-pathways-skill-profile/SkillProfileStep2';
+import { SKILL_PROFILE_WORK_HISTORY_KEY } from '../ai-pathways/ai-pathways-skill-profile/SkillProfileStep2.constants';
 import { SKILL_PROFILE_SALARY_KEY } from '../ai-pathways/ai-pathways-skill-profile/SkillProfileStep3';
 import {
     SKILL_PROFILE_JOB_STABILITY_KEY,

--- a/apps/learn-card-app/src/pages/dashboard/components/SkillProfileModal.tsx
+++ b/apps/learn-card-app/src/pages/dashboard/components/SkillProfileModal.tsx
@@ -43,7 +43,7 @@ const SkillProfileModal: React.FC<SkillProfileModalProps> = ({ onClose }) => {
 
     return (
         <div
-            className="font-poppins flex flex-col bg-white min-h-full px-5 pb-5 desktop:px-6 desktop:pb-6"
+            className="font-poppins flex flex-col bg-white h-full min-h-0 px-5 pb-5 desktop:px-6 desktop:pb-6"
             style={{ paddingTop: 'calc(env(safe-area-inset-top) + 1.5rem)' }}
         >
             <div className="flex items-center justify-between mb-4">
@@ -86,7 +86,7 @@ const SkillProfileModal: React.FC<SkillProfileModalProps> = ({ onClose }) => {
                 )}
             </div>
 
-            <div className="pt-4 border-t border-grayscale-200 w-full">
+            <div className="pt-4 border-t border-grayscale-200 w-full flex flex-col flex-1 min-h-0 overflow-hidden">
                 {steps[currentStep] ?? null}
             </div>
         </div>

--- a/packages/learn-card-base/src/react-query/mutations/boosts.ts
+++ b/packages/learn-card-base/src/react-query/mutations/boosts.ts
@@ -11,8 +11,6 @@ import {
     switchedProfileStore,
     useDeleteCredentialRecord,
     useGetProfile,
-    useGetSelfAssignedSkillsBoost,
-    useGetSelfAssignedSkillsCredential,
     useWallet,
     VC_WITH_URI,
 } from 'learn-card-base';
@@ -37,6 +35,7 @@ import { insertItem } from './mutation.helpers';
 import { convertAttachmentsToEvidence } from '../../components/boost/boost';
 import { v4 as uuidv4 } from 'uuid';
 import { LCR } from 'learn-card-base/types/credential-records';
+import { deleteCredentialFromAllContracts } from './pruneConsentFlowDeletedCredentials';
 import { useSyncAllCredentialsToContractsMutation } from './syncAllCredentials';
 import { getLogger } from '../../logging/logger';
 const log = getLogger('boosts');
@@ -527,11 +526,7 @@ export const useManageSelfAssignedSkillsBoost = () => {
     const { initWallet } = useWallet();
     const queryClient = useQueryClient();
     const syncAllCredentialsToContracts = useSyncAllCredentialsToContractsMutation();
-
     const { data: profile } = useGetProfile();
-    const { data: sasBoost, isLoading: isLoadingSasBoost } = useGetSelfAssignedSkillsBoost();
-    const { data: sasCred, isLoading: isLoadingSasCred } = useGetSelfAssignedSkillsCredential();
-
     const { mutateAsync: deleteCredentialRecord } = useDeleteCredentialRecord();
 
     return useMutation({
@@ -540,13 +535,8 @@ export const useManageSelfAssignedSkillsBoost = () => {
         }: {
             skills?: { frameworkId: string; id: string; proficiencyLevel?: number }[];
         }) => {
-            if (isLoadingSasBoost || isLoadingSasCred) {
-                log.debug('Loading self-assigned skills boost/credential... please try again.');
-                return { boostUri: undefined };
-            }
             if (!profile) {
-                log.debug('No profile found, please try again.');
-                return { boostUri: undefined };
+                throw new Error('No profile found, please try again.');
             }
 
             const wallet = await initWallet();
@@ -563,6 +553,7 @@ export const useManageSelfAssignedSkillsBoost = () => {
                     : undefined;
 
             const sasBoostExists = !!freshSasBoost;
+            const deletedUris: string[] = [];
 
             // If boost exists, delete ALL old credential records BEFORE updating
             // Query by multiple criteria to catch records with or without boostUri
@@ -595,14 +586,18 @@ export const useManageSelfAssignedSkillsBoost = () => {
                 // Delete ALL matching records
                 for (const record of allRecordsMap.values()) {
                     try {
-                        await deleteCredentialRecord(record);
+                        const deletionResult = await deleteCredentialRecord({
+                            ...record,
+                            skipPostDeleteCleanup: true,
+                        });
+                        deletedUris.push(...deletionResult.deletedUris);
                     } catch (e) {
                         log.warn('Failed to delete credential record:', e);
                     }
                 }
             }
 
-            const walletDid = wallet?.id?.did();
+            const walletDid = wallet.id.did();
             const currentDate = new Date()?.toISOString();
 
             const credentialPayload: Record<string, any> = {
@@ -668,17 +663,18 @@ export const useManageSelfAssignedSkillsBoost = () => {
                 });
             }
 
-            const sentCredentialUri = await wallet?.invoke?.sendBoost(
-                profile?.profileId,
-                boostUri,
-                {
-                    skipNotification: true,
-                    encrypt: true,
-                }
-            );
+            const sentCredentialUri = await wallet.invoke.sendBoost(profile.profileId, boostUri, {
+                skipNotification: true,
+                encrypt: true,
+            });
 
-            const sentCredential = await wallet?.read?.get(sentCredentialUri);
-            const issuedVcUri = await wallet?.store?.LearnCloud?.uploadEncrypted?.(sentCredential);
+            if (!sentCredentialUri)
+                throw new Error('Failed to issue self-assigned skills credential.');
+
+            const sentCredential = await wallet.read.get(sentCredentialUri);
+            const issuedVcUri = await wallet.store.LearnCloud.uploadEncrypted?.(sentCredential);
+
+            if (!issuedVcUri) throw new Error('Failed to store self-assigned skills credential.');
 
             // addCredentialToWallet
             const vc = await VCValidator.parseAsync(await wallet.read.get(issuedVcUri));
@@ -695,13 +691,17 @@ export const useManageSelfAssignedSkillsBoost = () => {
 
             return {
                 boostUri,
+                credentialUri: issuedVcUri,
+                category,
+                profileDid: walletDid,
+                deletedUris: [...new Set(deletedUris)],
                 // name: state.basicInfo.name,
                 // type: state.basicInfo.achievementType ?? '',
                 // category: state.basicInfo.type,
                 // status,
             };
         },
-        onSuccess: async ({ boostUri }) => {
+        onSuccess: ({ boostUri, credentialUri, category, profileDid, deletedUris }) => {
             const switchedDid = switchedProfileStore.get.switchedDid();
             queryClient.invalidateQueries({
                 queryKey: ['selfAssignedSkillsBoost', switchedDid ?? ''],
@@ -731,24 +731,30 @@ export const useManageSelfAssignedSkillsBoost = () => {
                 queryKey: ['useSyncConsentFlow'],
             });
 
-            try {
-                await syncAllCredentialsToContracts.mutateAsync();
-            } catch (error) {
-                log.warn(
-                    'Failed to sync credentials to contracts after saving self-assigned skills:',
-                    error
-                );
-            }
+            void (async () => {
+                try {
+                    const wallet = await initWallet();
 
-            try {
-                const wallet = await initWallet();
-                await queueAiInsightCredentialRefresh({
-                    wallet,
-                    queryClient,
-                });
-            } catch (error) {
-                log.warn('Failed to refresh AI insights after saving skills:', error);
-            }
+                    if (deletedUris.length > 0) {
+                        await deleteCredentialFromAllContracts({
+                            wallet,
+                            queryClient,
+                            deletedUris,
+                        });
+                    }
+
+                    await syncAllCredentialsToContracts.mutateAsync();
+                    await queueAiInsightCredentialRefresh({
+                        wallet,
+                        queryClient,
+                    });
+                } catch (error) {
+                    log.warn(
+                        'Failed to complete post-save contract sync or AI refresh for self-assigned skills:',
+                        error
+                    );
+                }
+            })();
         },
     });
 };


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
Self assigned skills save was waiting for all credentials to sync to contracts which made it take super long. We don't do that anymore and now it's faster

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
https://www.loom.com/share/32a26a59de3b4a929e372c47f74d6a55

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->
Save self-assigned skills. Confirm it works and it's faster

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement debounced skill saves with optimistic updates to eliminate long delays when managing self-assigned skills in the AI pathways modal.

Main changes:
- Added debounced persistence layer with 400ms delay and pending refs to batch rapid skill edits and prevent duplicate saves
- Refactored skill handlers to use non-async `persistSkills()` function, enabling immediate UI updates while background save occurs
- Enhanced cleanup with deferred credential deletion from contracts and AI refresh, reducing blocking operations during mutations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
