### PR TITLE
Add peerbadges.com as a style pack + badge group source

### DIFF
--- a/apps/learn-card-app/src/registries/useBadgeGroups.ts
+++ b/apps/learn-card-app/src/registries/useBadgeGroups.ts
@@ -24,9 +24,15 @@ export const mergeBadgeGroups = (sources: BadgeGroup[][]): BadgeGroup[] => {
     return [...merged.values()].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 };
 
+// Some registries (e.g. peerbadges.com) publish a single combined document
+// shaped like `{ categories: [...], badges: [...] }` instead of a bare array,
+// so this hook and `useStylePackRegistry` can both point at the same URL.
+// `categories[]` already matches the `BadgeGroup` shape field-for-field.
 const fetchBadgeGroupUrl = async (url: string): Promise<BadgeGroup[]> => {
     const data = await (await fetch(url)).json();
-    return Array.isArray(data) ? data : [];
+    if (Array.isArray(data)) return data;
+    const categories = (data as { categories?: BadgeGroup[] })?.categories;
+    return Array.isArray(categories) ? categories : [];
 };
 
 export const useBadgeGroups = () => {

--- a/apps/learn-card-app/src/registries/useStylePackRegistry.ts
+++ b/apps/learn-card-app/src/registries/useStylePackRegistry.ts
@@ -36,9 +36,43 @@ export const mergeStylePackEntries = (
     return [...merged.values()];
 };
 
+// Some registries (e.g. peerbadges.com) publish a single combined document
+// shaped like `{ categories: [...], badges: [...] }` instead of a bare array,
+// so `useBadgeGroups` and `useStylePackRegistry` can both point at the same
+// URL. `category` there is a fine-grained persona label (e.g. "Bold &
+// Adventurous"), which doesn't match the picker's coarse `PICKER_BADGE_CATEGORIES`
+// gate — normalize it the same way the bundled `badge-summit.json` snapshot of
+// this same catalog does, so entries also dedupe/enrich against it instead of
+// appearing as duplicate tiles.
+type PeerBadgeDocumentEntry = {
+    category: string;
+    type: string;
+    title?: string;
+    url: string;
+    backgroundColor?: string;
+    description?: string;
+    criteria?: string;
+};
+
+const fromCombinedDocument = (data: unknown): LCAStylesPackRegistryEntry[] => {
+    const badges = (data as { badges?: PeerBadgeDocumentEntry[] })?.badges;
+    if (!Array.isArray(badges)) return [];
+
+    return badges.map(badge => ({
+        category: badge.category === 'Standards & Specs' ? 'Standards Badge' : 'Social Badge',
+        type: badge.type,
+        url: badge.url,
+        backgroundColor: badge.backgroundColor,
+        title: badge.title,
+        description: badge.description,
+        criteria: badge.criteria,
+    }));
+};
+
 const fetchStylePackUrl = async (url: string): Promise<LCAStylesPackRegistryEntry[]> => {
     const data = await (await fetch(url)).json();
-    return Array.isArray(data) ? data : [];
+    if (Array.isArray(data)) return data;
+    return fromCombinedDocument(data);
 };
 
 export const useStylePackRegistry = () => {

--- a/packages/learn-card-base/src/config/tenantConfigSchema.ts
+++ b/packages/learn-card-base/src/config/tenantConfigSchema.ts
@@ -255,6 +255,11 @@ export const tenantEcosystemConfigSchema = z
  * files (LCAStylesPackRegistryEntry[]); `stylePackAssets` are names of bundled
  * JSON files shipped with the app (apps/learn-card-app/src/registries/style-packs/<name>.json).
  * All sources merge left→right, deduped by category+type, later source wins per field.
+ *
+ * A `stylePackUrls`/`badgeGroupUrls` entry may point at a bare array (the
+ * legacy shape) or at a single combined document shaped like
+ * `{ categories: [...], badges: [...] }` (e.g. peerbadges.com) — the same URL
+ * can then be listed in both arrays, since each hook extracts its own half.
  */
 export const tenantRegistriesConfigSchema = z
     .object({

--- a/packages/learn-card-base/src/config/tenantDefaults.ts
+++ b/packages/learn-card-base/src/config/tenantDefaults.ts
@@ -111,9 +111,10 @@ export const DEFAULT_LEARNCARD_TENANT_CONFIG: TenantConfig = {
     registries: {
         stylePackUrls: [
             'https://raw.githubusercontent.com/WeLibraryOS/metaversity-registry/main/lca-style-packs-registry.json',
+            'https://peerbadges.com/api/public/badges.json',
         ],
         stylePackAssets: ['learncard'],
-        badgeGroupUrls: [],
+        badgeGroupUrls: ['https://peerbadges.com/api/public/badges.json'],
         badgeGroupAssets: ['learncard'],
     },
 


### PR DESCRIPTION
peerbadges.com publishes a single combined document (`{ categories, badges }`)
instead of the separate arrays our two registries previously required, so
teach useStylePackRegistry/useBadgeGroups to unwrap that shape (falling back
to the legacy bare-array format) and point both stylePackUrls and
badgeGroupUrls at the same URL. Badge categories are normalized to the
existing Social/Standards Badge taxonomy so they merge with (and enrich)
the bundled learncard/badge-summit snapshots of the same catalog instead of
rendering as duplicate tiles.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable peerbadges.com as unified style pack and badge group source by supporting combined document format with categories and badges fields.

Main changes:
- Enhanced `fetchBadgeGroupUrl` and `fetchStylePackUrl` to handle both bare arrays and combined documents with normalized category mapping
- Added `fromCombinedDocument` function mapping peerbadges entries to LCAStylesPackRegistryEntry with category normalization (Standards & Specs → Standards Badge)
- Integrated peerbadges.com URL into default tenant registries for both stylePackUrls and badgeGroupUrls with documentation updates

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
