### PR TITLE
fix: did:web SAs

### DIFF
--- a/.changeset/tiny-impalas-ring.md
+++ b/.changeset/tiny-impalas-ring.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+fix: did:web SAs

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/learn-card-app": {
       "name": "learn-card-app",
-      "version": "1.96.5",
+      "version": "1.97.3",
       "dependencies": {
         "@capacitor-community/media": "9.1.0",
         "@capacitor-community/sqlite": "8.1.0",
@@ -246,7 +246,7 @@
     },
     "apps/scouts": {
       "name": "scoutpass-app",
-      "version": "1.90.20",
+      "version": "1.90.22",
       "dependencies": {
         "@capacitor-community/sqlite": "8.1.0",
         "@capacitor-firebase/analytics": "8.2.0",
@@ -365,7 +365,7 @@
     },
     "examples/app-store-apps/1-basic-launchpad-app": {
       "name": "@learncard/app-store-demo-basic-launchpad",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "dependencies": {
         "@astrojs/netlify": "^7.0.13",
         "@learncard/init": "workspace:*",
@@ -380,7 +380,7 @@
     },
     "examples/app-store-apps/2-lore-card-app": {
       "name": "@learncard/app-store-demo-lore-card",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@astrojs/netlify": "^7.0.13",
         "@learncard/init": "workspace:*",
@@ -393,7 +393,7 @@
     },
     "examples/app-store-apps/3-mozilla-social-badges-app": {
       "name": "@learncard/app-store-demo-mozilla-social-badges",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@astrojs/netlify": "^7.0.13",
         "@learncard/init": "workspace:*",
@@ -406,7 +406,7 @@
     },
     "examples/app-store-apps/4-request-learner-context-app": {
       "name": "@learncard/app-store-demo-request-learner-context",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@learncard/partner-connect": "workspace:*",
         "astro": "^6.4.8",
@@ -418,7 +418,7 @@
     },
     "examples/app-store-apps/5-northstar-learning": {
       "name": "@learncard/app-store-demo-northstar-learning",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@astrojs/netlify": "^7.0.13",
         "@learncard/init": "workspace:*",
@@ -431,7 +431,7 @@
     },
     "examples/app-store-apps/6-basic-sync-app": {
       "name": "@learncard/app-store-demo-basic-sync",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@astrojs/netlify": "^7.0.13",
         "@learncard/init": "workspace:*",
@@ -445,7 +445,7 @@
     },
     "examples/chapi-example": {
       "name": "@learncard/chapi-example",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "dependencies": {
         "@astrojs/react": "^5.0.7",
         "@astrojs/tailwind": "^6.0.2",
@@ -471,7 +471,7 @@
     },
     "examples/consent-flow-test": {
       "name": "consent-flow-test",
-      "version": "1.0.20",
+      "version": "1.0.22",
       "dependencies": {
         "@learncard/init": "workspace:*",
         "@learncard/network-brain-client": "workspace:*",
@@ -480,7 +480,7 @@
     },
     "examples/credential-viewer": {
       "name": "@learncard/credential-viewer",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@learncard/credential-library": "workspace:*",
         "@learncard/init": "workspace:*",
@@ -538,7 +538,7 @@
     },
     "examples/snap-chapi-example": {
       "name": "@learncard/snap-chapi-example",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "dependencies": {
         "@astrojs/react": "^5.0.7",
         "@astrojs/tailwind": "^6.0.2",
@@ -565,7 +565,7 @@
     },
     "examples/snap-example-dapp": {
       "name": "@learncard/snap-example-dapp",
-      "version": "1.0.144",
+      "version": "1.0.145",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -590,7 +590,7 @@
     },
     "packages/credential-library": {
       "name": "@learncard/credential-library",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@learncard/types": "workspace:*",
         "zod": "4.1.13",
@@ -607,7 +607,7 @@
     },
     "packages/email-templates": {
       "name": "@learncard/email-templates",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@react-email/components": "^0.0.36",
         "@react-email/render": "^1.0.5",
@@ -622,7 +622,7 @@
     },
     "packages/holder-continuity-bundle": {
       "name": "@learncard/holder-continuity",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@learncard/init": "workspace:*",
         "@learncard/sss-key-manager": "workspace:*",
@@ -656,7 +656,7 @@
     },
     "packages/learn-card-base": {
       "name": "learn-card-base",
-      "version": "0.2.5",
+      "version": "0.3.3",
       "dependencies": {
         "@capacitor-community/sqlite": "8.1.0",
         "@capacitor/app": "^8.1.0",
@@ -728,7 +728,7 @@
     },
     "packages/learn-card-bridge-http": {
       "name": "@learncard/create-http-bridge",
-      "version": "1.1.244",
+      "version": "1.1.245",
       "bin": "dist/index.js",
       "dependencies": {
         "@learncard/init": "workspace:*",
@@ -773,7 +773,7 @@
     },
     "packages/learn-card-cli": {
       "name": "@learncard/cli",
-      "version": "3.4.7",
+      "version": "3.4.8",
       "bin": "dist/index.js",
       "dependencies": {
         "@learncard/core": "workspace:*",
@@ -807,7 +807,7 @@
     },
     "packages/learn-card-core": {
       "name": "@learncard/core",
-      "version": "9.4.26",
+      "version": "9.4.27",
       "dependencies": {
         "@learncard/helpers": "workspace:*",
         "abort-controller": "^3.0.0",
@@ -847,7 +847,7 @@
     },
     "packages/learn-card-helpers": {
       "name": "@learncard/helpers",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "@learncard/types": "workspace:*",
         "@noble/hashes": "^1.8.0",
@@ -874,7 +874,7 @@
     },
     "packages/learn-card-init": {
       "name": "@learncard/init",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "dependencies": {
         "@learncard/chapi-plugin": "workspace:*",
         "@learncard/core": "workspace:*",
@@ -918,7 +918,7 @@
     },
     "packages/learn-card-network/brain-client": {
       "name": "@learncard/network-brain-client",
-      "version": "2.5.44",
+      "version": "2.5.46",
       "dependencies": {
         "@learncard/network-brain-service": "workspace:*",
         "@trpc/client": "11.3.0",
@@ -932,7 +932,7 @@
     },
     "packages/learn-card-network/cloud-client": {
       "name": "@learncard/learn-cloud-client",
-      "version": "1.6.31",
+      "version": "1.6.32",
       "dependencies": {
         "@learncard/learn-cloud-service": "workspace:*",
         "@trpc/client": "^11.7.1",
@@ -945,7 +945,7 @@
     },
     "packages/learn-card-network/simple-signing-client": {
       "name": "@learncard/simple-signing-client",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@learncard/simple-signing-service": "workspace:*",
         "@trpc/client": "^11.7.2",
@@ -961,7 +961,7 @@
     },
     "packages/learn-card-partner-connect-sdk": {
       "name": "@learncard/partner-connect",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@learncard/types": "workspace:*",
       },
@@ -977,7 +977,7 @@
     },
     "packages/learn-card-types": {
       "name": "@learncard/types",
-      "version": "5.17.5",
+      "version": "5.17.6",
       "dependencies": {
         "zod": "^4.1.13",
       },
@@ -996,7 +996,7 @@
     },
     "packages/plugins/ceramic": {
       "name": "@learncard/ceramic-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@ceramicnetwork/common": "2.13.0",
         "@ceramicnetwork/http-client": "2.7.0",
@@ -1027,7 +1027,7 @@
     },
     "packages/plugins/chapi": {
       "name": "@learncard/chapi-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -1049,7 +1049,7 @@
     },
     "packages/plugins/claimable-boosts": {
       "name": "@learncard/claimable-boosts-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1068,7 +1068,7 @@
     },
     "packages/plugins/crypto": {
       "name": "@learncard/crypto-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "isomorphic-webcrypto": "^2.3.8",
@@ -1087,7 +1087,7 @@
     },
     "packages/plugins/did-web-plugin": {
       "name": "@learncard/did-web-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
       },
@@ -1107,7 +1107,7 @@
     },
     "packages/plugins/didkey": {
       "name": "@learncard/didkey-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/helpers": "workspace:^",
@@ -1128,7 +1128,7 @@
     },
     "packages/plugins/didkit": {
       "name": "@learncard/didkit-plugin",
-      "version": "1.9.6",
+      "version": "1.9.7",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1148,7 +1148,7 @@
     },
     "packages/plugins/didkit-plugin-node": {
       "name": "@learncard/didkit-plugin-node",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:*",
@@ -1161,7 +1161,7 @@
     },
     "packages/plugins/dynamic-loader": {
       "name": "@learncard/dynamic-loader-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
       },
@@ -1179,7 +1179,7 @@
     },
     "packages/plugins/encryption": {
       "name": "@learncard/encryption-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1198,7 +1198,7 @@
     },
     "packages/plugins/ethereum": {
       "name": "@learncard/ethereum-plugin",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@uniswap/default-token-list": "^4.1.0",
@@ -1218,7 +1218,7 @@
     },
     "packages/plugins/expiration": {
       "name": "@learncard/expiration-plugin",
-      "version": "1.2.26",
+      "version": "1.2.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/vc-plugin": "workspace:^",
@@ -1238,7 +1238,7 @@
     },
     "packages/plugins/idx": {
       "name": "@learncard/idx-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@ceramicnetwork/http-client": "2.7.0",
         "@ceramicnetwork/streamid": "2.7.0",
@@ -1262,7 +1262,7 @@
     },
     "packages/plugins/lca-api-plugin": {
       "name": "@learncard/lca-api-plugin",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:*",
@@ -1289,7 +1289,7 @@
     },
     "packages/plugins/learn-card": {
       "name": "@learncard/learn-card-plugin",
-      "version": "1.2.26",
+      "version": "1.2.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -1310,7 +1310,7 @@
     },
     "packages/plugins/learn-card-network": {
       "name": "@learncard/network-plugin",
-      "version": "2.13.7",
+      "version": "2.13.9",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/helpers": "workspace:*",
@@ -1336,7 +1336,7 @@
     },
     "packages/plugins/learn-cloud": {
       "name": "@learncard/learn-cloud-plugin",
-      "version": "2.3.31",
+      "version": "2.3.32",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:*",
@@ -1363,7 +1363,7 @@
     },
     "packages/plugins/ler-rs": {
       "name": "@learncard/ler-rs-plugin",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1384,7 +1384,7 @@
     },
     "packages/plugins/linked-claims": {
       "name": "@learncard/linked-claims-plugin",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1405,7 +1405,7 @@
     },
     "packages/plugins/open-badge-v2": {
       "name": "@learncard/open-badge-v2-plugin",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/crypto-plugin": "workspace:*",
@@ -1426,7 +1426,7 @@
     },
     "packages/plugins/openid4vc": {
       "name": "@learncard/openid4vc-plugin",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -1452,7 +1452,7 @@
     },
     "packages/plugins/render-method": {
       "name": "@learncard/render-method-plugin",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "dependencies": {
         "@learncard/helpers": "workspace:*",
       },
@@ -1479,7 +1479,7 @@
     },
     "packages/plugins/sd-jwt-vc": {
       "name": "@learncard/sd-jwt-vc-plugin",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -1504,7 +1504,7 @@
     },
     "packages/plugins/simple-signing-plugin": {
       "name": "@learncard/simple-signing-plugin",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@learncard/simple-signing-client": "workspace:*",
         "isomorphic-webcrypto": "^2.3.8",
@@ -1524,7 +1524,7 @@
     },
     "packages/plugins/vc": {
       "name": "@learncard/vc-plugin",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/didkit-plugin": "workspace:^",
@@ -1545,7 +1545,7 @@
     },
     "packages/plugins/vc-api": {
       "name": "@learncard/vc-api-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1564,7 +1564,7 @@
     },
     "packages/plugins/vc-templates": {
       "name": "@learncard/vc-templates-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@learncard/core": "workspace:*",
         "@learncard/types": "workspace:*",
@@ -1583,7 +1583,7 @@
     },
     "packages/plugins/vpqr": {
       "name": "@learncard/vpqr-plugin",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@digitalbazaar/vpqr": "^3.0.0",
         "@learncard/core": "workspace:*",
@@ -1603,7 +1603,7 @@
     },
     "packages/react-learn-card": {
       "name": "@learncard/react",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "dependencies": {
         "@learncard/init": "workspace:*",
         "date-fns": "^2.28.0",
@@ -1666,7 +1666,7 @@
     },
     "packages/sss-key-manager": {
       "name": "@learncard/sss-key-manager",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@learncard/types": "workspace:*",
         "@noble/ed25519": "^2.0.0",
@@ -1731,7 +1731,7 @@
     },
     "services/learn-card-discord-bot": {
       "name": "learn-card-discord-bot",
-      "version": "1.1.232",
+      "version": "1.1.233",
       "bin": "dist/index.js",
       "dependencies": {
         "@learncard/init": "workspace:*",
@@ -1768,7 +1768,7 @@
     },
     "services/learn-card-network/brain-service": {
       "name": "@learncard/network-brain-service",
-      "version": "3.16.7",
+      "version": "3.16.9",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.379.1",
         "@digitalcredentials/issuer-registry-client": "^3.2.0-beta.5",
@@ -1847,7 +1847,7 @@
     },
     "services/learn-card-network/lca-api": {
       "name": "@learncard/lca-api-service",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/static": "^9.0.0",
@@ -1905,7 +1905,7 @@
     },
     "services/learn-card-network/learn-cloud-service": {
       "name": "@learncard/learn-cloud-service",
-      "version": "2.5.24",
+      "version": "2.5.25",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/static": "^9.0.0",
@@ -1980,7 +1980,7 @@
     },
     "services/learn-card-network/simple-signing-service": {
       "name": "@learncard/simple-signing-service",
-      "version": "1.2.25",
+      "version": "1.2.26",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.370.0",
         "@fastify/cors": "^11.2.0",
@@ -2039,7 +2039,7 @@
     },
     "services/meta-mask-snap": {
       "name": "@learncard/meta-mask-snap",
-      "version": "1.0.122",
+      "version": "1.0.123",
       "dependencies": {
         "@learncard/core": "workspace:*",
       },

--- a/services/learn-card-network/brain-service/src/accesslayer/app-store-listing/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/app-store-listing/relationships/create.ts
@@ -101,14 +101,21 @@ export const associateListingWithSigningAuthority = async (
     signingAuthorityEndpoint: string,
     props: { name: string; did: string; isPrimary?: boolean }
 ): Promise<boolean> => {
-    await AppStoreListing.relateTo({
-        alias: 'usesSigningAuthority',
-        where: {
-            source: { listing_id: listingId },
-            target: { endpoint: signingAuthorityEndpoint },
-        },
-        properties: props,
-    });
+    const { neogma } = await import('@instance');
+
+    await neogma.queryRunner.run(
+        `MATCH (listing:AppStoreListing { listing_id: $listingId })
+         MATCH (signingAuthority:SigningAuthority { endpoint: $endpoint })
+         MERGE (listing)-[rel:USES_SIGNING_AUTHORITY { name: $name, did: $did }]->(signingAuthority)
+         SET rel.isPrimary = $isPrimary`,
+        {
+            listingId,
+            endpoint: signingAuthorityEndpoint,
+            name: props.name,
+            did: props.did,
+            isPrimary: props.isPrimary ?? false,
+        }
+    );
 
     return true;
 };

--- a/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/create.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/signing-authority/relationships/create.ts
@@ -1,4 +1,5 @@
-import { SigningAuthorityInstance, Profile } from '@models';
+import { SigningAuthorityInstance } from '@models';
+import { neogma } from '@instance';
 import { ProfileType } from 'types/profile';
 
 export const createUseSigningAuthorityRelationship = async (
@@ -8,12 +9,11 @@ export const createUseSigningAuthorityRelationship = async (
     did: string,
     isPrimary: boolean = false
 ): Promise<void> => {
-    await Profile.relateTo({
-        alias: 'usesSigningAuthority',
-        where: {
-            source: { profileId: user.profileId },
-            target: { endpoint: signingAuthority.endpoint },
-        },
-        properties: { name, did, isPrimary },
-    });
+    await neogma.queryRunner.run(
+        `MATCH (profile:Profile { profileId: $profileId })
+         MATCH (signingAuthority:SigningAuthority { endpoint: $endpoint })
+         MERGE (profile)-[rel:USES_SIGNING_AUTHORITY { name: $name, did: $did }]->(signingAuthority)
+         SET rel.isPrimary = $isPrimary`,
+        { profileId: user.profileId, endpoint: signingAuthority.endpoint, name, did, isPrimary }
+    );
 };

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -53,15 +53,17 @@ const dedupeRefs = <T>(entries: T[] = []): T[] => {
     });
 };
 
-// A locally-hosted method's controller MUST be the base DID, never a fragment URI:
-// ControllerProofPurpose dereferences the controller, and a fragment resolves to
-// only the key node (no assertionMethod), which fails proof authorization.
+// Only repair controllers that point at a fragment of THIS document's own DID —
+// the exact corruption behind the bug. ControllerProofPurpose dereferences the
+// controller, and a self-fragment resolves to only the key node (no
+// assertionMethod), which fails proof authorization. Foreign or user-supplied
+// controllers (e.g. from addDidMetadata) are left untouched.
 const normalizeMethodController = (entry: any, did: string): any => {
     if (
         entry &&
         typeof entry === 'object' &&
-        typeof entry.id === 'string' &&
-        entry.id.startsWith(`${did}#`)
+        typeof entry.controller === 'string' &&
+        entry.controller.startsWith(`${did}#`)
     ) {
         return { ...entry, controller: did };
     }
@@ -69,7 +71,7 @@ const normalizeMethodController = (entry: any, did: string): any => {
     return entry;
 };
 
-const normalizeDidDocument = (doc: DidDocument): DidDocument => {
+export const normalizeDidDocument = (doc: DidDocument): DidDocument => {
     const did = doc.id;
 
     return {

--- a/services/learn-card-network/brain-service/src/dids.ts
+++ b/services/learn-card-network/brain-service/src/dids.ts
@@ -36,6 +36,71 @@ const encodeKey = (key: Uint8Array) => {
     return base58btc.encode(bytes);
 };
 
+const getRefId = (entry: any): string =>
+    typeof entry === 'string' ? entry : entry?.id ?? JSON.stringify(entry);
+
+const dedupeRefs = <T>(entries: T[] = []): T[] => {
+    const seen = new Set<string>();
+
+    return entries.filter(entry => {
+        const key = getRefId(entry);
+
+        if (seen.has(key)) return false;
+
+        seen.add(key);
+
+        return true;
+    });
+};
+
+// A locally-hosted method's controller MUST be the base DID, never a fragment URI:
+// ControllerProofPurpose dereferences the controller, and a fragment resolves to
+// only the key node (no assertionMethod), which fails proof authorization.
+const normalizeMethodController = (entry: any, did: string): any => {
+    if (
+        entry &&
+        typeof entry === 'object' &&
+        typeof entry.id === 'string' &&
+        entry.id.startsWith(`${did}#`)
+    ) {
+        return { ...entry, controller: did };
+    }
+
+    return entry;
+};
+
+const normalizeDidDocument = (doc: DidDocument): DidDocument => {
+    const did = doc.id;
+
+    return {
+        ...doc,
+        ...(doc.verificationMethod
+            ? {
+                  verificationMethod: dedupeRefs(
+                      doc.verificationMethod.map(entry => normalizeMethodController(entry, did))
+                  ) as DidDocument['verificationMethod'],
+              }
+            : {}),
+        ...(doc.authentication
+            ? { authentication: dedupeRefs(doc.authentication) as DidDocument['authentication'] }
+            : {}),
+        ...(doc.assertionMethod
+            ? {
+                  assertionMethod: dedupeRefs(
+                      doc.assertionMethod
+                  ) as DidDocument['assertionMethod'],
+              }
+            : {}),
+        ...(doc.keyAgreement
+            ? {
+                  keyAgreement: dedupeRefs(
+                      doc.keyAgreement.map(entry => normalizeMethodController(entry, did))
+                  ) as DidDocument['keyAgreement'],
+              }
+            : {}),
+    };
+};
+
 // Validate manager ID to prevent injection attacks
 const isValidManagerId = (id: string): boolean => {
     // Manager IDs should be valid UUIDs
@@ -136,7 +201,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                                 .replaceAll(`#${_key}`, `#${sa.relationship.name}`)
                         );
 
-                        _replacedDoc.verificationMethod[0].controller += `#${sa.relationship.name}`;
+                        _replacedDoc.verificationMethod[0].controller = did;
 
                         return _replacedDoc;
                     })
@@ -187,7 +252,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
 
         if (saDocs) {
             saDocs.map(sa => {
-                ((finalDoc.verificationMethod = [
+                (finalDoc.verificationMethod = [
                     ...(finalDoc.verificationMethod || []),
                     ...sa.verificationMethod,
                 ]),
@@ -202,7 +267,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                     (finalDoc.keyAgreement = [
                         ...(finalDoc.keyAgreement || []),
                         ...(sa.keyAgreement || []),
-                    ]));
+                    ]);
             });
         }
 
@@ -228,7 +293,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                         finalDoc.verificationMethod.unshift({
                             id,
                             type: 'Ed25519VerificationKey2018',
-                            controller: id,
+                            controller: did,
                             publicKeyJwk: targetJwk,
                         });
                         finalDoc.authentication.push(id);
@@ -236,7 +301,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                         finalDoc.keyAgreement.push({
                             id: `${did}#${encodeKey(_x25519PublicKeyBytes)}`,
                             type: 'X25519KeyAgreementKey2019',
-                            controller: id,
+                            controller: did,
                             publicKeyBase58: base58btc.encode(_x25519PublicKeyBytes).slice(1),
                         });
                     })
@@ -255,6 +320,8 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                 return undefined;
             });
         });
+
+        finalDoc = normalizeDidDocument(finalDoc);
 
         setDidDocForProfile(profileId, finalDoc);
 
@@ -320,7 +387,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
         );
 
         if (replacedDoc?.verificationMethod?.[0]) {
-            replacedDoc.verificationMethod[0].controller = `${did}#${authorityName}`;
+            replacedDoc.verificationMethod[0].controller = did;
         }
 
         let saDocs: Record<string, any>[] = [];
@@ -345,7 +412,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                     );
 
                     if (_replacedDoc?.verificationMethod?.[0]) {
-                        _replacedDoc.verificationMethod[0].controller += `#${sa.relationship.name}`;
+                        _replacedDoc.verificationMethod[0].controller = did;
                     }
 
                     return _replacedDoc;
@@ -401,6 +468,8 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                 ];
             });
         }
+
+        finalDoc = normalizeDidDocument(finalDoc);
 
         await setDidDocForApp(slug, finalDoc);
 
@@ -483,7 +552,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                     finalDoc.verificationMethod!.unshift({
                         id,
                         type: 'Ed25519VerificationKey2018',
-                        controller: id,
+                        controller: did,
                         publicKeyJwk: targetJwk,
                     });
                     finalDoc.authentication!.push(id);
@@ -491,12 +560,14 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                     finalDoc.keyAgreement!.push({
                         id: `${did}#${encodeKey(_x25519PublicKeyBytes)}`,
                         type: 'X25519KeyAgreementKey2019',
-                        controller: id,
+                        controller: did,
                         publicKeyBase58: base58btc.encode(_x25519PublicKeyBytes).slice(1),
                     });
                 })
             );
         }
+
+        finalDoc = normalizeDidDocument(finalDoc);
 
         setDidDocForProfileManager(id, finalDoc);
 
@@ -542,7 +613,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
         const { bytes: ed25519Bytes } = extractEd25519FromVerificationMethod(vm);
         const x25519PublicKeyBytes = sodium.crypto_sign_ed25519_pk_to_curve25519(ed25519Bytes);
 
-        const finalDoc = {
+        const finalDoc = normalizeDidDocument({
             ...(replacedDoc as any),
             keyAgreement: [
                 {
@@ -555,7 +626,7 @@ export const didFastifyPlugin: FastifyPluginAsync = async fastify => {
                     (ka: any) => ka?.id !== `${didWeb}#${encodeKey(x25519PublicKeyBytes)}`
                 ),
             ],
-        } as any;
+        } as any);
 
         setDidDocForProfile('::root::', finalDoc);
 

--- a/services/learn-card-network/brain-service/test/dids.spec.ts
+++ b/services/learn-card-network/brain-service/test/dids.spec.ts
@@ -1,0 +1,286 @@
+import { describe, it, beforeAll, beforeEach, afterAll, expect } from 'vitest';
+
+import { Profile, SigningAuthority } from '@models';
+import { neogma } from '@instance';
+
+import { app as didApp, normalizeDidDocument } from '../src/dids';
+import { getUser } from './helpers/getClient';
+import { getDidWeb } from '@helpers/did.helpers';
+import { getProfileByProfileId } from '@accesslayer/profile/read';
+import { createSigningAuthority } from '@accesslayer/signing-authority/create';
+import { createUseSigningAuthorityRelationship } from '@accesslayer/signing-authority/relationships/create';
+import { getSigningAuthoritiesForUser } from '@accesslayer/signing-authority/relationships/read';
+import { deleteDidDocForProfile } from '@cache/did-docs';
+import { DidDocument } from '@learncard/types';
+
+const DOMAIN = 'localhost%3A3000';
+const SA_ENDPOINT = 'http://localhost:4000';
+const SA_DID = 'did:key:z6MkitsQTk2GDNYXAFckVcQHtC68S9j9ruVFYWrixM6RG5Mw';
+
+const createRawSigningAuthorityRelationship = async (
+    profileId: string,
+    endpoint: string,
+    name: string,
+    did: string
+): Promise<void> => {
+    await neogma.queryRunner.run(
+        `MATCH (profile:Profile { profileId: $profileId })
+         MATCH (signingAuthority:SigningAuthority { endpoint: $endpoint })
+         CREATE (profile)-[:USES_SIGNING_AUTHORITY { name: $name, did: $did, isPrimary: false }]->(signingAuthority)`,
+        { profileId, endpoint, name, did }
+    );
+};
+
+describe('normalizeDidDocument', () => {
+    const did = 'did:web:example.com:users:alice';
+
+    it('rewrites fragment controllers on locally-hosted methods to the base DID', () => {
+        const doc = {
+            id: did,
+            verificationMethod: [
+                {
+                    id: `${did}#lca-sa`,
+                    type: 'Ed25519VerificationKey2020',
+                    controller: `${did}#lca-sa`,
+                    publicKeyMultibase: 'z6Mksg1V5WqRtChCHgptso9JccDH5XcT89EKAjK9wio2PtoQ',
+                },
+            ],
+        } as unknown as DidDocument;
+
+        const result = normalizeDidDocument(doc);
+
+        expect(result.verificationMethod?.[0].controller).toBe(did);
+        expect(result.verificationMethod?.[0].id).toBe(`${did}#lca-sa`);
+    });
+
+    it('leaves already-correct owner controllers untouched', () => {
+        const doc = {
+            id: did,
+            verificationMethod: [
+                {
+                    id: `${did}#owner`,
+                    type: 'Ed25519VerificationKey2020',
+                    controller: did,
+                    publicKeyMultibase: 'z6Mkn6NYjSu8XkvS2fMGHrWVy66qiif3YzUiKnjJBnL2WEMZ',
+                },
+            ],
+        } as unknown as DidDocument;
+
+        const result = normalizeDidDocument(doc);
+
+        expect(result.verificationMethod?.[0].controller).toBe(did);
+    });
+
+    it('de-duplicates identical verification methods and reference arrays', () => {
+        const saVm = {
+            id: `${did}#lca-sa`,
+            type: 'Ed25519VerificationKey2020',
+            controller: `${did}#lca-sa`,
+            publicKeyMultibase: 'z6Mksg1V5WqRtChCHgptso9JccDH5XcT89EKAjK9wio2PtoQ',
+        };
+
+        const doc = {
+            id: did,
+            verificationMethod: [saVm, { ...saVm }, { ...saVm }],
+            assertionMethod: [`${did}#lca-sa`, `${did}#lca-sa`, `${did}#lca-sa`],
+            authentication: [`${did}#lca-sa`, `${did}#lca-sa`],
+        } as unknown as DidDocument;
+
+        const result = normalizeDidDocument(doc);
+
+        expect(result.verificationMethod).toHaveLength(1);
+        expect(result.assertionMethod).toEqual([`${did}#lca-sa`]);
+        expect(result.authentication).toEqual([`${did}#lca-sa`]);
+    });
+
+    it('preserves distinct keys while de-duplicating', () => {
+        const doc = {
+            id: did,
+            verificationMethod: [
+                {
+                    id: `${did}#owner`,
+                    type: 'Ed25519VerificationKey2020',
+                    controller: did,
+                    publicKeyMultibase: 'z6Mkn6NYjSu8XkvS2fMGHrWVy66qiif3YzUiKnjJBnL2WEMZ',
+                },
+                {
+                    id: `${did}#lca-sa`,
+                    type: 'Ed25519VerificationKey2020',
+                    controller: `${did}#lca-sa`,
+                    publicKeyMultibase: 'z6Mksg1V5WqRtChCHgptso9JccDH5XcT89EKAjK9wio2PtoQ',
+                },
+                {
+                    id: `${did}#lca-sa`,
+                    type: 'Ed25519VerificationKey2020',
+                    controller: `${did}#lca-sa`,
+                    publicKeyMultibase: 'z6Mksg1V5WqRtChCHgptso9JccDH5XcT89EKAjK9wio2PtoQ',
+                },
+            ],
+        } as unknown as DidDocument;
+
+        const result = normalizeDidDocument(doc);
+
+        expect(result.verificationMethod).toHaveLength(2);
+        const ids = result.verificationMethod?.map(vm => (vm as { id: string }).id);
+        expect(ids).toContain(`${did}#owner`);
+        expect(ids).toContain(`${did}#lca-sa`);
+    });
+
+    it('normalizes keyAgreement controllers to the base DID', () => {
+        const doc = {
+            id: did,
+            keyAgreement: [
+                {
+                    id: `${did}#kak`,
+                    type: 'X25519KeyAgreementKey2019',
+                    controller: `${did}#kak`,
+                    publicKeyBase58: 'FDpghMdHkqB8VuWAtorgDcamuixDydL8ai8rzoFq1siZ',
+                },
+            ],
+        } as unknown as DidDocument;
+
+        const result = normalizeDidDocument(doc);
+
+        expect((result.keyAgreement?.[0] as { controller: string }).controller).toBe(did);
+    });
+});
+
+describe('did:web profile document generation with signing authorities', () => {
+    let user: Awaited<ReturnType<typeof getUser>>;
+    const profileId = 'sa-did-user';
+
+    beforeAll(async () => {
+        await didApp.ready();
+        user = await getUser('a'.repeat(64));
+    });
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await SigningAuthority.delete({ detach: true, where: {} });
+        await deleteDidDocForProfile(profileId);
+
+        await user.clients.fullAuth.profile.createProfile({ profileId, displayName: 'SA User' });
+    });
+
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await SigningAuthority.delete({ detach: true, where: {} });
+        await deleteDidDocForProfile(profileId);
+    });
+
+    it('never emits a fragment on a verificationMethod controller', async () => {
+        const profile = await getProfileByProfileId(profileId);
+        const sa = await createSigningAuthority(SA_ENDPOINT);
+        await createUseSigningAuthorityRelationship(profile!, sa, 'lca-sa', SA_DID, true);
+        await deleteDidDocForProfile(profileId);
+
+        const response = await didApp.inject({
+            method: 'GET',
+            url: `/users/${profileId}/did.json`,
+        });
+
+        expect(response.statusCode).toBe(200);
+        const doc = JSON.parse(response.body) as DidDocument;
+        const did = getDidWeb(DOMAIN, profileId);
+
+        expect(doc.id).toBe(did);
+        (doc.verificationMethod ?? []).forEach(vm => {
+            const controller = (vm as { controller: string }).controller;
+            expect(controller).toBe(did);
+            expect(controller).not.toContain('#');
+        });
+
+        const saVm = (doc.verificationMethod ?? []).find(
+            vm => (vm as { id: string }).id === `${did}#lca-sa`
+        );
+        expect(saVm).toBeDefined();
+        expect((saVm as { controller: string }).controller).toBe(did);
+    });
+
+    it('de-duplicates repeated signing-authority relationships in the rendered document', async () => {
+        const profile = await getProfileByProfileId(profileId);
+        await createSigningAuthority(SA_ENDPOINT);
+
+        await createRawSigningAuthorityRelationship(profileId, SA_ENDPOINT, 'lca-sa', SA_DID);
+        await createRawSigningAuthorityRelationship(profileId, SA_ENDPOINT, 'lca-sa', SA_DID);
+        await createRawSigningAuthorityRelationship(profileId, SA_ENDPOINT, 'lca-sa', SA_DID);
+
+        const relationships = await getSigningAuthoritiesForUser(profile!);
+        expect(relationships.length).toBeGreaterThanOrEqual(3);
+
+        await deleteDidDocForProfile(profileId);
+
+        const response = await didApp.inject({
+            method: 'GET',
+            url: `/users/${profileId}/did.json`,
+        });
+
+        expect(response.statusCode).toBe(200);
+        const doc = JSON.parse(response.body) as DidDocument;
+        const did = getDidWeb(DOMAIN, profileId);
+
+        const saVmCount = (doc.verificationMethod ?? []).filter(
+            vm => (vm as { id: string }).id === `${did}#lca-sa`
+        ).length;
+        expect(saVmCount).toBe(1);
+
+        const assertionSaCount = (doc.assertionMethod ?? []).filter(
+            ref => ref === `${did}#lca-sa`
+        ).length;
+        expect(assertionSaCount).toBe(1);
+
+        const vmIds = (doc.verificationMethod ?? []).map(vm => (vm as { id: string }).id);
+        expect(new Set(vmIds).size).toBe(vmIds.length);
+    });
+});
+
+describe('signing-authority relationship idempotency', () => {
+    let user: Awaited<ReturnType<typeof getUser>>;
+    const profileId = 'sa-idempotency-user';
+
+    beforeAll(async () => {
+        user = await getUser('b'.repeat(64));
+    });
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await SigningAuthority.delete({ detach: true, where: {} });
+
+        await user.clients.fullAuth.profile.createProfile({ profileId });
+    });
+
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await SigningAuthority.delete({ detach: true, where: {} });
+    });
+
+    it('does not create duplicate relationships when the same authority is registered repeatedly', async () => {
+        const profile = await getProfileByProfileId(profileId);
+        const sa = await createSigningAuthority(SA_ENDPOINT);
+
+        await createUseSigningAuthorityRelationship(profile!, sa, 'lca-sa', SA_DID, true);
+        await createUseSigningAuthorityRelationship(profile!, sa, 'lca-sa', SA_DID, true);
+        await createUseSigningAuthorityRelationship(profile!, sa, 'lca-sa', SA_DID, true);
+
+        const relationships = await getSigningAuthoritiesForUser(profile!);
+        const matching = relationships.filter(
+            rel => rel.relationship.name === 'lca-sa' && rel.relationship.did === SA_DID
+        );
+
+        expect(matching).toHaveLength(1);
+    });
+
+    it('keeps distinct authorities as separate relationships', async () => {
+        const profile = await getProfileByProfileId(profileId);
+        const sa = await createSigningAuthority(SA_ENDPOINT);
+
+        await createUseSigningAuthorityRelationship(profile!, sa, 'lca-sa', SA_DID, true);
+        await createUseSigningAuthorityRelationship(profile!, sa, 'other-sa', SA_DID, false);
+
+        const relationships = await getSigningAuthoritiesForUser(profile!);
+        const names = relationships.map(rel => rel.relationship.name);
+
+        expect(names).toContain('lca-sa');
+        expect(names).toContain('other-sa');
+    });
+});


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

A partner reported that LearnCard-issued credentials were failing to verify in strict verifiers (`@digitalcredentials/vc`) with:

> Verification method "did:web:network.learncard.com:users:lefdemoschool#lca-sa" not authorized by controller for proof purpose "assertionMethod"

The root cause is in how we build a profile's (and app's) `did:web` document when a signing authority is attached. Two things were wrong, plus the underlying data problem that caused them to pile up.

#### 🥴 TL;DR

- Signing-authority keys had a `controller` that included a fragment (e.g. `...:lefdemoschool#lca-sa`). Per the DID spec, a key hosted in its own document must be controlled by the base DID (no fragment). When a verifier dereferences a fragment controller it only gets the key node back — which has no `assertionMethod` — so authorization fails. Credentials signed with the profile's own `#owner` key were fine; only signing-authority-signed credentials broke.
- The same key showed up multiple times in the document (`lefdemoschool` had it 3×). That's because the "profile uses signing authority" relationship was created with a plain create every time it was registered, so re-registering stacked duplicate relationships, and the document builder appended each one without de-duping.

#### 💡 What changed

1. **`dids.ts`** — signing-authority (and manager) verification methods now use the base DID as their `controller`, never a fragment. Added a small `normalizeDidDocument` pass that runs right before each document is cached/returned. It (a) forces any locally-hosted method's controller to the base DID and (b) de-duplicates `verificationMethod` / `authentication` / `assertionMethod` / `keyAgreement`. This is applied to the profile, app, manager, and root `.well-known` routes, and also cleans up any already-bad data still living in the graph.
2. **`accesslayer/signing-authority/relationships/create.ts`** and **`accesslayer/app-store-listing/relationships/create.ts`** — the "uses signing authority" relationship is now created with a `MERGE` keyed on name + did instead of an unconditional create, so registering the same authority twice no longer produces duplicate relationships.

The `bun.lock` changes are incidental lockfile churn.

#### 🔍 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

This is backwards compatible. Public keys, key IDs, and the `assertionMethod`/`authentication` lists are unchanged — only the `controller` values are corrected and duplicates removed. No credential needs to be re-issued; affected credentials simply start verifying once the corrected document is served.

# Testing

#### 🔬 How Can Someone QA This?

Before deploy you can reproduce against production data:

```
curl -s https://network.learncard.com/users/lefdemoschool/did.json
```

Today you'll see `#lca-sa` repeated three times and its `controller` ending in `#lca-sa`.

After deploy, on a profile that has a signing authority attached:

1. Fetch `/users/<profileId>/did.json`.
2. Confirm every `verificationMethod[].controller` equals the document `id` (no `#` fragment).
3. Confirm each key id appears only once across `verificationMethod`, `authentication`, and `assertionMethod`.
4. Verify a credential that was signed via that signing authority against the document using `@digitalcredentials/vc` — it should now pass.

Note: DID documents are cached in Redis (~1h TTL, refreshed on read). To see the fix immediately after deploy, evict the `did-doc:*` / `app-did-doc:*` / `manager-did-doc:*` keys; otherwise they self-heal within the hour.

#### 🧪 Code Coverage

There is a local test file (`services/learn-card-network/brain-service/test/dids.spec.ts`) covering the controller normalization, de-duplication, and relationship idempotency — unit tests for the normalizer plus integration tests through the real route. It is not yet committed to this branch; commit it before merge if we want it in CI.

# Follow-ups (not in this PR)

- A one-time cleanup/migration to collapse duplicate `USES_SIGNING_AUTHORITY` relationships already in Neo4j. The read-time de-dup masks them, but removing them at the source is cleaner.
- There is no `deleteDidDocForApp` cache helper yet (profile and manager have one); worth adding for symmetry.
