### PR TITLE
fix: Query Param Merging

### DIFF
--- a/.changeset/mighty-moose-write.md
+++ b/.changeset/mighty-moose-write.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: Query Param Merging

--- a/.changeset/modern-pigs-brake.md
+++ b/.changeset/modern-pigs-brake.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: Query Param Merging

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ services/learn-card-network/*/didkit-native-layer/
 services/learn-card-network/lca-api/.env.scouts
 /apps/scouts/.vite-local
 /apps/scouts/.vite-docker
+
+# Sisyphus agent working directory (local only)
+.sisyphus/

--- a/apps/learn-card-app/src/pages/appStoreDeveloper/components/AppPreviewModal.tsx
+++ b/apps/learn-card-app/src/pages/appStoreDeveloper/components/AppPreviewModal.tsx
@@ -4,7 +4,7 @@ import { X, Maximize2, Play, AlertCircle } from 'lucide-react';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('app-preview-modal');
 
-import { useModal } from 'learn-card-base';
+import { useModal, appendQueryParams } from 'learn-card-base';
 import { useLearnCardPostMessage } from '../../../hooks/post-message/useLearnCardPostMessage';
 import { useLearnCardMessageHandlers } from '../../../hooks/post-message/useLearnCardMessageHandlers';
 
@@ -173,7 +173,7 @@ export const AppPreviewModal: React.FC<AppPreviewModalProps> = ({ listing, onClo
     };
 
     const embedUrlWithOverride = embedUrl
-        ? `${embedUrl}?lc_host_override=${window.location.origin}`
+        ? appendQueryParams(embedUrl, { lc_host_override: window.location.origin })
         : '';
 
     if (!isEmbeddable) {

--- a/apps/learn-card-app/src/pages/launchPad/EmbedAppFullScreen.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/EmbedAppFullScreen.tsx
@@ -10,7 +10,7 @@ import {
     IonTitle,
 } from '@ionic/react';
 
-import { getLogger, useIsOffline, connectivityStore } from 'learn-card-base';
+import { getLogger, useIsOffline, connectivityStore, appendQueryParams } from 'learn-card-base';
 import { Network } from '@capacitor/network';
 import { AppEmbedOfflineState } from './AppEmbedOfflineState';
 const log = getLogger('embed-app-full-screen');
@@ -120,9 +120,9 @@ export const EmbedAppFullScreen: React.FC = () => {
                 // Verify the constructed URL hasn't escaped to a different origin
                 if (base.origin !== expectedOrigin) return;
 
-                iframeRef.current.src = `${base.toString()}?lc_host_override=${encodeURIComponent(
-                    window.location.origin
-                )}`;
+                iframeRef.current.src = appendQueryParams(base.toString(), {
+                    lc_host_override: window.location.origin,
+                });
             } catch {
                 // embedUrl is invalid — do not navigate
             }
@@ -178,7 +178,9 @@ export const EmbedAppFullScreen: React.FC = () => {
         return null; // Will redirect via useEffect
     }
 
-    const embedUrlWithOverride = `${embedUrl}?lc_host_override=${window.location.origin}`;
+    const embedUrlWithOverride = appendQueryParams(embedUrl, {
+        lc_host_override: window.location.origin,
+    });
     return (
         <IonPage>
             <IonHeader>

--- a/apps/learn-card-app/src/pages/launchPad/EmbedIframeModal.tsx
+++ b/apps/learn-card-app/src/pages/launchPad/EmbedIframeModal.tsx
@@ -5,7 +5,13 @@ import { X } from 'lucide-react';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('embed-iframe-modal');
 
-import { useModal, useDeviceTypeByWidth, useIsOffline, connectivityStore } from 'learn-card-base';
+import {
+    useModal,
+    useDeviceTypeByWidth,
+    useIsOffline,
+    connectivityStore,
+    appendQueryParams,
+} from 'learn-card-base';
 import { Network } from '@capacitor/network';
 import { AppEmbedOfflineState } from './AppEmbedOfflineState';
 import { IonPage, IonContent, IonToast, IonHeader, IonToolbar } from '@ionic/react';
@@ -104,9 +110,9 @@ export const EmbedIframeModal: React.FC<EmbedIframeModalProps> = ({
                 // Verify the constructed URL hasn't escaped to a different origin
                 if (base.origin !== expectedOrigin) return;
 
-                iframeRef.current.src = `${base.toString()}?lc_host_override=${encodeURIComponent(
-                    window.location.origin
-                )}`;
+                iframeRef.current.src = appendQueryParams(base.toString(), {
+                    lc_host_override: window.location.origin,
+                });
             } catch {
                 // embedUrl is invalid — do not navigate
             }
@@ -166,7 +172,9 @@ export const EmbedIframeModal: React.FC<EmbedIframeModalProps> = ({
         debug: false, // Disable detailed logging
     });
 
-    const embedUrlWithOverride = `${embedUrl}?lc_host_override=${window.location.origin}`;
+    const embedUrlWithOverride = appendQueryParams(embedUrl, {
+        lc_host_override: window.location.origin,
+    });
 
     return (
         <IonPage className="h-full w-full">

--- a/packages/learn-card-base/src/helpers/__tests__/urlHelpers.test.ts
+++ b/packages/learn-card-base/src/helpers/__tests__/urlHelpers.test.ts
@@ -47,7 +47,11 @@ describe('appendQueryParams', () => {
         expect(params.get('b')).toBe('2');
     });
 
-    it('throws on an invalid absolute URL', () => {
-        expect(() => appendQueryParams('/relative/path', { a: 'b' })).toThrow();
+    it('returns the input unchanged for an invalid absolute URL', () => {
+        expect(appendQueryParams('/relative/path', { a: 'b' })).toBe('/relative/path');
+    });
+
+    it('returns the input unchanged for an empty string', () => {
+        expect(appendQueryParams('', { a: 'b' })).toBe('');
     });
 });

--- a/packages/learn-card-base/src/helpers/__tests__/urlHelpers.test.ts
+++ b/packages/learn-card-base/src/helpers/__tests__/urlHelpers.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { appendQueryParams } from '../urlHelpers';
+
+describe('appendQueryParams', () => {
+    it('adds a param to a URL with no existing query string', () => {
+        expect(
+            appendQueryParams('https://foo.com/jobs', {
+                lc_host_override: 'https://learncard.app',
+            })
+        ).toBe('https://foo.com/jobs?lc_host_override=https%3A%2F%2Flearncard.app');
+    });
+
+    it('merges with an existing query string instead of producing a double-?', () => {
+        const result = appendQueryParams('https://foo.com/jobs?embed=partner-connect', {
+            lc_host_override: 'https://learncard.app',
+        });
+
+        expect(result).not.toContain('?embed=partner-connect?');
+
+        const params = new URL(result).searchParams;
+        expect(params.get('embed')).toBe('partner-connect');
+        expect(params.get('lc_host_override')).toBe('https://learncard.app');
+    });
+
+    it('overwrites an existing value for the same key', () => {
+        const result = appendQueryParams('https://foo.com?lc_host_override=https://old.app', {
+            lc_host_override: 'https://new.app',
+        });
+
+        expect(new URL(result).searchParams.get('lc_host_override')).toBe('https://new.app');
+    });
+
+    it('preserves the URL fragment', () => {
+        const result = appendQueryParams('https://foo.com/jobs#section', { a: 'b' });
+
+        expect(result).toContain('#section');
+        expect(new URL(result).searchParams.get('a')).toBe('b');
+    });
+
+    it('sets multiple params at once', () => {
+        const params = new URL(appendQueryParams('https://foo.com', { a: '1', b: '2' }))
+            .searchParams;
+
+        expect(params.get('a')).toBe('1');
+        expect(params.get('b')).toBe('2');
+    });
+
+    it('throws on an invalid absolute URL', () => {
+        expect(() => appendQueryParams('/relative/path', { a: 'b' })).toThrow();
+    });
+});

--- a/packages/learn-card-base/src/helpers/urlHelpers.ts
+++ b/packages/learn-card-base/src/helpers/urlHelpers.ts
@@ -7,6 +7,22 @@ export const isValidUrl = (str: string): boolean => {
     }
 };
 
+/**
+ * Sets query params on a URL, merging with any existing query string. Unlike
+ * `${url}?key=value` concatenation, this stays well-formed when `url` already
+ * has a query string (which would otherwise produce a malformed double-`?` URL
+ * that silently drops the appended param). Throws on invalid absolute URLs.
+ */
+export const appendQueryParams = (rawUrl: string, params: Record<string, string>): string => {
+    const url = new URL(rawUrl);
+
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+
+    return url.toString();
+};
+
 export const getMediaBaseUrl = (url: string | null | undefined): string => {
     if (!url) return '';
 

--- a/packages/learn-card-base/src/helpers/urlHelpers.ts
+++ b/packages/learn-card-base/src/helpers/urlHelpers.ts
@@ -11,16 +11,22 @@ export const isValidUrl = (str: string): boolean => {
  * Sets query params on a URL, merging with any existing query string. Unlike
  * `${url}?key=value` concatenation, this stays well-formed when `url` already
  * has a query string (which would otherwise produce a malformed double-`?` URL
- * that silently drops the appended param). Throws on invalid absolute URLs.
+ * that silently drops the appended param). If `rawUrl` is not a valid absolute
+ * URL it is returned unchanged, so callers can rely on their existing
+ * invalid-URL handling instead of guarding against a throw.
  */
 export const appendQueryParams = (rawUrl: string, params: Record<string, string>): string => {
-    const url = new URL(rawUrl);
+    try {
+        const url = new URL(rawUrl);
 
-    for (const [key, value] of Object.entries(params)) {
-        url.searchParams.set(key, value);
+        for (const [key, value] of Object.entries(params)) {
+            url.searchParams.set(key, value);
+        }
+
+        return url.toString();
+    } catch {
+        return rawUrl;
     }
-
-    return url.toString();
 };
 
 export const getMediaBaseUrl = (url: string | null | undefined): string => {


### PR DESCRIPTION
# Overview

#### 📚 What is the context and goal of this PR?

When a partner submits an embedded app with a launch URL that already has query params (e.g. `https://verifier.prettygoodskills.com/jobs?embed=learncard-partner-connect`), we tack on our own `lc_host_override` param with a raw `?`. That produced a broken URL with two `?`:

`.../jobs?embed=learncard-partner-connect?lc_host_override=https://learncard.app`

This isn't just ugly — it silently breaks the override. The partner-connect SDK reads it with `URLSearchParams(...).get('lc_host_override')`, and with the double-`?` the whole thing parses as a single `embed` value, so `lc_host_override` is never found. The embedded app then falls back to its default origin, so staging/cross-tenant embeds don't work.

#### 🥴 TL; RL:

We were string-concatenating query params onto URLs that might already have a query string. Now we merge them properly.

#### 💡 Feature Breakdown

- Added a small `appendQueryParams(url, params)` helper in `packages/learn-card-base/src/helpers/urlHelpers.ts` that uses the native `URL` API to merge params correctly (well-formed output, auto-encoded, overwrites duplicate keys).
- Swapped all 5 places that built these URLs by hand over to the helper:
  - `EmbedAppFullScreen.tsx` — iframe src + notification deep-link navigation
  - `EmbedIframeModal.tsx` — iframe src + notification deep-link navigation
  - `AppPreviewModal.tsx` — preview iframe src
- The two notification handlers also dropped their now-redundant manual `encodeURIComponent`.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. Take a partner app whose launch URL already has a query string, e.g. `https://verifier.prettygoodskills.com/jobs?embed=learncard-partner-connect`.
2. Launch it (both the modal and full-screen views).
3. Inspect the iframe `src`. It should now read `...?embed=learncard-partner-connect&lc_host_override=<host>` — one `?`, an `&` before our param, no double-`?`.
4. Confirm the embedded app actually picks up the host override (works against staging), instead of falling back to its default origin.
5. Send a notification with an `actionPath` and tap it — the resulting navigation URL should also be well-formed.
6. Repeat the check in the app preview modal (`AppPreviewModal`).

#### 🧪 Code Coverage

Added unit tests for the new helper (`urlHelpers.test.ts`): no existing query string, existing query string (no double-`?`), duplicate-key overwrite, fragment preservation, multiple params, and invalid-URL throwing.

# Documentation

#### 💭 Documentation Notes

Internal bug fix, no API or user-facing changes. The new helper has JSDoc explaining the footgun it prevents.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace manual query parameter string concatenation with a utility function to properly merge parameters and prevent malformed URLs with duplicate query separators.

Main changes:
- Added `appendQueryParams()` utility function to `urlHelpers.ts` using URL API for safe parameter merging with comprehensive test coverage
- Replaced all manual `${url}?param=value` concatenations with `appendQueryParams()` calls across three embed components
- Updated imports across files to include new `appendQueryParams` from `learn-card-base`

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
