### PR TITLE
fix: Badge Summit Bugs

### DIFF
--- a/.changeset/gold-months-rhyme.md
+++ b/.changeset/gold-months-rhyme.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+fix: Badge Summit Bugs

--- a/apps/learn-card-app/src/components/learncard/LearnCardIdView.tsx
+++ b/apps/learn-card-app/src/components/learncard/LearnCardIdView.tsx
@@ -89,7 +89,8 @@ const LearnCardIdView: React.FC<LearnCardIdViewProps> = ({ user }) => {
                     alt="Brand mark"
                     className="rounded-full h-[50px] w-[50px]"
                     onError={e => {
-                        if (e.currentTarget.src !== DEFAULT_BRAND_MARK) {
+                        if (!e.currentTarget.dataset.fallbackApplied) {
+                            e.currentTarget.dataset.fallbackApplied = 'true';
                             e.currentTarget.src = DEFAULT_BRAND_MARK;
                         }
                     }}

--- a/apps/learn-card-app/src/components/learncard/LearnCardIdView.tsx
+++ b/apps/learn-card-app/src/components/learncard/LearnCardIdView.tsx
@@ -6,7 +6,7 @@ import {
     useGetCurrentLCNUser,
     walletStore,
 } from 'learn-card-base';
-import { useTenantBrandingAssets } from '../../config/brandingAssets';
+import { useTenantBrandingAssets, DEFAULT_BRAND_MARK } from '../../config/brandingAssets';
 import { useBrandingConfig } from 'learn-card-base/config/TenantConfigProvider';
 
 import { getIdBackgroundStyles } from '../learncardID-CMS/learncard-cms.helpers';
@@ -20,6 +20,7 @@ const LearnCardIdView: React.FC<LearnCardIdViewProps> = ({ user }) => {
     const brandingConfig = useBrandingConfig();
     const currentUser = useCurrentUser();
     const { currentLCNUser } = useGetCurrentLCNUser();
+    const { brandMark } = useTenantBrandingAssets();
 
     const { displayName, profileId } = currentLCNUser ?? {};
 
@@ -84,9 +85,14 @@ const LearnCardIdView: React.FC<LearnCardIdViewProps> = ({ user }) => {
                 // style={{ backgroundColor: credential?.boostID?.accentColor }}
             >
                 <img
-                    src={useTenantBrandingAssets().brandMark}
+                    src={brandMark}
                     alt="Brand mark"
                     className="rounded-full h-[50px] w-[50px]"
+                    onError={e => {
+                        if (e.currentTarget.src !== DEFAULT_BRAND_MARK) {
+                            e.currentTarget.src = DEFAULT_BRAND_MARK;
+                        }
+                    }}
                 />
             </div>
         </div>

--- a/apps/learn-card-app/src/components/network-prompts/hooks/useLCNGatedAction.tsx
+++ b/apps/learn-card-app/src/components/network-prompts/hooks/useLCNGatedAction.tsx
@@ -5,14 +5,15 @@ export const useLCNGatedAction = () => {
     const { handlePresentJoinNetworkModal } = useJoinLCNetworkModal();
     const { handlePresentEUParentalConsentModal } = useEUParentalConsentModal();
 
-    const gate = async (): Promise<{ prompted: boolean }> => {
+    const gate = async (onSuccess?: () => void): Promise<{ prompted: boolean }> => {
         // Ask the join-network prompt directly instead of short-circuiting on
         // `!isLCNUser`. `isLCNUser` is false for every non-`present` auth state
         // (loading / error / resolving / absent), but onboarding only actually
         // fires on a confirmed `absent`. Returning `prompted: true` for the other
         // states without showing anything dead-locks every gated action, so defer
         // to the prompt's own canonical decision and report what it really did.
-        const join = await handlePresentJoinNetworkModal();
+        // `onSuccess` lets a caller auto-resume its action once onboarding completes.
+        const join = await handlePresentJoinNetworkModal(onSuccess);
         if (join.prompted) return { prompted: true };
 
         const consent = await handlePresentEUParentalConsentModal();

--- a/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
+++ b/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
@@ -34,7 +34,10 @@ export const UserQRCode: React.FC<{
         if (!url) return;
 
         fetch(url, { mode: 'cors', credentials: 'omit' })
-            .then(response => response.blob())
+            .then(response => {
+                if (!response.ok) throw new Error(`logo fetch failed: ${response.status}`);
+                return response.blob();
+            })
             .then(
                 blob =>
                     new Promise<string>((resolve, reject) => {

--- a/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
+++ b/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
@@ -33,7 +33,7 @@ export const UserQRCode: React.FC<{
 
         if (!url) return;
 
-        fetch(url)
+        fetch(url, { mode: 'cors', credentials: 'omit' })
             .then(response => response.blob())
             .then(
                 blob =>

--- a/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
+++ b/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { QRCodeSVG } from 'qrcode.react';
 import { getAppBaseUrl } from '../../../config/bootstrapTenantConfig';
+import { getLogger } from 'learn-card-base';
 
 import { useTenantBrandingAssets } from '../../../config/brandingAssets';
+
+const log = getLogger('user-qr-code');
 
 export const QR_CODE_LOGO = 'https://cdn.filestackcontent.com/UDCRoOl7TyKkQOGWjApF';
 
@@ -16,6 +19,45 @@ export const UserQRCode: React.FC<{
     let link = `${getAppBaseUrl()}/connect?connect=true&did=${walletDid}`;
 
     const brandingAssets = useTenantBrandingAssets();
+
+    // Inline the brand mark as a base64 data URI: cross-origin URLs in an SVG
+    // <image> fail to render on iOS WKWebView (broken-image placeholder) and
+    // when rasterized. On failure we omit the logo; level="H" keeps it scannable.
+    const [logoSrc, setLogoSrc] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        let cancelled = false;
+        const url = brandingAssets.brandMark;
+
+        setLogoSrc(undefined);
+
+        if (!url) return;
+
+        fetch(url)
+            .then(response => response.blob())
+            .then(
+                blob =>
+                    new Promise<string>((resolve, reject) => {
+                        const reader = new FileReader();
+                        reader.onloadend = () => resolve(reader.result as string);
+                        reader.onerror = () => reject(reader.error);
+                        reader.readAsDataURL(blob);
+                    })
+            )
+            .then(dataUri => {
+                if (!cancelled) setLogoSrc(dataUri);
+            })
+            .catch(error => {
+                if (!cancelled) {
+                    log.warn('brandMark.load.failed', error, { url });
+                    setLogoSrc(undefined);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [brandingAssets.brandMark]);
 
     if (contractUri) {
         link = `${getAppBaseUrl()}/passport?contractUri=${contractUri}&teacherProfileId=${profileId}&insightsConsent=true`;
@@ -34,12 +76,14 @@ export const UserQRCode: React.FC<{
                     data-testid="qrcode-card"
                     bgColor="transparent"
                     level="H"
-                    imageSettings={{
-                        src: brandingAssets.brandMark,
-                        height: 35,
-                        width: 35,
-                        excavate: true,
-                    }}
+                    {...(logoSrc && {
+                        imageSettings: {
+                            src: logoSrc,
+                            height: 35,
+                            width: 35,
+                            excavate: true,
+                        },
+                    })}
                 />
 
                 {profileId && (

--- a/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
+++ b/apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx
@@ -33,11 +33,12 @@ export const UserQRCode: React.FC<{
                     value={link}
                     data-testid="qrcode-card"
                     bgColor="transparent"
+                    level="H"
                     imageSettings={{
                         src: brandingAssets.brandMark,
                         height: 35,
                         width: 35,
-                        excavate: false,
+                        excavate: true,
                     }}
                 />
 

--- a/apps/learn-card-app/src/config/brandingAssets.ts
+++ b/apps/learn-card-app/src/config/brandingAssets.ts
@@ -16,6 +16,8 @@ import type { BrandingAssets } from 'learn-card-base/config/TenantConfigProvider
 import DefaultTextLogo from '../assets/images/learncard-text-logo.svg';
 import DefaultBrandMark from '../assets/images/lca-brandmark.png';
 import DefaultAppIcon from '../assets/images/lca-icon-v2.png';
+
+export const DEFAULT_BRAND_MARK = DefaultBrandMark;
 // DefaultDesktopLoginBg and DefaultDesktopLoginBgAlt removed —
 // tenants without custom desktop bg images now show LoginWelcomePanel instead.
 
@@ -74,16 +76,19 @@ export const resolveAssets = (assets: BrandingAssets): ResolvedBrandingAssets =>
 export const useTenantBrandingAssets = (): ResolvedBrandingAssets => {
     const assets = useBrandingAssets();
 
-    return useMemo(() => resolveAssets(assets), [
-        assets.textLogoUrl,
-        assets.textLogoDarkUrl,
-        assets.brandMarkUrl,
-        assets.brandMarkLightUrl,
-        assets.appIconUrl,
-        assets.desktopLoginBgUrl,
-        assets.desktopLoginBgAltUrl,
-        assets.fullLogoUrl,
-        assets.fullLogoDarkUrl,
-        assets.logoUrl,
-    ]);
+    return useMemo(
+        () => resolveAssets(assets),
+        [
+            assets.textLogoUrl,
+            assets.textLogoDarkUrl,
+            assets.brandMarkUrl,
+            assets.brandMarkLightUrl,
+            assets.appIconUrl,
+            assets.desktopLoginBgUrl,
+            assets.desktopLoginBgAltUrl,
+            assets.fullLogoUrl,
+            assets.fullLogoDarkUrl,
+            assets.logoUrl,
+        ]
+    );
 };

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -35,6 +35,7 @@ import {
     resolveBadgeStyle,
     buildPreviewCredential,
 } from './boostAFriend.helpers';
+import useLCNGatedAction from '../../components/network-prompts/hooks/useLCNGatedAction';
 import { useStylePackRegistry } from '../../registries/useStylePackRegistry';
 import { useBadgeGroups } from '../../registries/useBadgeGroups';
 import BoostEarnedCard from '../../components/boost/boost-earned-card/BoostEarnedCard';
@@ -66,6 +67,7 @@ const BoostAFriendPage: React.FC = () => {
     const { getRegisteredSigningAuthorities, getRegisteredSigningAuthority } =
         useSigningAuthority();
     const { presentToast } = useToast();
+    const { gate } = useLCNGatedAction();
     const { data: stylePacks } = useStylePackRegistry();
     const { data: badgeGroups } = useBadgeGroups();
     const categoryFallback = walletSubtypeToDefaultImageSrc(WalletCategoryTypes.socialBadges);
@@ -119,6 +121,14 @@ const BoostAFriendPage: React.FC = () => {
         }
 
         setError(null);
+
+        // Every send mode needs an LCN profile. If the user has none, open
+        // onboarding and resume this same send once it completes.
+        const { prompted } = await gate(() => {
+            void handleIssue();
+        });
+        if (prompted) return;
+
         setIsIssuing(true);
 
         try {

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -91,6 +91,7 @@ const BoostAFriendPage: React.FC = () => {
     const [claimLink, setClaimLink] = useState<string | null>(null);
     const [copied, setCopied] = useState(false);
     const qrCanvasRef = useRef<HTMLCanvasElement>(null);
+    const handleIssueRef = useRef<() => Promise<void>>(async () => {});
 
     const handleSelectBadge = (badge: BadgePreset, color: string) => {
         const {
@@ -189,12 +190,6 @@ const BoostAFriendPage: React.FC = () => {
         }
     };
 
-    // The onboarding resume callback below is created once (at send-time) but
-    // fires later, after onboarding. Routing through a ref invokes the latest
-    // runIssue closure (post-onboarding auth/profile) instead of a stale one.
-    const runIssueRef = useRef(runIssue);
-    runIssueRef.current = runIssue;
-
     const handleIssue = async () => {
         if (!selectedBadge) return;
 
@@ -208,11 +203,10 @@ const BoostAFriendPage: React.FC = () => {
         setError(null);
 
         // Every send mode needs an LCN profile. If the user has none, open
-        // onboarding, then resume via the ref so the send runs against fresh
-        // state without re-triggering the profile gate.
+        // onboarding, then resume through the latest gate-aware handler.
         const { prompted } = await gate(async () => {
             try {
-                await runIssueRef.current();
+                await handleIssueRef.current();
             } catch (err) {
                 setError(getFriendlyIssueError(err, recipientMode).message);
             }
@@ -221,6 +215,7 @@ const BoostAFriendPage: React.FC = () => {
 
         await runIssue();
     };
+    handleIssueRef.current = handleIssue;
 
     const handleCopyLink = async () => {
         if (!claimLink) return;

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -124,8 +124,12 @@ const BoostAFriendPage: React.FC = () => {
 
         // Every send mode needs an LCN profile. If the user has none, open
         // onboarding and resume this same send once it completes.
-        const { prompted } = await gate(() => {
-            void handleIssue();
+        const { prompted } = await gate(async () => {
+            try {
+                await handleIssue();
+            } catch (err) {
+                setError(getFriendlyIssueError(err, recipientMode).message);
+            }
         });
         if (prompted) return;
 

--- a/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
+++ b/apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx
@@ -109,29 +109,10 @@ const BoostAFriendPage: React.FC = () => {
         setStep('personalize');
     };
 
-    const handleIssue = async () => {
+    const runIssue = async () => {
         if (!selectedBadge) return;
 
         const isLinkMode = recipientMode === 'link';
-        const hasRecipients = recipients.length > 0;
-
-        if (recipientMode === 'people' && !hasRecipients) {
-            setError('Please add at least one recipient.');
-            return;
-        }
-
-        setError(null);
-
-        // Every send mode needs an LCN profile. If the user has none, open
-        // onboarding and resume this same send once it completes.
-        const { prompted } = await gate(async () => {
-            try {
-                await handleIssue();
-            } catch (err) {
-                setError(getFriendlyIssueError(err, recipientMode).message);
-            }
-        });
-        if (prompted) return;
 
         setIsIssuing(true);
 
@@ -206,6 +187,39 @@ const BoostAFriendPage: React.FC = () => {
         } finally {
             setIsIssuing(false);
         }
+    };
+
+    // The onboarding resume callback below is created once (at send-time) but
+    // fires later, after onboarding. Routing through a ref invokes the latest
+    // runIssue closure (post-onboarding auth/profile) instead of a stale one.
+    const runIssueRef = useRef(runIssue);
+    runIssueRef.current = runIssue;
+
+    const handleIssue = async () => {
+        if (!selectedBadge) return;
+
+        const hasRecipients = recipients.length > 0;
+
+        if (recipientMode === 'people' && !hasRecipients) {
+            setError('Please add at least one recipient.');
+            return;
+        }
+
+        setError(null);
+
+        // Every send mode needs an LCN profile. If the user has none, open
+        // onboarding, then resume via the ref so the send runs against fresh
+        // state without re-triggering the profile gate.
+        const { prompted } = await gate(async () => {
+            try {
+                await runIssueRef.current();
+            } catch (err) {
+                setError(getFriendlyIssueError(err, recipientMode).message);
+            }
+        });
+        if (prompted) return;
+
+        await runIssue();
     };
 
     const handleCopyLink = async () => {

--- a/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
+++ b/apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts
@@ -42,7 +42,12 @@ export const buildPreviewCredential = (input: {
     const json = templateToJson(template) as Record<string, any>;
 
     json.validFrom = new Date().toISOString();
-    if (json.issuer) {
+    // serializeIssuer emits a bare `{{issuer_did}}` string (not an object) when
+    // the issuer has no name/url/image/email — e.g. a user without an LCN profile.
+    // Assigning `.id` to that string throws, so replace/patch based on shape.
+    if (typeof json.issuer === 'string') {
+        json.issuer = 'did:key:preview';
+    } else if (json.issuer && typeof json.issuer === 'object') {
         json.issuer.id = 'did:key:preview';
     }
     if (json.credentialSubject) {


### PR DESCRIPTION
# Overview

A handful of small, unrelated fixes found during Badge Summit. Each is independent, so they can be reviewed commit-by-commit.

## What's in here

**1. Profile share QR wouldn't scan**
The "share my profile" QR embedded a center logo but used the library's default error-correction level (7%). The logo covered enough of the code that phones couldn't read it. Bumped to level `H` (30%) and told the library to reserve a clean zone under the logo.
- `apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx`

**2. Blue "broken image" square in the QR on some tenants/devices**
The QR logo is a remote (per-tenant) image, and inline SVG `<image>` won't render cross-origin URLs reliably (notably iOS WKWebView). We now fetch the logo and inline it as a base64 data URI; if that fails we just drop the logo (the QR still scans thanks to fix #1).
- `apps/learn-card-app/src/components/qrcode-user-card/UserQRCode/UserQRCode.tsx`

**3. Same broken-image square on the LearnCard ID card**
The brand mark `<img>` had no fallback when a tenant's remote logo failed to load. Added an `onError` that swaps in the bundled default mark. Also moved a hook call out of JSX (it was being called mid-render).
- `apps/learn-card-app/src/components/learncard/LearnCardIdView.tsx`
- `apps/learn-card-app/src/config/brandingAssets.ts` (exports the bundled default so it can be used as a fallback)

**4. Boost-a-friend crashed when selecting a badge**
Selecting a badge threw `Cannot create property 'id' on string '{{issuer_did}}'`. The template serializer returns the issuer as a plain string when it has no name/url/etc. (which is the case for users without a profile), but the preview builder always treated it as an object. Now it handles both shapes.
- `apps/learn-card-app/src/pages/boostAFriend/boostAFriend.helpers.ts`

**5. Boost-a-friend send needs an account, with no prompt**
Users without an LCN profile could pick recipients but hitting "Send Badge" just failed. Now the existing account-gate runs on send: if they have no profile, onboarding opens, and the send resumes automatically once it's done. Everything they entered is preserved. Users who already have a profile see no change.
- `apps/learn-card-app/src/pages/boostAFriend/BoostAFriendPage.tsx`
- `apps/learn-card-app/src/components/network-prompts/hooks/useLCNGatedAction.tsx` (gate now takes an optional `onSuccess` to auto-resume; existing callers unaffected)

## How to QA

1. **Profile QR** — Open your profile share QR and scan it with another phone. It should resolve (was unscannable before). On a tenant with a custom brand mark, confirm the center logo shows and isn't a blue "?" square.
2. **ID card** — View your LearnCard ID; the brand mark in the corner should render (or fall back to the default), never a broken-image box.
3. **Boost-a-friend, has account** — Pick a badge; the flow should no longer error. Personalize, pick recipients, send — works as before.
4. **Boost-a-friend, no account** — As a user without a profile, pick a badge, choose recipients, tap Send Badge. Onboarding should appear; after finishing, the badge should send on its own without re-tapping, and your selections should still be there.

## Types of Changes
- [x] Bug fix

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix badge rendering and LCN gating issues in Badge Summit, addressing QR code logo display, brand mark fallbacks, and onboarding flow integration.

Main changes:
- Added error handling and base64 conversion for QR code brand mark to resolve iOS WKWebView cross-origin rendering failures
- Refactored `useLCNGatedAction` to accept optional `onSuccess` callback for resuming gated actions post-onboarding
- Integrated LCN gating into boost issuance flow with proper recipient validation and issuer type checking for preview credentials

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
