### PR TITLE
feat: Live in-app toasts for incoming events 

### DIFF
--- a/.changeset/brave-shrimps-attend.md
+++ b/.changeset/brave-shrimps-attend.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+feat: Live Notifications

--- a/apps/learn-card-app/src/FullApp.tsx
+++ b/apps/learn-card-app/src/FullApp.tsx
@@ -24,6 +24,7 @@ import PresentVcModalListener from './components/modalListener/ModalListener';
 import QRCodeScannerListener from './components/qrcode-scanner-listener/QRCodeScannerListener';
 import NetworkListener from './components/network-listener/NetworkListener';
 import CredentialSyncListener from './components/credential-sync-listener/CredentialSyncListener';
+import NotificationToastListener from './components/notification-toast-listener/NotificationToastListener';
 import PathwayProgressReactorMount from './pages/pathways/events/PathwayProgressReactorMount';
 import { installPathwaysDevGlobals } from './pages/pathways/dev/pathwaysDevGlobals';
 import { QRCodeScannerStore } from 'learn-card-base';
@@ -211,6 +212,7 @@ const FullApp: React.FC = () => {
                                         <PushNotificationListener />
                                         <PresentVcModalListener />
                                         <CredentialSyncListener />
+                                        <NotificationToastListener />
                                         {/* Subscribes the pathway-progress reactor to
                                             the wallet event bus. Placed alongside the
                                             other app-level listeners so every claim

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/SdJwtVcClaimsBox.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/SdJwtVcClaimsBox.tsx
@@ -32,7 +32,7 @@ const ClaimsBoxHeader: React.FC = () => (
     </div>
 );
 
-export const SdJwtVcClaimsBox: React.FC<SdJwtVcClaimsBoxProps> = ({ credential }) => {
+const SdJwtVcClaimsBoxContent: React.FC<SdJwtVcClaimsBoxProps> = ({ credential }) => {
     const format = useCredentialFormat(credential);
     const isSdJwt = format === 'dc+sd-jwt' || format === 'vc+sd-jwt';
 
@@ -187,5 +187,10 @@ export const SdJwtVcClaimsBox: React.FC<SdJwtVcClaimsBoxProps> = ({ credential }
         </ClaimsBoxShell>
     );
 };
+
+// The claim deep-link (`/notifications?uri=...&claim=true`) opens the claim modal
+// before the credential has resolved, so guard against a not-yet-loaded credential.
+export const SdJwtVcClaimsBox: React.FC<{ credential?: VC }> = ({ credential }) =>
+    credential ? <SdJwtVcClaimsBoxContent credential={credential} /> : null;
 
 export default SdJwtVcClaimsBox;

--- a/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
+++ b/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
@@ -7,6 +7,7 @@ import {
     useIsLoggedIn,
     getNotificationToastCopy,
     getNotificationSenderImage,
+    shouldToastNotification,
     PushNotificationToast,
     switchedProfileStore,
 } from 'learn-card-base';
@@ -58,9 +59,9 @@ const NotificationToastListener: React.FC = () => {
 
         if (Capacitor.isNativePlatform()) return;
 
-        // Toast only the newest new notification per poll; any others still
-        // appear in the Alerts list and badge, so nothing is lost.
-        const newest = freshNotifications[0];
+        // Toast only the newest toastable notification per poll; any others
+        // still appear in the Alerts list and badge, so nothing is lost.
+        const newest = freshNotifications.find(shouldToastNotification);
         if (!newest) return;
 
         const { title, body } = getNotificationToastCopy(newest);

--- a/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
+++ b/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
@@ -8,6 +8,7 @@ import {
     useIsLoggedIn,
     resolveNotificationRoute,
     getNotificationToastCopy,
+    getNotificationSenderImage,
     PushNotificationToast,
 } from 'learn-card-base';
 
@@ -58,11 +59,13 @@ const NotificationToastListener: React.FC = () => {
 
         const { title, body } = getNotificationToastCopy(newest);
         const path = resolveNotificationRoute(newest);
+        const imageUrl = getNotificationSenderImage(newest);
 
         presentToast(
             <PushNotificationToast
                 title={title}
                 body={body}
+                imageUrl={imageUrl}
                 onClick={() => {
                     history.push(path);
                     dismissToast();

--- a/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
+++ b/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
@@ -8,6 +8,7 @@ import {
     getNotificationToastCopy,
     getNotificationSenderImage,
     PushNotificationToast,
+    switchedProfileStore,
 } from 'learn-card-base';
 
 import useOpenNotifications from '../notifications/useOpenNotifications';
@@ -20,6 +21,7 @@ const TOAST_DURATION_MS = 6000;
 // polls everywhere to keep the Alerts badge fresh from the same source.
 const NotificationToastListener: React.FC = () => {
     const isLoggedIn = useIsLoggedIn();
+    const switchedDid = switchedProfileStore.use.switchedDid();
     const openNotifications = useOpenNotifications();
     const { presentToast, dismissToast } = useToast();
 
@@ -50,10 +52,14 @@ const NotificationToastListener: React.FC = () => {
             notification => notification._id && !seenIds.has(notification._id)
         );
 
-        currentIds.forEach(id => seenIds.add(id));
+        // Rebuild the baseline from the current unread set each cycle so it
+        // stays bounded to what's actually unread.
+        seenIdsRef.current = new Set(currentIds);
 
         if (Capacitor.isNativePlatform()) return;
 
+        // Toast only the newest new notification per poll; any others still
+        // appear in the Alerts list and badge, so nothing is lost.
         const newest = freshNotifications[0];
         if (!newest) return;
 
@@ -74,9 +80,11 @@ const NotificationToastListener: React.FC = () => {
         );
     }, [data, presentToast, dismissToast, openNotifications]);
 
+    // Reset the baseline on logout OR profile switch — the unread query is
+    // per-DID, so a switched profile must not toast its existing backlog.
     useEffect(() => {
-        if (!isLoggedIn) seenIdsRef.current = null;
-    }, [isLoggedIn]);
+        seenIdsRef.current = null;
+    }, [isLoggedIn, switchedDid]);
 
     return null;
 };

--- a/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
+++ b/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Capacitor } from '@capacitor/core';
+
+import {
+    useGetUnreadUserNotifications,
+    useToast,
+    useIsLoggedIn,
+    resolveNotificationRoute,
+    getNotificationToastCopy,
+    PushNotificationToast,
+} from 'learn-card-base';
+
+const POLL_INTERVAL_MS = 30_000;
+const TOAST_DURATION_MS = 6000;
+
+// Native builds surface foreground events via PushNotificationListener, so this
+// listener only toasts on web — where there is no push channel at all. It still
+// polls everywhere to keep the Alerts badge fresh from the same source.
+const NotificationToastListener: React.FC = () => {
+    const isLoggedIn = useIsLoggedIn();
+    const history = useHistory();
+    const { presentToast, dismissToast } = useToast();
+
+    const { data } = useGetUnreadUserNotifications({
+        refetchInterval: POLL_INTERVAL_MS,
+        enabled: isLoggedIn,
+    });
+
+    const seenIdsRef = useRef<Set<string> | null>(null);
+
+    useEffect(() => {
+        if (!data || data === false) return;
+
+        const notifications = data.notifications ?? [];
+        const currentIds = notifications
+            .map(notification => notification._id)
+            .filter((id): id is string => Boolean(id));
+
+        // First successful load establishes the baseline without toasting the
+        // existing backlog.
+        if (seenIdsRef.current === null) {
+            seenIdsRef.current = new Set(currentIds);
+            return;
+        }
+
+        const seenIds = seenIdsRef.current;
+        const freshNotifications = notifications.filter(
+            notification => notification._id && !seenIds.has(notification._id)
+        );
+
+        currentIds.forEach(id => seenIds.add(id));
+
+        if (Capacitor.isNativePlatform()) return;
+
+        const newest = freshNotifications[0];
+        if (!newest) return;
+
+        const { title, body } = getNotificationToastCopy(newest);
+        const path = resolveNotificationRoute(newest);
+
+        presentToast(
+            <PushNotificationToast
+                title={title}
+                body={body}
+                onClick={() => {
+                    history.push(path);
+                    dismissToast();
+                }}
+            />,
+            { autoDismiss: true, duration: TOAST_DURATION_MS }
+        );
+    }, [data, presentToast, dismissToast, history]);
+
+    useEffect(() => {
+        if (!isLoggedIn) seenIdsRef.current = null;
+    }, [isLoggedIn]);
+
+    return null;
+};
+
+export default NotificationToastListener;

--- a/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
+++ b/apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useRef } from 'react';
-import { useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
 
 import {
     useGetUnreadUserNotifications,
     useToast,
     useIsLoggedIn,
-    resolveNotificationRoute,
     getNotificationToastCopy,
     getNotificationSenderImage,
     PushNotificationToast,
 } from 'learn-card-base';
+
+import useOpenNotifications from '../notifications/useOpenNotifications';
 
 const POLL_INTERVAL_MS = 30_000;
 const TOAST_DURATION_MS = 6000;
@@ -20,7 +20,7 @@ const TOAST_DURATION_MS = 6000;
 // polls everywhere to keep the Alerts badge fresh from the same source.
 const NotificationToastListener: React.FC = () => {
     const isLoggedIn = useIsLoggedIn();
-    const history = useHistory();
+    const openNotifications = useOpenNotifications();
     const { presentToast, dismissToast } = useToast();
 
     const { data } = useGetUnreadUserNotifications({
@@ -58,7 +58,6 @@ const NotificationToastListener: React.FC = () => {
         if (!newest) return;
 
         const { title, body } = getNotificationToastCopy(newest);
-        const path = resolveNotificationRoute(newest);
         const imageUrl = getNotificationSenderImage(newest);
 
         presentToast(
@@ -67,13 +66,13 @@ const NotificationToastListener: React.FC = () => {
                 body={body}
                 imageUrl={imageUrl}
                 onClick={() => {
-                    history.push(path);
                     dismissToast();
+                    openNotifications();
                 }}
             />,
             { autoDismiss: true, duration: TOAST_DURATION_MS }
         );
-    }, [data, presentToast, dismissToast, history]);
+    }, [data, presentToast, dismissToast, openNotifications]);
 
     useEffect(() => {
         if (!isLoggedIn) seenIdsRef.current = null;

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/ConnectionRequestCard.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/ConnectionRequestCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 
 // import X from '../../../assets/images/X.svg';
 import X from 'learn-card-base/svgs/X';

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/ConnectionRequestCard.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/ConnectionRequestCard.tsx
@@ -45,7 +45,6 @@ const ConnectionRequestCard: React.FC<ConnectionRequestCardProps> = ({
     handleRead,
     cardLoading,
 }) => {
-    const [isAccepted, setisAccepted] = useState<boolean>(acceptStatus);
     const [isRead, setisRead] = useState<boolean>(notification?.read);
 
     // Ref for the element that we want to detect whether on screen
@@ -53,24 +52,15 @@ const ConnectionRequestCard: React.FC<ConnectionRequestCardProps> = ({
 
     const onScreen: boolean = useOnScreen<HTMLDivElement>(ref, '-130px');
 
-    useEffect(() => {
-        setisAccepted(acceptStatus);
-    }, [acceptStatus]);
-
     const { textStyles, viewButtonStyles, claimedButtonStyles, unclaimedButtonStyles, typeText } =
         UserNotificationTypeStyles[UserNotificationTypeEnum.ConnectionRequest];
 
-    const claimButtonStyles = isAccepted ? claimedButtonStyles : unclaimedButtonStyles;
+    const claimButtonStyles = acceptStatus ? claimedButtonStyles : unclaimedButtonStyles;
 
-    let buttonText: string = '';
+    const buttonText: string = acceptStatus ? 'Accepted' : 'Accept';
 
-    if (isAccepted) {
-        buttonText = 'Accepted';
-    } else if (!isAccepted) {
-        buttonText = 'Accept';
-    }
-
-    const handleAcceptConnection = async () => {
+    const handleAcceptConnection = async (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
         if (!acceptStatus && !isLoading) {
             await handleButtonClick?.();
         }
@@ -141,7 +131,7 @@ const ConnectionRequestCard: React.FC<ConnectionRequestCardProps> = ({
                             name="notification-claim-button"
                         >
                             {isLoading ? 'Loading...' : buttonText}
-                            {isAccepted && <Checkmark className="h-[24px] p-0 m-0" />}{' '}
+                            {acceptStatus && <Checkmark className="h-[24px] p-0 m-0" />}{' '}
                         </button>
 
                         <button

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/NewNotificationsList.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/NewNotificationsList.tsx
@@ -50,8 +50,6 @@ const NewNotificationsList: React.FC<NewNotificationsListProps> = ({
 
     useLoadingLine(isLoading || isFetching);
 
-    const queryOptions = { options, filter };
-
     const flatNotifications: NotificationType[] =
         data?.pages?.flatMap(group => group?.notifications ?? []) ?? [];
 
@@ -68,10 +66,7 @@ const NewNotificationsList: React.FC<NewNotificationsListProps> = ({
 
         return (
             <GenericErrorBoundary key={item.notification?._id}>
-                <NotificationCardContainer
-                    queryOptions={queryOptions}
-                    notification={item.notification}
-                />
+                <NotificationCardContainer notification={item.notification} />
             </GenericErrorBoundary>
         );
     });

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/NewNotificationsList.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/NewNotificationsList.tsx
@@ -39,10 +39,7 @@ const NewNotificationsList: React.FC<NewNotificationsListProps> = ({
 
     const primaryColor = colorSet.primaryColor;
 
-    const { data, isLoading, refetch, isRefetching, isFetching } = useGetUserNotifications(
-        options,
-        filter
-    );
+    const { data, isLoading, refetch, isFetching } = useGetUserNotifications(options, filter);
 
     useEffect(() => {
         if (!isLoading && data) {
@@ -81,7 +78,12 @@ const NewNotificationsList: React.FC<NewNotificationsListProps> = ({
 
     const handleRefetch = () => refetch();
 
-    const notificationsLoading = isRefetching || isLoading;
+    // Gate the full-screen spinner on the INITIAL load only. Including
+    // `isRefetching` here tore the whole list down and rebuilt it on every
+    // background refetch — that caused the constant flashing and remounted each
+    // card (wiping local accepted state). Background refetches now surface only
+    // via the subtle top loading line (useLoadingLine above).
+    const notificationsLoading = isLoading;
 
     return (
         <div className="m-auto max-w-[600px] h-full bg-white">

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import moment from 'moment';
 import {
     useUpdateNotification,
@@ -18,7 +18,6 @@ import NotificationGuardianApprovalCard from './NotificationGuardianApprovalCard
 import NotificationGuardianOutcomeCard from './NotificationGuardianOutcomeCard';
 import NotificationAppNotificationCard from './NotificationAppNotificationCard';
 import { useQueryClient } from '@tanstack/react-query';
-import { useIonAlert } from '@ionic/react';
 
 type NotificationCardProps = {
     className?: string;
@@ -72,13 +71,13 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
     }
 
     const { type, message, from, to, sent } = notification;
-    const [presentAlert, dismissAlert] = useIonAlert();
     const displayDate = moment(sent).format('MMMM Do, YYYY');
 
     const queryClient = useQueryClient();
-    const { mutate: acceptConnectionRequest, isPending: acceptConnectionLoading } =
+    const { mutateAsync: acceptConnectionRequest, isPending: acceptConnectionLoading } =
         useAcceptConnectionRequestMutation();
-    const { mutate: updateNotification } = useUpdateNotification();
+    const { mutate: updateNotification, mutateAsync: updateNotificationAsync } =
+        useUpdateNotification();
 
     const { mutate: markNotificationAsRead } = useMarkNotificationRead();
     const { refetch: refetchCurrentLCNUser } = useGetCurrentLCNUser();
@@ -103,7 +102,22 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
         });
     };
 
-    const syncAcceptedConnection = () => {
+    // Local accepted state is the source of truth for the button after the user
+    // clicks Accept. The server does not round-trip `actionStatus` on the
+    // notifications refetch triggered by updateNotification, so relying on the
+    // refetched notification would revert the button to "Accept".
+    const [locallyAccepted, setLocallyAccepted] = useState(false);
+
+    const finalizeAcceptedUi = async () => {
+        try {
+            await updateNotificationAsync({
+                notificationId: notification?._id,
+                payload: { actionStatus: 'COMPLETED', read: true },
+            });
+        } catch (error) {
+            log.warn('Failed to persist notification meta after accept', error);
+        }
+
         queryClient.setQueriesData({ queryKey: ['useGetUserNotifications'] }, (old: any) => {
             if (!old?.pages) return old;
 
@@ -132,49 +146,38 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
     };
 
     const handleConnectionRequest = async () => {
-        await acceptConnectionRequest(
-            { profileId: notification?.from?.profileId },
-            {
-                async onSuccess() {
-                    await updateNotification({
-                        notificationId: notification?._id,
-                        payload: { actionStatus: 'COMPLETED', read: true },
-                    });
+        if (
+            locallyAccepted ||
+            notification?.actionStatus === 'COMPLETED' ||
+            acceptConnectionLoading
+        ) {
+            return;
+        }
 
-                    syncAcceptedConnection();
-                },
-                async onError(err) {
-                    log.info('///ON ERROR CONNECTION REQUEST', err);
-                    if (err?.toString()?.includes('Profiles are already connected')) {
-                        await updateNotification({
-                            notificationId: notification?._id,
-                            payload: { actionStatus: 'COMPLETED', read: true },
-                        });
+        // Optimistically flip the button. The server occasionally rejects the
+        // accept *after* creating the connection (e.g. a post-write notification
+        // step fails), so we treat both success and "already connected" as
+        // accepted, and only roll back on a genuine failure.
+        setLocallyAccepted(true);
 
-                        presentAlert({
-                            backdropDismiss: false,
-                            cssClass: 'boost-confirmation-alert',
-                            header: 'You are already connected.',
-                            buttons: [
-                                {
-                                    text: 'Okay',
-                                    role: 'confirm',
-                                    handler: () => {
-                                        syncAcceptedConnection();
-                                        dismissAlert();
-                                    },
-                                },
-                            ],
-                        });
-                    }
-                },
+        try {
+            await acceptConnectionRequest({ profileId: notification?.from?.profileId });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+
+            if (!message.includes('Profiles are already connected')) {
+                setLocallyAccepted(false);
+                log.error('Failed to accept connection request', err);
+                return;
             }
-        );
+        }
+
+        await finalizeAcceptedUi();
     };
 
     /* Someone has sent you a connection request to accept */
     if (type === NOTIFICATION_TYPES.CONNECTION_REQUEST) {
-        const actionStatus = notification?.actionStatus === 'COMPLETED' ? true : false;
+        const actionStatus = notification?.actionStatus === 'COMPLETED' || locallyAccepted;
         return (
             <ConnectionRequestCard
                 title={message?.body ?? ''}
@@ -191,7 +194,7 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
     }
     /* Someone has sent you a connection request from an expired invite */
     if (type === NOTIFICATION_TYPES.CONNECTION_REQUEST_EXPIRED_INVITE) {
-        const actionStatus = notification?.actionStatus === 'COMPLETED' ? true : false;
+        const actionStatus = notification?.actionStatus === 'COMPLETED' || locallyAccepted;
         return (
             <ConnectionRequestCard
                 title={message?.body ?? ''}

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
@@ -22,7 +22,6 @@ import { useQueryClient } from '@tanstack/react-query';
 type NotificationCardProps = {
     className?: string;
     notification: NotificationType;
-    queryOptions?: any;
 };
 
 export const NOTIFICATION_TYPES = {

--- a/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
+++ b/apps/learn-card-app/src/components/notifications/notificationsV2/NotificationCardContainer.tsx
@@ -6,7 +6,6 @@ import {
     useMarkNotificationRead,
     useGetProfile,
     useGetCurrentLCNUser,
-    switchedProfileStore,
 } from 'learn-card-base';
 import { NotificationType } from 'packages/plugins/lca-api-plugin/src/types';
 import { notificationCardStyles } from './types';
@@ -51,10 +50,8 @@ const log = getLogger('notification-card-container');
 export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
     className,
     notification: _notification,
-    queryOptions,
 }) => {
     const { data, isLoading } = useGetProfile(_notification.from.profileId);
-    const switchedDid = switchedProfileStore.use.switchedDid();
 
     const notification = data ? { ..._notification, from: data, message: {} } : _notification;
 
@@ -106,83 +103,53 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
         });
     };
 
+    const syncAcceptedConnection = () => {
+        queryClient.setQueriesData({ queryKey: ['useGetUserNotifications'] }, (old: any) => {
+            if (!old?.pages) return old;
+
+            return {
+                ...old,
+                pages: old.pages.map((page: any) => ({
+                    ...page,
+                    notifications: page?.notifications?.map((n: any) =>
+                        n?._id === notification?._id
+                            ? { ...n, actionStatus: 'COMPLETED', read: true }
+                            : n
+                    ),
+                })),
+            };
+        });
+
+        queryClient.invalidateQueries({ queryKey: ['useGetUnreadUserNotifications'] });
+
+        [
+            'connections',
+            'getConnectionRequests',
+            'paginatedConnections',
+            'paginatedPendingConnections',
+            'paginatedConnectionRequests',
+        ].forEach(key => queryClient.invalidateQueries({ queryKey: [key] }));
+    };
+
     const handleConnectionRequest = async () => {
         await acceptConnectionRequest(
             { profileId: notification?.from?.profileId },
             {
-                async onSuccess(data, variables, context) {
+                async onSuccess() {
                     await updateNotification({
                         notificationId: notification?._id,
                         payload: { actionStatus: 'COMPLETED', read: true },
                     });
 
-                    //update query cache
-                    const currentQuery = queryClient.getQueryData([
-                        'useGetUserNotifications',
-                        switchedDid ?? '',
-                        queryOptions?.options,
-                        queryOptions?.filter,
-                    ]);
-
-                    if (currentQuery) {
-                        // find notification in query cache
-                        // const updatedQueryNotifications = currentQuery?.notifications?.map(
-                        //     _notification => {
-                        //         if (_notification?._id === notification?._id) {
-                        //             _notification.actionStatus = 'COMPLETED';
-                        //             return _notification;
-                        //         }
-                        //         return _notification;
-                        //     }
-                        // );
-                        // Note the below is for infiniteQuery hook, above commented out is normal....todo, handle this better.
-                        const updatedQueryNotifications = currentQuery?.pages.map(page => {
-                            return {
-                                hasMore: page?.hasMore,
-                                notifications: page?.notifications?.filter(_notification => {
-                                    if (_notification?._id === notification?._id) {
-                                        _notification.actionStatus = 'COMPLETED';
-                                        _notification.read = true;
-                                        return _notification;
-                                    }
-                                    return _notification;
-                                }),
-                            };
-                        });
-
-                        const updatedQuery = {
-                            ...currentQuery,
-                            notifications: updatedQueryNotifications,
-                        };
-
-                        // update to the new value
-                        queryClient.setQueryData(
-                            [
-                                'useGetUserNotifications',
-                                switchedDid ?? '',
-                                queryOptions?.options,
-                                queryOptions?.filter,
-                            ],
-                            updatedQuery
-                        );
-                    }
-
-                    return true;
+                    syncAcceptedConnection();
                 },
-                async onError(err, variables, context) {
+                async onError(err) {
                     log.info('///ON ERROR CONNECTION REQUEST', err);
                     if (err?.toString()?.includes('Profiles are already connected')) {
-                        log.info('//profiles already connected mutation firing');
                         await updateNotification({
                             notificationId: notification?._id,
                             payload: { actionStatus: 'COMPLETED', read: true },
                         });
-                        const currentQuery = queryClient.getQueryData([
-                            'useGetUserNotifications',
-                            switchedDid ?? '',
-                            queryOptions?.options,
-                            queryOptions?.filter,
-                        ]);
 
                         presentAlert({
                             backdropDismiss: false,
@@ -192,58 +159,14 @@ export const NotificationCardContainer: React.FC<NotificationCardProps> = ({
                                 {
                                     text: 'Okay',
                                     role: 'confirm',
-                                    handler: async () => {
-                                        //extract to helper function....
-                                        if (currentQuery) {
-                                            // find notification in query cache
-                                            // Note the below is for infiniteQuery hook, above commented out is normal....todo, handle this better.
-                                            const updatedQueryNotifications =
-                                                currentQuery?.pages.map(page => {
-                                                    return {
-                                                        hasMore: page?.hasMore,
-                                                        notifications: page?.notifications?.filter(
-                                                            _notification => {
-                                                                if (
-                                                                    _notification?._id ===
-                                                                    notification?._id
-                                                                ) {
-                                                                    _notification.actionStatus =
-                                                                        'COMPLETED';
-                                                                    _notification.read = true;
-                                                                    return _notification;
-                                                                }
-                                                                return _notification;
-                                                            }
-                                                        ),
-                                                    };
-                                                });
-
-                                            const updatedQuery = {
-                                                ...currentQuery,
-                                                notifications: updatedQueryNotifications,
-                                            };
-
-                                            // update to the new value
-                                            queryClient.setQueryData(
-                                                [
-                                                    'useGetUserNotifications',
-                                                    switchedDid ?? '',
-                                                    queryOptions?.options,
-                                                    queryOptions?.filter,
-                                                ],
-                                                updatedQuery
-                                            );
-                                            dismissAlert();
-                                        }
+                                    handler: () => {
+                                        syncAcceptedConnection();
+                                        dismissAlert();
                                     },
                                 },
                             ],
                         });
-
-                        log.info('//profiles already connected mutation firing complete');
-                        return true;
                     }
-                    return false;
                 },
             }
         );

--- a/apps/learn-card-app/src/pages/addressBook/AddressBook.tsx
+++ b/apps/learn-card-app/src/pages/addressBook/AddressBook.tsx
@@ -29,6 +29,7 @@ import {
 
 import useTheme from '../../theme/hooks/useTheme';
 import useHeaderScrollSync from '../../hooks/useHeaderScrollSync';
+import useDebounce from '../../hooks/useDebounce';
 import { IconSetEnum } from '../../theme/icons';
 
 const getActiveRouteTab = (url: string): AddressBookTabsEnum | undefined => {
@@ -55,14 +56,28 @@ const AddressBook: React.FC = () => {
 
     const { url } = useRouteMatch();
     const { presentToast } = useToast();
-    const searchInputRef = useRef<HTMLIonInputElement>(null);
+    const searchInputRef = useRef<HTMLInputElement>(null);
 
     // Block profile mutation
     const { mutate: blockProfile } = useBlockProfileMutation();
 
-    // Search state and query
+    // Search state and query. The input is fully controlled by `search` (updated
+    // immediately per keystroke), while the network query runs off a debounced
+    // copy so we don't fire a request on every character.
     const [search, setSearch] = useState<string>('');
-    const { data: connections, isLoading: loading, refetch } = useGetSearchProfiles(search);
+    const [debouncedSearch, setDebouncedSearch] = useState<string>('');
+    const {
+        data: connections,
+        isLoading: loading,
+        refetch,
+    } = useGetSearchProfiles(debouncedSearch);
+
+    const updateDebouncedSearch = useDebounce(() => setDebouncedSearch(search), 350);
+
+    useEffect(() => {
+        updateDebouncedSearch();
+        return () => (updateDebouncedSearch as any).cancel?.();
+    }, [search, updateDebouncedSearch]);
 
     // Active tab (derived from the route URL) and connection count state
     const initialTab = getActiveRouteTab(url) || AddressBookTabsEnum.Connections;
@@ -115,10 +130,12 @@ const AddressBook: React.FC = () => {
     // Search input handlers
     const handleSearch = useCallback((value: string) => setSearch(value), []);
     const handleSearchFocus = useCallback(() => {
-        searchInputRef.current?.blur();
-        searchInputRef.current?.setFocus();
+        searchInputRef.current?.focus();
     }, []);
-    const clearSearch = useCallback(() => setSearch(''), []);
+    const clearSearch = useCallback(() => {
+        setSearch('');
+        setDebouncedSearch('');
+    }, []);
 
     // Derived booleans for search result rendering
     const isSearching = search.length > 0;

--- a/apps/learn-card-app/src/pages/addressBook/addressBookTabs/AddressBookTabs.tsx
+++ b/apps/learn-card-app/src/pages/addressBook/addressBookTabs/AddressBookTabs.tsx
@@ -88,29 +88,29 @@ const AddressBookTabs: React.FC<{
                 </IonRow>
             )}
             <IonRow className="w-full max-w-[600px] p-2">
-                <IonCol className="relative flex w-full items-center justify-start">
-                    <div className="absolute left-6 top-1/2 transform -translate-y-1/2 z-10">
-                        <Search className="text-grayscale-900 w-[24px] h-[24px]" />
+                <IonCol className="p-0">
+                    <div className="relative w-full">
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 z-10 w-5 h-5 text-grayscale-400 pointer-events-none" />
+                        <input
+                            autoCapitalize="on"
+                            placeholder="Search"
+                            value={search}
+                            onChange={e => handleSearch?.(e.target.value)}
+                            ref={searchInputRef}
+                            type="text"
+                            className="w-full py-3 pl-12 pr-11 rounded-2xl text-base text-grayscale-900 placeholder:text-grayscale-400 bg-grayscale-100 border border-transparent focus:outline-none focus:bg-white focus:border-grayscale-200 focus:ring-2 focus:ring-emerald-500/40 transition-all"
+                        />
+                        {search?.length > 0 && (
+                            <button
+                                type="button"
+                                onClick={clearSearch}
+                                aria-label="Clear search"
+                                className="absolute right-4 top-1/2 -translate-y-1/2 z-10 text-grayscale-400 hover:text-grayscale-700 transition-colors"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
                     </div>
-                    <input
-                        autoCapitalize="on"
-                        placeholder="Search"
-                        value={search}
-                        onChange={e => handleSearch?.(e.target.value)}
-                        ref={searchInputRef}
-                        type="text"
-                        className="w-full bg-grayscale-100 text-grayscale-800 placeholder:text-grayscale-400 rounded-[15px] text-base font-medium tracking-wider subpixel-antialiased py-3 pl-[40px] pr-[40px] focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
-                    />
-                    {search?.length > 0 && (
-                        <button
-                            type="button"
-                            onClick={clearSearch}
-                            aria-label="Clear search"
-                            className="absolute right-6 top-1/2 transform -translate-y-1/2 z-10"
-                        >
-                            <X className="text-grayscale-600 w-[18px] h-[18px]" />
-                        </button>
-                    )}
                 </IonCol>
             </IonRow>
         </>

--- a/apps/learn-card-app/src/pages/addressBook/addressBookTabs/AddressBookTabs.tsx
+++ b/apps/learn-card-app/src/pages/addressBook/addressBookTabs/AddressBookTabs.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { IonRow, IonCol, IonInput } from '@ionic/react';
+import { IonRow, IonCol } from '@ionic/react';
 
 import Search from 'learn-card-base/svgs/Search';
+import X from 'learn-card-base/svgs/X';
 import { AddressBookTabsEnum } from '../addressBookHelpers';
 
 import useTheme from '../../../theme/hooks/useTheme';
@@ -16,7 +17,7 @@ const AddressBookTabs: React.FC<{
     search: string;
     clearSearch: () => void;
     handleSearch?: (value: string) => void;
-    searchInputRef: React.MutableRefObject<HTMLIonInputElement | null>;
+    searchInputRef: React.MutableRefObject<HTMLInputElement | null>;
     blockedCount: number;
     requestCount: number;
 }> = ({
@@ -87,21 +88,29 @@ const AddressBookTabs: React.FC<{
                 </IonRow>
             )}
             <IonRow className="w-full max-w-[600px] p-2">
-                <IonCol className="flex w-full items-center justify-start">
+                <IonCol className="relative flex w-full items-center justify-start">
                     <div className="absolute left-6 top-1/2 transform -translate-y-1/2 z-10">
                         <Search className="text-grayscale-900 w-[24px] h-[24px]" />
                     </div>
-                    <IonInput
-                        autocapitalize="on"
+                    <input
+                        autoCapitalize="on"
                         placeholder="Search"
                         value={search}
-                        className="bg-grayscale-100 text-grayscale-800 ion-padding rounded-[15px] text-base font-medium tracking-wider subpixel-antialiased !pl-[40px]"
-                        onIonInput={e => handleSearch(e.detail.value as string)}
-                        debounce={500}
-                        type="text"
-                        clearInput
+                        onChange={e => handleSearch?.(e.target.value)}
                         ref={searchInputRef}
+                        type="text"
+                        className="w-full bg-grayscale-100 text-grayscale-800 placeholder:text-grayscale-400 rounded-[15px] text-base font-medium tracking-wider subpixel-antialiased py-3 pl-[40px] pr-[40px] focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                     />
+                    {search?.length > 0 && (
+                        <button
+                            type="button"
+                            onClick={clearSearch}
+                            aria-label="Clear search"
+                            className="absolute right-6 top-1/2 transform -translate-y-1/2 z-10"
+                        >
+                            <X className="text-grayscale-600 w-[18px] h-[18px]" />
+                        </button>
+                    )}
                 </IonCol>
             </IonRow>
         </>

--- a/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
+++ b/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
@@ -1,17 +1,27 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Capacitor } from '@capacitor/core';
+import { useQueryClient } from '@tanstack/react-query';
+import { PushNotificationSchema } from '@capacitor/push-notifications';
 
 import { useWallet, useToast, ToastTypeEnum, useIsLoggedIn } from 'learn-card-base';
 
 import { pushUtilities } from '../../utils/pushUtilities';
+import {
+    parseForegroundPushNotification,
+    resolveNotificationRoute,
+    getNotificationToastCopy,
+} from '../../helpers/pushNotificationHelpers';
+import { PushNotificationToast } from './PushNotificationToast';
+
+const FOREGROUND_TOAST_DURATION_MS = 6000;
 
 export const PushNotificationListener = () => {
     const { initWallet } = useWallet();
     const isLoggedIn = useIsLoggedIn();
     const history = useHistory();
+    const queryClient = useQueryClient();
 
-    const { presentToast } = useToast();
+    const { presentToast, dismissToast } = useToast();
 
     const handleNotificationRegistrationError = (text: string) => {
         presentToast(text, {
@@ -20,14 +30,42 @@ export const PushNotificationListener = () => {
         });
     };
 
+    const handleForegroundNotification = useCallback(
+        (payload: PushNotificationSchema) => {
+            const notification = parseForegroundPushNotification(payload);
+
+            if (!notification) return;
+
+            queryClient.invalidateQueries({ queryKey: ['useGetUnreadUserNotifications'] });
+            queryClient.invalidateQueries({ queryKey: ['useGetUserNotifications'] });
+
+            const { title, body } = getNotificationToastCopy(notification);
+            const path = resolveNotificationRoute(notification);
+
+            presentToast(
+                <PushNotificationToast
+                    title={title}
+                    body={body}
+                    onClick={() => {
+                        history.push(path);
+                        dismissToast();
+                    }}
+                />,
+                { autoDismiss: true, duration: FOREGROUND_TOAST_DURATION_MS }
+            );
+        },
+        [queryClient, presentToast, dismissToast, history]
+    );
+
     useEffect(() => {
         pushUtilities.addBackgroundPushNotificationListeners(
             initWallet,
             history,
             isLoggedIn,
-            handleNotificationRegistrationError
+            handleNotificationRegistrationError,
+            handleForegroundNotification
         );
-    }, [history, isLoggedIn]);
+    }, [history, isLoggedIn, handleForegroundNotification]);
 
     return null;
 };

--- a/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
+++ b/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
@@ -11,6 +11,7 @@ import {
     resolveNotificationRoute,
     getNotificationToastCopy,
     getNotificationSenderImage,
+    shouldToastNotification,
 } from '../../helpers/pushNotificationHelpers';
 import { PushNotificationToast } from './PushNotificationToast';
 
@@ -39,6 +40,8 @@ export const PushNotificationListener = () => {
 
             queryClient.invalidateQueries({ queryKey: ['useGetUnreadUserNotifications'] });
             queryClient.invalidateQueries({ queryKey: ['useGetUserNotifications'] });
+
+            if (!shouldToastNotification(notification)) return;
 
             const { title, body } = getNotificationToastCopy(notification);
             const path = resolveNotificationRoute(notification);

--- a/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
+++ b/packages/learn-card-base/src/components/push-notifications/PushNotificationListener.tsx
@@ -10,6 +10,7 @@ import {
     parseForegroundPushNotification,
     resolveNotificationRoute,
     getNotificationToastCopy,
+    getNotificationSenderImage,
 } from '../../helpers/pushNotificationHelpers';
 import { PushNotificationToast } from './PushNotificationToast';
 
@@ -41,11 +42,13 @@ export const PushNotificationListener = () => {
 
             const { title, body } = getNotificationToastCopy(notification);
             const path = resolveNotificationRoute(notification);
+            const imageUrl = getNotificationSenderImage(notification);
 
             presentToast(
                 <PushNotificationToast
                     title={title}
                     body={body}
+                    imageUrl={imageUrl}
                     onClick={() => {
                         history.push(path);
                         dismissToast();

--- a/packages/learn-card-base/src/components/push-notifications/PushNotificationToast.tsx
+++ b/packages/learn-card-base/src/components/push-notifications/PushNotificationToast.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { IonIcon } from '@ionic/react';
+import { notificationsOutline } from 'ionicons/icons';
+
+export type PushNotificationToastProps = {
+    title: string;
+    body?: string;
+    onClick: () => void;
+};
+
+export const PushNotificationToast: React.FC<PushNotificationToastProps> = ({
+    title,
+    body,
+    onClick,
+}) => (
+    <button
+        type="button"
+        onClick={onClick}
+        className="w-full flex items-center gap-3 text-left font-poppins"
+    >
+        <span className="flex items-center justify-center shrink-0 h-9 w-9 rounded-full bg-emerald-50">
+            <IonIcon icon={notificationsOutline} className="text-emerald-600 text-lg" />
+        </span>
+
+        <span className="flex flex-col min-w-0">
+            <span className="text-sm font-semibold text-grayscale-900 truncate">{title}</span>
+            {body && <span className="text-xs text-grayscale-600 truncate">{body}</span>}
+        </span>
+    </button>
+);
+
+export default PushNotificationToast;

--- a/packages/learn-card-base/src/components/push-notifications/PushNotificationToast.tsx
+++ b/packages/learn-card-base/src/components/push-notifications/PushNotificationToast.tsx
@@ -1,32 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IonIcon } from '@ionic/react';
 import { notificationsOutline } from 'ionicons/icons';
 
 export type PushNotificationToastProps = {
     title: string;
     body?: string;
+    imageUrl?: string;
     onClick: () => void;
 };
+
+const FallbackIcon: React.FC = () => (
+    <span className="flex items-center justify-center h-9 w-9 rounded-full bg-emerald-50">
+        <IonIcon icon={notificationsOutline} className="text-emerald-600 text-lg" />
+    </span>
+);
 
 export const PushNotificationToast: React.FC<PushNotificationToastProps> = ({
     title,
     body,
+    imageUrl,
     onClick,
-}) => (
-    <button
-        type="button"
-        onClick={onClick}
-        className="w-full flex items-center gap-3 text-left font-poppins"
-    >
-        <span className="flex items-center justify-center shrink-0 h-9 w-9 rounded-full bg-emerald-50">
-            <IonIcon icon={notificationsOutline} className="text-emerald-600 text-lg" />
-        </span>
+}) => {
+    const [imageFailed, setImageFailed] = useState(false);
+    const showImage = imageUrl && !imageFailed;
 
-        <span className="flex flex-col min-w-0">
-            <span className="text-sm font-semibold text-grayscale-900 truncate">{title}</span>
-            {body && <span className="text-xs text-grayscale-600 truncate">{body}</span>}
-        </span>
-    </button>
-);
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="w-full flex items-center gap-3 text-left font-poppins"
+        >
+            <span className="shrink-0">
+                {showImage ? (
+                    <img
+                        src={imageUrl}
+                        alt=""
+                        referrerPolicy="no-referrer"
+                        onError={() => setImageFailed(true)}
+                        className="h-9 w-9 rounded-full object-cover"
+                    />
+                ) : (
+                    <FallbackIcon />
+                )}
+            </span>
+
+            <span className="flex flex-col min-w-0">
+                <span className="text-sm font-semibold text-grayscale-900 truncate">{title}</span>
+                {body && <span className="text-xs text-grayscale-600 truncate">{body}</span>}
+            </span>
+        </button>
+    );
+};
 
 export default PushNotificationToast;

--- a/packages/learn-card-base/src/components/toast/Toast.tsx
+++ b/packages/learn-card-base/src/components/toast/Toast.tsx
@@ -55,12 +55,18 @@ export const Toast = () => {
                         transition: { duration: 0.2, ease: 'easeInOut' },
                     }}
                     style={{ zIndex }}
-                    className={`fixed top-4 !left-1/2 !-translate-x-1/2 !w-full !px-4 pointer-events-none safe-area-top-margin`}
+                    className={`fixed top-4 right-4 left-auto w-auto phone:left-0 phone:right-0 phone:w-full phone:px-4 pointer-events-none safe-area-top-margin`}
                 >
                     <div
-                        style={{ backgroundColor: isError ? '#f43f5e' : '#FBFBFC' }}
-                        className={`max-w-[600px] mx-auto rounded-[15px] shadow-[0_2px_4px_0_rgba(0,_0,_0,_0.25)] border-2 border-white py-2 px-4 pointer-events-auto relative ${
-                            isError ? 'hover:bg-rose-600' : 'hover:bg-grayscale-100'
+                        style={{
+                            backgroundColor: isError
+                                ? 'rgba(244, 63, 94, 0.85)'
+                                : 'rgba(251, 251, 252, 0.72)',
+                            backdropFilter: 'blur(20px) saturate(180%)',
+                            WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+                        }}
+                        className={`w-[380px] max-w-[calc(100vw-2rem)] phone:w-full phone:max-w-[600px] phone:mx-auto rounded-[18px] border border-white/60 shadow-[0_8px_30px_0_rgba(0,_0,_0,_0.12)] py-2.5 px-4 pointer-events-auto relative transition-[background-color] ${
+                            isError ? 'hover:bg-rose-600/90' : 'hover:bg-white/80'
                         }`}
                     >
                         {isCustomComponent ? (

--- a/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
+++ b/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
@@ -1,34 +1,36 @@
-import { ActionPerformed } from '@capacitor/push-notifications';
+import { ActionPerformed, PushNotificationSchema } from '@capacitor/push-notifications';
 import { LCNNotification, LCNNotificationTypeEnumValidator } from '@learncard/types';
 import { RouteComponentProps } from 'react-router-dom';
 
-export const handlePushNotificationActionPerformed = (
-    notificationPayload: ActionPerformed,
-    history: RouteComponentProps['history']
-) => {
-    if (!notificationPayload) return;
-    if (!history) return;
+import { getLogger } from '../logging/logger';
 
-    const notification: LCNNotification = JSON.parse(notificationPayload.notification.data.raw);
+const log = getLogger('push-notification-helpers');
 
-    const { from, type } = notification;
+// FCM delivers the full LCNNotification as a JSON string on `data.raw`.
+export const parseNotificationFromPushRaw = (
+    raw: string | undefined | null
+): LCNNotification | null => {
+    if (!raw) return null;
 
-    const recipient = typeof from === 'string' ? from : from?.profileId;
+    try {
+        return JSON.parse(raw) as LCNNotification;
+    } catch (error) {
+        log.warn('Failed to parse push notification payload', error);
+        return null;
+    }
+};
+
+export const resolveNotificationRoute = (notification: LCNNotification): string => {
+    const { type } = notification;
 
     switch (type) {
         case LCNNotificationTypeEnumValidator.enum.CONNECTION_REQUEST:
-            history.push(`/notifications`);
-            break;
+            return '/notifications';
         case LCNNotificationTypeEnumValidator.enum.CONNECTION_ACCEPTED:
-            history.push(`/contacts`);
-            break;
+            return '/contacts';
         case LCNNotificationTypeEnumValidator.enum.BOOST_RECEIVED:
         case LCNNotificationTypeEnumValidator.enum.CREDENTIAL_RECEIVED:
-            history.push(`/notifications?uri=${notification?.data?.vcUris?.[0]}&claim=true`);
-            break;
-        case LCNNotificationTypeEnumValidator.enum.PRESENTATION_RECEIVED:
-            // TODO: handle VP redirect
-            break;
+            return `/notifications?uri=${notification?.data?.vcUris?.[0]}&claim=true`;
         case LCNNotificationTypeEnumValidator.enum.DEVICE_LINK_REQUEST:
             // Store session data so the app can auto-open the approver overlay
             if (notification.data?.metadata) {
@@ -44,12 +46,72 @@ export const handlePushNotificationActionPerformed = (
             }
             // Navigate to home — the app's AuthCoordinatorProvider will detect
             // the sessionStorage flag and auto-open the approver overlay.
-            history.push('/');
-            break;
+            return '/';
         default:
-            history.push('/');
-            break;
+            return '/';
     }
 };
+
+export const getNotificationToastCopy = (
+    notification: LCNNotification
+): { title: string; body: string } => {
+    const fromName =
+        typeof notification.from === 'string' ? '' : notification.from?.displayName ?? '';
+
+    if (notification.message?.title || notification.message?.body) {
+        return {
+            title: notification.message?.title ?? 'New notification',
+            body: notification.message?.body ?? '',
+        };
+    }
+
+    switch (notification.type) {
+        case LCNNotificationTypeEnumValidator.enum.CONNECTION_REQUEST:
+            return {
+                title: 'New connection request',
+                body: fromName ? `${fromName} wants to connect` : 'Someone wants to connect',
+            };
+        case LCNNotificationTypeEnumValidator.enum.CONNECTION_ACCEPTED:
+            return {
+                title: 'Connection accepted',
+                body: fromName ? `You're now connected with ${fromName}` : "You're now connected",
+            };
+        case LCNNotificationTypeEnumValidator.enum.BOOST_RECEIVED:
+        case LCNNotificationTypeEnumValidator.enum.CREDENTIAL_RECEIVED:
+            return {
+                title: 'New credential received',
+                body: fromName ? `${fromName} sent you a credential` : 'You received a credential',
+            };
+        case LCNNotificationTypeEnumValidator.enum.PRESENTATION_REQUEST:
+            return {
+                title: 'New request',
+                body: fromName
+                    ? `${fromName} requested information`
+                    : 'Someone requested information',
+            };
+        case LCNNotificationTypeEnumValidator.enum.GUARDIAN_APPROVAL_PENDING:
+            return { title: 'Approval needed', body: 'A request is waiting for your approval' };
+        default:
+            return { title: 'New notification', body: fromName ? `From ${fromName}` : '' };
+    }
+};
+
+export const handlePushNotificationActionPerformed = (
+    notificationPayload: ActionPerformed,
+    history: RouteComponentProps['history']
+) => {
+    if (!notificationPayload) return;
+    if (!history) return;
+
+    const notification = parseNotificationFromPushRaw(notificationPayload.notification?.data?.raw);
+
+    if (!notification) return;
+
+    history.push(resolveNotificationRoute(notification));
+};
+
+export const parseForegroundPushNotification = (
+    payload: PushNotificationSchema
+): LCNNotification | null => parseNotificationFromPushRaw(payload?.data?.raw);
 
 export { handlePushNotificationActionPerformed as default };

--- a/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
+++ b/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
@@ -117,4 +117,13 @@ export const parseForegroundPushNotification = (
 export const getNotificationSenderImage = (notification: LCNNotification): string | undefined =>
     typeof notification.from === 'string' ? undefined : notification.from?.image;
 
+// Notification types that are too noisy / low-signal to surface as an in-app
+// toast. They still land in the Alerts list and badge.
+const TOAST_EXCLUDED_TYPES: LCNNotification['type'][] = [
+    LCNNotificationTypeEnumValidator.enum.CONSENT_FLOW_TRANSACTION,
+];
+
+export const shouldToastNotification = (notification: LCNNotification): boolean =>
+    !TOAST_EXCLUDED_TYPES.includes(notification.type);
+
 export { handlePushNotificationActionPerformed as default };

--- a/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
+++ b/packages/learn-card-base/src/helpers/pushNotificationHelpers.ts
@@ -114,4 +114,7 @@ export const parseForegroundPushNotification = (
     payload: PushNotificationSchema
 ): LCNNotification | null => parseNotificationFromPushRaw(payload?.data?.raw);
 
+export const getNotificationSenderImage = (notification: LCNNotification): string | undefined =>
+    typeof notification.from === 'string' ? undefined : notification.from?.image;
+
 export { handlePushNotificationActionPerformed as default };

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/QRCodeScannerOverlay/QRCodeScannerOverlay';
 export * from './components/QRCodeScannerOverlay/QRCodeScannerFooter';
 export * from './components/ErrorBoundary';
 export * from './components/push-notifications/PushNotificationListener';
+export * from './components/push-notifications/PushNotificationToast';
 export * from './components/earned-and-managed-tabs/EarnedAndManagedTabs';
 export * from './components/sharecreds/ShareCredentialsModal';
 export * from './components/boost/boostOptions/boostOptions';

--- a/packages/learn-card-base/src/react-query/queries/notifications.ts
+++ b/packages/learn-card-base/src/react-query/queries/notifications.ts
@@ -73,12 +73,17 @@ export const useGetUserNotifications = (
 };
 
 /* Get unread user notifications (up to 30) */
-export const useGetUnreadUserNotifications = () => {
+export const useGetUnreadUserNotifications = (options?: {
+    refetchInterval?: number;
+    enabled?: boolean;
+}) => {
     const { initWallet } = useWallet();
     const switchedDid = switchedProfileStore.use.switchedDid();
 
     return useQuery({
         queryKey: ['useGetUnreadUserNotifications', switchedDid ?? ''],
+        refetchInterval: options?.refetchInterval,
+        enabled: options?.enabled,
         queryFn: async () => {
             const wallet = await initWallet();
             const options = {

--- a/packages/learn-card-base/src/utils/pushUtilities.ts
+++ b/packages/learn-card-base/src/utils/pushUtilities.ts
@@ -106,7 +106,8 @@ export const pushUtilities = {
         initWallet: any,
         history: RouteComponentProps['history'],
         syncToken: boolean,
-        handleNotificationRegistrationError?: (text: string) => void
+        handleNotificationRegistrationError?: (text: string) => void,
+        handleForegroundNotification?: (payload: PushNotificationSchema) => void
     ) => {
         if (!pushNotificationsSupported()) return;
 
@@ -144,7 +145,9 @@ export const pushUtilities = {
             'pushNotificationReceived',
             (payload: PushNotificationSchema) => {
                 log.info('Push notification received:', payload);
-                // Handle received notification if needed
+                // The OS suppresses the banner while the app is foregrounded, so
+                // surface it in-app instead of letting the event drop.
+                handleForegroundNotification?.(payload);
             }
         );
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<img width="549" height="553" alt="Screenshot 2026-07-16 at 2 45 16 PM" src="https://github.com/user-attachments/assets/ab0c0933-40be-48aa-bb9c-ebd883f814c9" />

#### 📚 What is the context and goal of this PR?

We only surfaced incoming events (connection requests, received credentials, boosts) in the Alerts area, backed by push notifications. But when the app is open, the OS suppresses the push banner — so if someone sends you a request while you're standing next to them, nothing shows up. This PR adds live in-app notifications so those events appear immediately, and fixes a handful of bugs found in the Alerts and Contacts screens along the way.

#### 🥴 TL; RL:

Live in-app toasts for incoming events (native + web), plus fixes for: a crash when claiming a credential from a notification, the Alerts list constantly flashing, having to click "Accept" twice on a connection request, and the Contacts search bar wiping your typing.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

**1. Live in-app notifications**
- Native: the foreground push listener was previously a no-op (the reason foreground events were dropped). It now shows a tappable toast and keeps the Alerts badge in sync. See `packages/learn-card-base/src/utils/pushUtilities.ts` and `.../components/push-notifications/PushNotificationListener.tsx`.
- Web (no push channel at all): a small listener polls unread notifications and toasts when a new one arrives — `apps/learn-card-app/src/components/notification-toast-listener/NotificationToastListener.tsx`.
- Shared toast shows the sender's avatar and friendly copy, and tapping it opens the Alerts modal (same as the bell). New `PushNotificationToast` component; copy/routing helpers live in `packages/learn-card-base/src/helpers/pushNotificationHelpers.ts`. The shared `Toast` was also restyled (glass look) and repositioned to top-right on desktop so it no longer overlaps the header.

**2. Fixed crash when claiming from a notification**
Opening a boost/credential claim deep-link crashed with "Cannot read properties of undefined (reading 'proof')" because the claim modal renders before the credential has loaded. Guarded `SdJwtVcClaimsBox` against an undefined credential.

**3. Alerts list no longer flashes**
The list showed a full-screen spinner on every background refetch, tearing down and rebuilding all cards (constant flashing, and it wiped card state). Now the spinner only shows on the initial load; background refetches are silent. See `.../notificationsV2/NewNotificationsList.tsx`.

**4. Accept connection works in one click**
Accepting a request needed two clicks: the first silently failed to update the UI, the second showed "already connected." The server sometimes rejects the accept *after* creating the connection, and the click also triggered the card's read handler. Now the button flips optimistically on click and only rolls back on a genuine failure. See `.../notificationsV2/NotificationCardContainer.tsx` and `ConnectionRequestCard.tsx`.

**5. Contacts search bar fixed + restyled**
The search box fought you while typing (text flashed and cleared). It was a controlled `IonInput` with a debounce — a known conflict. Replaced with a native input (immediate value) and moved the debounce onto the query instead, and cleaned up the styling. See `apps/learn-card-app/src/pages/addressBook/AddressBook.tsx` and `.../addressBookTabs/AddressBookTabs.tsx`.

#### 🛠 Important tradeoffs made:

- Web toasts poll unread notifications every ~30s (no push channel exists on web). Interval is easy to tune.
- The "already connected" case is now treated as success (no modal) for a smoother one-click accept.
- Frontend is resilient to the accept-then-reject server quirk, but the underlying server behavior (a post-connect step failing surfaces as a client error) is worth fixing separately.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

**Live notifications**
- Web: log in as two users in two browsers. From user B, send user A a connection request (or issue a credential). Within ~30s user A sees a toast; tapping it opens Alerts; the badge updates.
- Native (device/simulator with push, app in foreground): trigger the same from another account — a toast should appear immediately instead of nothing.

**Claim crash**
- Tap a "Boost Received" / credential toast (or open `/notifications?uri=<uri>&claim=true`). The claim modal should open without the "Something went wrong" error.

**Alerts flashing**
- Open Alerts and let notifications update in the background — the list should stay steady, no full-screen reload/flash.

**Accept connection**
- Accept a connection request from Alerts. One click should flip it to "Accepted" (checkmark) and stay, with no "already connected" popup.

**Contacts search**
- Go to Contacts and type quickly in the search box. Text should stick (no flashing/clearing); results update shortly after you stop typing.

#### 📱 🖥 Which devices would you like help testing on?

Chromium / iOS Native / Android Native

#### 🧪 Code Coverage

No new automated tests — the push path can't run in unit tests, and the rest are UI state/render fixes. Verified manually.

# Documentation

#### 📝 Documentation Checklist

**Internal/AI Docs**

-   [x] **Code comments/JSDoc** — Added only where the reasoning is non-obvious (foreground push suppression, optimistic-accept rollback, the refetch teardown gotcha)

#### 💭 Documentation Notes

App UX behavior and bug fixes; no SDK/API surface changes.

# ✅ PR Checklist

-   [ ] Related to a Jira issue
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication
