### PR TITLE
fix: [LC-1970] - hide sidenav scroll bar

### DIFF
--- a/.changeset/giant-pugs-attack.md
+++ b/.changeset/giant-pugs-attack.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"scoutpass-app": patch
+---
+
+fix: [LC-1970] - hide sidenav scroll bar

--- a/apps/learn-card-app/src/assets/sass/sidemenu.scss
+++ b/apps/learn-card-app/src/assets/sass/sidemenu.scss
@@ -109,6 +109,17 @@ ion-split-pane {
 // The selected row is already conveyed by its background highlight; the default
 // outline drew an unwanted box around the focused/just-clicked item.
 .lc-side-menu-content {
+    &::part(scroll) {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    &::part(scroll)::-webkit-scrollbar {
+        display: none;
+        width: 0;
+        height: 0;
+    }
+
     a,
     button {
         &:focus,

--- a/apps/scouts/src/assets/sass/sidemenu.scss
+++ b/apps/scouts/src/assets/sass/sidemenu.scss
@@ -9,6 +9,19 @@ ion-split-pane {
   }
 }
 
+.scout-pass-side-menu-content {
+  &::part(scroll) {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  &::part(scroll)::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+}
+
 .scout-pass-side-menu-list {
   background: #18224e;
   padding: 0;

--- a/apps/scouts/src/components/sidemenu/SideMenu.tsx
+++ b/apps/scouts/src/components/sidemenu/SideMenu.tsx
@@ -111,7 +111,7 @@ const SideMenu: React.FC<{ branding: BrandingEnum }> = ({ branding = BrandingEnu
 
     return (
         <IonMenu contentId="main" swipeGesture menuId="appSideMenu">
-            <IonContent>
+            <IonContent className="scout-pass-side-menu-content">
                 <IonHeader className="learn-card-header ion-no-border ion-no-padding">
                     <IonToolbar
                         className="ion-no-border ion-no-padding"


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

This change hides the native scrollbars in the side navigation content for both LearnCard and Scouts, creating a cleaner menu experience without changing the underlying scroll behavior.

## Changes

- Added scrollbar-hiding styles to the LearnCard side menu content.
- Added matching scrollbar-hiding styles to the Scouts side menu content.

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

- On desktop, shrink the window until the side menu becomes scrollable.
- Open the side menu and confirm the scrollbar is hidden.
- Verify the menu still scrolls normally.

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [X] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [X] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [ ] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Hide scrollbar in side navigation menus across learn-card and scouts apps using CSS pseudo-elements.

Main changes:
- Added `scout-pass-side-menu-content` CSS class with scrollbar hiding for webkit and standard browsers
- Updated SideMenu component to apply new className to IonContent wrapper element
- Extended existing `.lc-side-menu-content` styles with cross-browser scrollbar suppression rules

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
