### PR TITLE
chore: [LC-1979] - VC display card polishes

### DIFF
--- a/.changeset/clean-ribbons-fit.md
+++ b/.changeset/clean-ribbons-fit.md
@@ -1,0 +1,8 @@
+---
+"@learncard/react": minor
+"learn-card-base": patch
+"learn-card-app": patch
+"scoutpass-app": patch
+---
+
+Keep credential-card padding aligned with the rendered card variant and improve responsive ribbon-title fitting.

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
@@ -3,7 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import { useRenderMethodEnabled } from '../../../../hooks/useRenderMethodEnabled';
 
 import { IonPage } from '@ionic/react';
-import { VCDisplayCard2 } from '@learncard/react';
+import { getVCDisplayCardVariant, VCDisplayCard2 } from '@learncard/react';
 import * as m from '../../../../paraglide/messages.js';
 import { BoostPreviewTabsEnum } from '../../../boost-preview-tabs/boost-preview-tabs.helpers';
 import { boostPreviewStore } from 'learn-card-base';
@@ -234,6 +234,9 @@ const BoostPreview: React.FC<BoostPreviewProps> = ({
         enableRenderMethod &&
         Boolean(renderMethod) &&
         selectedDisplayView === BoostPreviewDisplayViewEnum.Issuer;
+    const shouldUseHostCardPadding =
+        isIssuerViewSelected ||
+        getVCDisplayCardVariant(credential, categoryType, formattedDisplayType) !== 'ribbon';
 
     const { isMobile } = useDeviceTypeByWidth();
 
@@ -341,14 +344,14 @@ const BoostPreview: React.FC<BoostPreviewProps> = ({
             <div className="flex h-full">
                 <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0">
                     <div
-                        className={`w-full px-2 flex flex-col items-center justify-center overflow-x-auto ${boostPreviewWrapperCustomClass} ${
+                        className={`w-full flex flex-col items-center justify-center overflow-x-auto ${boostPreviewWrapperCustomClass} ${
                             isCertificate ? 'certificate-display-zoom' : ''
                         } ${isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''}`}
                     >
                         <section
-                            className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
-                                Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'
-                            }`}
+                            className={`w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
+                                shouldUseHostCardPadding ? 'px-6' : ''
+                            } ${Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'}`}
                         >
                             {isIssuerViewSelected && renderMethod ? (
                                 <RenderMethodDisplay

--- a/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
+++ b/apps/learn-card-app/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
@@ -5,6 +5,7 @@ import { Capacitor } from '@capacitor/core';
 import { useRenderMethodEnabled } from '../../../../hooks/useRenderMethodEnabled';
 
 import { IonPage } from '@ionic/react';
+import { getVCDisplayCardVariant } from '@learncard/react';
 import RenderMethodDisplay from '../../../render-method/RenderMethodDisplay';
 import BoostDetailsSideBar from './BoostDetailsSideBar';
 import BoostDetailsSideMenu from './BoostDetailsSideMenu';
@@ -226,6 +227,19 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
         enableRenderMethod &&
         Boolean(renderMethod) &&
         selectedDisplayView === BoostPreviewDisplayViewEnum.Issuer;
+    const shouldUseHostCardPadding =
+        isIssuerViewSelected ||
+        getVCDisplayCardVariant(credential, categoryType, displayType) !== 'ribbon';
+    let previewWrapperPaddingClass = '';
+    let previewContentPaddingClass = '';
+
+    if (isMobile && isClrCredential) {
+        previewWrapperPaddingClass = 'px-0';
+        previewContentPaddingClass = '!p-0';
+    } else if (shouldUseHostCardPadding) {
+        previewWrapperPaddingClass = 'px-2';
+        previewContentPaddingClass = 'px-6';
+    }
 
     const bgImage = credential?.display?.backgroundImager;
     const showBackground = bgImage && isCertificate;
@@ -321,9 +335,7 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
                     className={`flex h-full overflow-y-scroll pb-[80px] flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0`}
                 >
                     <div
-                        className={`w-full ${
-                            isMobile && isClrCredential ? 'px-0' : 'px-2'
-                        } flex flex-col items-center justify-center overflow-x-auto ${boostPreviewWrapperCustomClass} ${
+                        className={`w-full ${previewWrapperPaddingClass} flex flex-col items-center justify-center overflow-x-auto ${boostPreviewWrapperCustomClass} ${
                             isCertificate ? 'certificate-display-zoom' : ''
                         } ${isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''}`}
                     >
@@ -332,7 +344,7 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
                                 Capacitor.isNativePlatform() && !isClrCredential
                                     ? 'pt-0 safe-area-top-margin'
                                     : 'pt-[30px]'
-                            } ${isMobile && isClrCredential ? '!p-0' : 'px-6'}`}
+                            } ${previewContentPaddingClass}`}
                         >
                             {credentialContent}
                         </section>

--- a/apps/learn-card-app/src/components/boost/claim-boost-card/BoostClaimCard.tsx
+++ b/apps/learn-card-app/src/components/boost/claim-boost-card/BoostClaimCard.tsx
@@ -414,11 +414,7 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                     </div>
                 )}
                 <section className="flex flex-1 h-full overflow-y-auto items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0">
-                    <section
-                        className={`flex flex-col items-center justify-center w-full ${
-                            shouldUseHostCardPadding ? 'px-2' : ''
-                        }`}
-                    >
+                    <section className="flex flex-col items-center justify-center w-full">
                         <section
                             className={`boost-preview-display w-full safe-area-top-margin max-h-full pb-32 disable-scrollbars ${
                                 shouldUseHostCardPadding ? 'px-6' : ''

--- a/apps/learn-card-app/src/components/boost/claim-boost-card/BoostClaimCard.tsx
+++ b/apps/learn-card-app/src/components/boost/claim-boost-card/BoostClaimCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
+import { getVCDisplayCardVariant } from '@learncard/react';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('boost-claim-card');
 
@@ -329,6 +330,10 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
         enableRenderMethod &&
         Boolean(renderMethod) &&
         selectedDisplayView === BoostPreviewDisplayViewEnum.Issuer;
+    const shouldUseHostCardPadding =
+        !credential ||
+        isIssuerViewSelected ||
+        getVCDisplayCardVariant(displayCredential, category) !== 'ribbon';
 
     const credentialDisplay = (
         <VCDisplayCardWrapper2
@@ -409,11 +414,15 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                     </div>
                 )}
                 <section className="flex flex-1 h-full overflow-y-auto items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0">
-                    <section className="flex flex-col items-center justify-center px-2 w-full">
+                    <section
+                        className={`flex flex-col items-center justify-center w-full ${
+                            shouldUseHostCardPadding ? 'px-2' : ''
+                        }`}
+                    >
                         <section
-                            className={`boost-preview-display px-6 w-full safe-area-top-margin max-h-full pb-32 disable-scrollbars ${
-                                Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'
-                            }`}
+                            className={`boost-preview-display w-full safe-area-top-margin max-h-full pb-32 disable-scrollbars ${
+                                shouldUseHostCardPadding ? 'px-6' : ''
+                            } ${Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'}`}
                         >
                             {credential && !selectedImage && (
                                 <>

--- a/apps/learn-card-app/src/components/creds-bundle/ViewSharedBoost.tsx
+++ b/apps/learn-card-app/src/components/creds-bundle/ViewSharedBoost.tsx
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
 import { Browser } from '@capacitor/browser';
+import { getVCDisplayCardVariant } from '@learncard/react';
 import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFooter';
 import {
     IonContent,
@@ -224,6 +225,15 @@ const ViewSharedBoost: React.FC<{
     const lifecyclePillBg = lifecycleStatus === 'suspended' ? '#D97706' : '#DC2626';
     const lifecyclePillLabel =
         lifecycleStatus === 'suspended' ? m['issue.suspended']() : m['issue.revoked']();
+    const isRibbonDisplayCard =
+        sharedCredential && getVCDisplayCardVariant(sharedCredential as VC, category) === 'ribbon';
+    let previewHorizontalPaddingClass = 'px-[32px]';
+
+    if (category === 'ID') {
+        previewHorizontalPaddingClass = 'px-[12px]';
+    } else if (isRibbonDisplayCard) {
+        previewHorizontalPaddingClass = 'px-0';
+    }
 
     if (showEndorsementRequest) {
         return (
@@ -298,9 +308,7 @@ const ViewSharedBoost: React.FC<{
                 )}
                 {boost && wallet && !loading && (
                     <section
-                        className={`relative w-full h-full text-left flex flex-col items-center justify-start pt-4 overflow-y-scroll pb-[100px] ${
-                            category === 'ID' ? 'px-[12px]' : 'px-[32px]'
-                        } ]`}
+                        className={`relative w-full h-full text-left flex flex-col items-center justify-start pt-4 overflow-y-scroll pb-[100px] ${previewHorizontalPaddingClass}`}
                     >
                         {/* 
                            // TODO: FIX THE NAV BUTTON FOR CERTIFICATES  

--- a/apps/learn-card-app/src/pages/claim-from-dashboard/ClaimFromDashboard.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-dashboard/ClaimFromDashboard.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { useHistory, useLocation } from 'react-router-dom';
 import queryString from 'query-string';
 import { VC, UnsignedVP } from '@learncard/types';
+import { getVCDisplayCardVariant } from '@learncard/react';
 import {
     IonLoading,
     IonContent,
@@ -361,6 +362,17 @@ const ClaimFromDashboard: React.FC = () => {
     const isCertificate = credential?.display?.displayType === 'certificate';
     const isID =
         credential?.display?.displayType === 'id' || credential?.hasOwnProperty('boostID') || false;
+    const isRibbonDisplayCard =
+        credential &&
+        getVCDisplayCardVariant(credential, getDefaultCategoryForCredential(credential)) ===
+            'ribbon';
+    let previewHorizontalPaddingClass = 'px-[40px]';
+
+    if (isID) {
+        previewHorizontalPaddingClass = 'px-[12px]';
+    } else if (isRibbonDisplayCard) {
+        previewHorizontalPaddingClass = 'px-0';
+    }
 
     const credBackground = credential?.display?.backgroundImage ?? undefined;
 
@@ -374,9 +386,7 @@ const ClaimFromDashboard: React.FC = () => {
             />
             <IonContent fullscreen color="grayscale-100">
                 <div
-                    className={`px-[40px] pb-[100px] vc-preview-modal-safe-area h-full overflow-y-auto ${
-                        isID ? '!px-[12px]' : ''
-                    }`}
+                    className={`pb-[100px] vc-preview-modal-safe-area h-full overflow-y-auto ${previewHorizontalPaddingClass}`}
                     style={{
                         backgroundImage: `url(${credBackground})`,
                         backgroundSize: 'cover',

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -484,7 +484,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
             <IonPage>
                 <IonLoading isOpen={claiming} message={m['claim.accept.claiming']()} />
                 <div className="flex h-full bg-grayscale-100">
-                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-100">
+                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-500">
                         <section
                             className={`w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
                                 getVCDisplayCardVariant(

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -483,7 +483,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
             <IonPage>
                 <IonLoading isOpen={claiming} message={m['claim.accept.claiming']()} />
                 <div className="flex h-full bg-grayscale-100">
-                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-100">
+                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-500">
                         <section
                             className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
                                 Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -5,6 +5,7 @@ import { VC, VP, VerificationItem } from '@learncard/types';
 import { prettifyVerificationItems } from 'learn-card-base/helpers/verificationPrettifier';
 import { IonContent, IonPage, IonFooter, IonLoading } from '@ionic/react';
 import { Gift, Check, AlertCircle, Home, HelpCircle } from 'lucide-react';
+import { getVCDisplayCardVariant } from '@learncard/react';
 
 import { getLogger } from 'learn-card-base';
 import * as m from '../../paraglide/messages.js';
@@ -485,9 +486,14 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
                 <div className="flex h-full bg-grayscale-100">
                     <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-500">
                         <section
-                            className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
-                                Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'
-                            }`}
+                            className={`w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
+                                getVCDisplayCardVariant(
+                                    credential,
+                                    resolveDetailsCategoryType(credential)
+                                ) !== 'ribbon'
+                                    ? 'px-6'
+                                    : ''
+                            } ${Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'}`}
                         >
                             <div className="pb-4 vc-preview-modal-safe-area h-full w-full">
                                 {renderSingleCredentialCard(credential)}

--- a/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
+++ b/apps/learn-card-app/src/pages/claim-from-request/ExchangeAcceptCredentials.tsx
@@ -484,7 +484,7 @@ const ExchangeAcceptCredentials: React.FC<ExchangeAcceptCredentialsProps> = ({
             <IonPage>
                 <IonLoading isOpen={claiming} message={m['claim.accept.claiming']()} />
                 <div className="flex h-full bg-grayscale-100">
-                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-500">
+                    <section className="flex h-full overflow-y-scroll flex-1 items-start justify-center relative boost-cms-preview [&::part(scroll)]:px-0 bg-grayscale-100">
                         <section
                             className={`w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
                                 getVCDisplayCardVariant(

--- a/apps/learn-card-app/src/pages/claimBoost/ClaimBoost.tsx
+++ b/apps/learn-card-app/src/pages/claimBoost/ClaimBoost.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
+import { getVCDisplayCardVariant } from '@learncard/react';
 import moment from 'moment';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('claim-boost');
@@ -431,6 +432,10 @@ const ClaimBoost: React.FC<{
         enableRenderMethod &&
         Boolean(renderMethod) &&
         selectedDisplayView === BoostPreviewDisplayViewEnum.Issuer;
+    const shouldUseHostCardPadding =
+        !renderMethodSource ||
+        isIssuerViewSelected ||
+        getVCDisplayCardVariant(displayCredential, category ?? undefined) !== 'ribbon';
 
     const renderClaimCredentialDisplay = (credentialToDisplay: VC) => (
         <VCDisplayCardWrapper2
@@ -488,9 +493,9 @@ const ClaimBoost: React.FC<{
                         className="flex flex-col items-center justify-center px-2 overflow-x-auto h-full pt-[30px]"
                     > */}
                     <section
-                        className={`px-6 w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
-                            Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'
-                        }`}
+                        className={`w-full safe-area-top-margin overflow-y-auto max-h-full pb-32 disable-scrollbars ${
+                            shouldUseHostCardPadding ? 'px-6' : ''
+                        } ${Capacitor.isNativePlatform() ? 'pt-0' : 'pt-[30px]'}`}
                     >
                         <div className="pb-4 vc-preview-modal-safe-area h-full w-full">
                             {loading && (

--- a/apps/scouts/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
@@ -4,7 +4,7 @@ import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFoote
 import CredentialIssuerPopover, {
     useCredentialIssuerPopover,
 } from 'learn-card-base/components/CredentialBadge/CredentialIssuerPopover';
-import { VCDisplayCard2 } from '@learncard/react';
+import { getVCDisplayCardVariant, VCDisplayCard2 } from '@learncard/react';
 import { IonContent, IonFooter, IonPage, IonRow } from '@ionic/react';
 
 import { VC, VerificationItem } from '@learncard/types';
@@ -118,6 +118,7 @@ const BoostPreview: React.FC<BoostPreviewProps> = ({
         credential?.display?.displayType === 'id' ||
         categoryType === BoostCategoryOptionsEnum.membership ||
         categoryType === BoostCategoryOptionsEnum.id;
+    const shouldUseHostCardPadding = getVCDisplayCardVariant(credential, categoryType) !== 'ribbon';
     let _categoryType = categoryType;
 
     const bgImage = credential?.display?.backgroundImage;
@@ -151,11 +152,15 @@ const BoostPreview: React.FC<BoostPreviewProps> = ({
                 className={`flex items-center justify-center ion-padding boost-cms-preview transition-colors [&::part(scroll)]:px-0 gradient-mask-b-90`}
             >
                 <IonRow
-                    className={`flex flex-col items-center justify-center px-1 overflow-x-auto pb-32  ${boostPreviewWrapperCustomClass} ${
+                    className={`flex flex-col items-center justify-center overflow-x-auto pb-32  ${boostPreviewWrapperCustomClass} ${
                         isCertificate ? 'pt-14 md:pt-20' : ''
                     } ${isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''}`}
                 >
-                    <section className="px-6 w-full safe-area-top-margin">
+                    <section
+                        className={`w-full safe-area-top-margin ${
+                            shouldUseHostCardPadding ? 'px-6' : ''
+                        }`}
+                    >
                         <VCDisplayCard2
                             credential={credential}
                             issueeOverride={issueeOverride}

--- a/apps/scouts/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/BoostPreview/BoostPreview.tsx
@@ -152,9 +152,11 @@ const BoostPreview: React.FC<BoostPreviewProps> = ({
                 className={`flex items-center justify-center ion-padding boost-cms-preview transition-colors [&::part(scroll)]:px-0 gradient-mask-b-90`}
             >
                 <IonRow
-                    className={`flex flex-col items-center justify-center overflow-x-auto pb-32  ${boostPreviewWrapperCustomClass} ${
-                        isCertificate ? 'pt-14 md:pt-20' : ''
-                    } ${isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''}`}
+                    className={`flex flex-col items-center justify-center overflow-x-auto pb-32 ${boostPreviewWrapperCustomClass} ${
+                        shouldUseHostCardPadding ? 'px-1' : ''
+                    } ${isCertificate ? 'pt-14 md:pt-20' : ''} ${
+                        isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''
+                    }`}
                 >
                     <section
                         className={`w-full safe-area-top-margin ${

--- a/apps/scouts/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/BoostPreview/NonBoostPreview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 
+import { getVCDisplayCardVariant } from '@learncard/react';
 import BoostFooter from 'learn-card-base/components/boost/boostFooter/BoostFooter';
 import VCDisplayCardWrapper2 from 'learn-card-base/components/vcmodal/VCDisplayCardWrapper2';
 import { IonContent, IonFooter, IonPage, IonRow, IonToolbar } from '@ionic/react';
@@ -103,6 +104,7 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
 
     const isCertificate = credential?.display?.displayType === 'certificate';
     const isID = credential?.display?.displayType === 'id' || categoryType === 'ID';
+    const shouldUseHostCardPadding = getVCDisplayCardVariant(credential, categoryType) !== 'ribbon';
 
     const bgImage = credential?.display?.backgroundImager;
     const showBackground = bgImage && isCertificate;
@@ -114,11 +116,13 @@ const NonBoostPreview: React.FC<NonBoostPreviewProps> = ({
                 className={`flex items-center justify-center ion-padding boost-cms-preview transition-colors [&::part(scroll)]:px-0 gradient-mask-b-90`}
             >
                 <IonRow
-                    className={`flex flex-col items-center justify-center px-1 overflow-x-auto pb-32 ${boostPreviewWrapperCustomClass} ${
-                        isCertificate ? 'pt-14 md:pt-20' : ''
-                    } ${isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''}`}
+                    className={`flex flex-col items-center justify-center overflow-x-auto pb-32 ${boostPreviewWrapperCustomClass} ${
+                        shouldUseHostCardPadding ? 'px-1' : ''
+                    } ${isCertificate ? 'pt-14 md:pt-20' : ''} ${
+                        isID ? '!px-0 safe-area-top-margin mt-[20px]' : ''
+                    }`}
                 >
-                    <section className="px-6 w-full">
+                    <section className={`w-full ${shouldUseHostCardPadding ? 'px-6' : ''}`}>
                         <div className="flex items-center justify-center mb-2 vc-preview-modal-safe-area" />
                         <VCDisplayCardWrapper2
                             credential={credential}

--- a/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
+++ b/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 
+import { getVCDisplayCardVariant } from '@learncard/react';
 import { useIsLoggedIn } from 'learn-card-base/stores/currentUserStore';
 import { useClaimCredential, BrandingEnum } from 'learn-card-base';
 import useFirebaseAnalytics from '../../../hooks/useFirebaseAnalytics';
@@ -55,13 +56,13 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
     const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
     // Extract issuer DID and profileID for scouts role logic
-    const issuerDid = 
+    const issuerDid =
         typeof credential?.issuer === 'string' ? credential.issuer : credential?.issuer?.id;
     const profileID = issuerDid?.split(':').pop();
 
     // Fetch highlighted credentials to get the issuer's role
     const { credentials: highlightedCreds } = useHighlightedCredentials(profileID);
-    
+
     // Compute unknownVerifierTitle based on the role (same logic as BoostPreview)
     const unknownVerifierTitle = useMemo(() => {
         if (!highlightedCreds || highlightedCreds.length === 0) return undefined;
@@ -87,6 +88,11 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
     }, []);
 
     const isID = credential?.display?.displayType === 'id' || false;
+    const shouldUseHostCardPadding =
+        getVCDisplayCardVariant(
+            credential as VC,
+            getDefaultCategoryForCredential(credential as VC)
+        ) !== 'ribbon';
 
     let claimStatusText;
 
@@ -107,7 +113,11 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                 fullscreen
                 className={`flex items-center justify-center ion-padding boost-cms-preview transition-colors [&::part(scroll)]:px-0 gradient-mask-b-80`}
             >
-                <IonRow className="flex flex-col items-center justify-center px-6 overflow-x-auto safe-area-top-margin pb-32">
+                <IonRow
+                    className={`flex flex-col items-center justify-center overflow-x-auto safe-area-top-margin pb-32 ${
+                        shouldUseHostCardPadding ? 'px-6' : ''
+                    }`}
+                >
                     {isClaiming && (
                         <div className="absolute w-full h-full top-0 left-0 z-50 flex items-center justify-center flex-col boost-loading-wrapper">
                             <div className="w-[180px] h-full m-auto mt-[5px] flex items-center justify-center">
@@ -120,7 +130,11 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                             </div>
                         </div>
                     )}
-                    <section className={`px-6 w-full ${isID ? '!px-0' : ''}`}>
+                    <section
+                        className={`w-full ${shouldUseHostCardPadding ? 'px-6' : ''} ${
+                            isID ? '!px-0' : ''
+                        }`}
+                    >
                         {credential && (
                             <VCDisplayCardWrapper2
                                 credential={credential}

--- a/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
+++ b/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
@@ -16,6 +16,7 @@ import { VC, VP } from '@learncard/types';
 import {
     getAchievementType,
     getDefaultCategoryForCredential,
+    unwrapBoostCredential,
 } from 'learn-card-base/helpers/credentialHelpers';
 import { useHighlightedCredentials } from '../../../hooks/useHighlightedCredentials';
 import { getRoleFromCred, getScoutsNounForRole } from '../../../helpers/troop.helpers';
@@ -87,11 +88,15 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
         setSelectedImage(url);
     }, []);
 
+    const displayCredential = useMemo(
+        () => (credential ? (unwrapBoostCredential(credential as VC) as VC) : undefined),
+        [credential]
+    );
     const shouldUseHostCardPadding =
-        !credential ||
+        !displayCredential ||
         getVCDisplayCardVariant(
-            credential as VC,
-            getDefaultCategoryForCredential(credential as VC)
+            displayCredential,
+            getDefaultCategoryForCredential(displayCredential)
         ) !== 'ribbon';
 
     let claimStatusText;
@@ -133,7 +138,7 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                     <section className="w-full">
                         {credential && (
                             <VCDisplayCardWrapper2
-                                credential={credential}
+                                credential={displayCredential}
                                 hideNavButtons
                                 isFrontOverride={isFront}
                                 setIsFrontOverride={setIsFront}

--- a/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
+++ b/apps/scouts/src/components/boost/claim-boost-card/BoostClaimCard.tsx
@@ -21,7 +21,7 @@ import { useHighlightedCredentials } from '../../../hooks/useHighlightedCredenti
 import { getRoleFromCred, getScoutsNounForRole } from '../../../helpers/troop.helpers';
 
 type BoostClaimCardProps = {
-    credential: VC | VP;
+    credential: VC | VP | undefined;
     dismiss: ({ historyPush, callback }) => void;
     showFooter?: boolean;
     credentialUri?: string;
@@ -87,8 +87,8 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
         setSelectedImage(url);
     }, []);
 
-    const isID = credential?.display?.displayType === 'id' || false;
     const shouldUseHostCardPadding =
+        !credential ||
         getVCDisplayCardVariant(
             credential as VC,
             getDefaultCategoryForCredential(credential as VC)
@@ -130,11 +130,7 @@ export const BoostClaimCard: React.FC<BoostClaimCardProps> = ({
                             </div>
                         </div>
                     )}
-                    <section
-                        className={`w-full ${shouldUseHostCardPadding ? 'px-6' : ''} ${
-                            isID ? '!px-0' : ''
-                        }`}
-                    >
+                    <section className="w-full">
                         {credential && (
                             <VCDisplayCardWrapper2
                                 credential={credential}

--- a/apps/scouts/src/components/creds-bundle/ViewSharedBoost.tsx
+++ b/apps/scouts/src/components/creds-bundle/ViewSharedBoost.tsx
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Capacitor } from '@capacitor/core';
 import { Browser } from '@capacitor/browser';
+import { getVCDisplayCardVariant } from '@learncard/react';
 
 import {
     useIonAlert,
@@ -159,6 +160,15 @@ const ViewSharedBoost: React.FC = () => {
     const redirectHome = () => history.push('/');
 
     const troopBackgroundStyles = getWallpaperBackgroundStyles(undefined, boost as any);
+    const isRibbonDisplayCard = boost && getVCDisplayCardVariant(boost, category) === 'ribbon';
+    let previewHorizontalPaddingClass = 'px-[32px]';
+
+    if (category === 'ID') {
+        previewHorizontalPaddingClass = 'px-[12px]';
+    } else if (isRibbonDisplayCard) {
+        previewHorizontalPaddingClass = 'px-0';
+    }
+
     const troopIdComponent = isFront ? (
         <ViewTroopIdTemplate
             idMainText={issueeProfile?.displayName}
@@ -233,9 +243,7 @@ const ViewSharedBoost: React.FC = () => {
                 )}
                 {boost && wallet && !loading && (
                     <section
-                        className={`relative w-full h-full text-left flex flex-col items-center justify-start pt-4 overflow-y-scroll pb-[100px] ${
-                            category === 'ID' ? 'px-[12px]' : 'px-[32px]'
-                        } ]`}
+                        className={`relative w-full h-full text-left flex flex-col items-center justify-start pt-4 overflow-y-scroll pb-[100px] ${previewHorizontalPaddingClass}`}
                         style={isTroopId ? troopBackgroundStyles : undefined}
                     >
                         {/* 

--- a/apps/scouts/src/pages/claimBoost/ClaimBoost.tsx
+++ b/apps/scouts/src/pages/claimBoost/ClaimBoost.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { useHistory } from 'react-router';
 
 import { IonContent, IonPage, IonSpinner, useIonAlert, IonRow } from '@ionic/react';
+import { getVCDisplayCardVariant } from '@learncard/react';
 // import MainHeader from '../../components/main-header/MainHeader';
 import X from 'learn-card-base/svgs/X';
 // @ts-ignore
@@ -313,6 +314,9 @@ export const ClaimBoostModal: React.FC<{
     const isTroopIdClaim = boost ? isTroopCredential(boost) : false;
 
     const boostExists = !!boost && !loading;
+    const isRibbonDisplayCard =
+        boostExists &&
+        getVCDisplayCardVariant(boost, getDefaultCategoryForCredential(boost)) === 'ribbon';
 
     return (
         <IonPage>
@@ -322,7 +326,11 @@ export const ClaimBoostModal: React.FC<{
                 customHeaderClass="main-header-branding-public-route"
             /> */}
             <IonContent fullscreen color="grayscale-100">
-                <div className="px-[40px] pb-4 vc-preview-modal-safe-area h-full">
+                <div
+                    className={`pb-4 vc-preview-modal-safe-area h-full ${
+                        isRibbonDisplayCard ? 'px-0' : 'px-[40px]'
+                    }`}
+                >
                     {!boostExists && (
                         <section className="relative loading-spinner-container flex flex-col items-center justify-center h-full w-full">
                             <IonSpinner color="black" />

--- a/packages/learn-card-base/src/components/vcmodal/VCDisplayCardWrapper.tsx
+++ b/packages/learn-card-base/src/components/vcmodal/VCDisplayCardWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { VCDisplayCard2 } from '@learncard/react';
+import { getVCDisplayCardVariant, VCDisplayCard2 } from '@learncard/react';
 import { VC, VerificationItem, CredentialRecord } from '@learncard/types';
 import { getCredentialSubject } from '../IssueVC/helpers';
 import useCurrentUser from 'learn-card-base/hooks/useGetCurrentUser';
@@ -205,6 +205,7 @@ export const VCDisplayCardWrapper = ({
 
     const category: CredentialCategory = VcCategory || cr?.category || 'Achievement';
     const categoryImgUrl = categoryMetadata[category].defaultImageSrc;
+    const shouldUseHostCardPadding = getVCDisplayCardVariant(credential, category) !== 'ribbon';
 
     //override default image component in vc display which depends on assumption of a default vc data shape
     const cardImgUrl =
@@ -224,10 +225,16 @@ export const VCDisplayCardWrapper = ({
     return (
         <IonPage>
             <IonContent
-                className="flex items-center justify-center ion-padding boost-cms-preview"
+                className={`flex items-center justify-center ion-padding boost-cms-preview ${
+                    shouldUseHostCardPadding ? '' : '[&::part(scroll)]:px-0'
+                }`}
                 fullscreen
             >
-                <IonRow className="flex flex-col items-center justify-center px-6">
+                <IonRow
+                    className={`flex flex-col items-center justify-center ${
+                        shouldUseHostCardPadding ? 'px-6' : ''
+                    }`}
+                >
                     <div className="flex items-center justify-cente mb-2 vc-preview-modal-safe-area">
                         <button
                             onClick={handleCloseModal}

--- a/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
+++ b/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
@@ -359,7 +359,8 @@ export const VCModal = ({
     };
 
     const isCertificate = credential?.display?.displayType === 'certificate';
-    const category = cr?.category || getDefaultCategoryForCredential(credential);
+    const category =
+        cr?.category || (credential ? getDefaultCategoryForCredential(credential) : undefined);
     const shouldUseHostCardPadding =
         !credential || getVCDisplayCardVariant(credential, category) !== 'ribbon';
 

--- a/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
+++ b/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
@@ -24,7 +24,10 @@ import { useIsLoggedIn } from 'learn-card-base/stores/currentUserStore';
 
 import redirectStore from 'learn-card-base/stores/redirectStore';
 import modalStateStore from 'learn-card-base/stores/modalStateStore';
-import { unwrapBoostCredential } from 'learn-card-base/helpers/credentialHelpers';
+import {
+    getDefaultCategoryForCredential,
+    unwrapBoostCredential,
+} from 'learn-card-base/helpers/credentialHelpers';
 import { VC, CredentialRecord } from '@learncard/types';
 import { useAcceptCredentialMutation } from 'learn-card-base/react-query/mutations/mutations';
 
@@ -172,7 +175,8 @@ export const VCClaim: React.FC<{
     }
 
     const isCertificate = vc?.display?.displayType === 'certificate';
-    const shouldUseHostCardPadding = !vc || getVCDisplayCardVariant(vc) !== 'ribbon';
+    const shouldUseHostCardPadding =
+        !vc || getVCDisplayCardVariant(vc, getDefaultCategoryForCredential(vc)) !== 'ribbon';
 
     return (
         <IonPage>
@@ -354,9 +358,10 @@ export const VCModal = ({
         onDismiss?.();
     };
 
-    const isCertificate = vc?.display?.displayType === 'certificate';
+    const isCertificate = credential?.display?.displayType === 'certificate';
+    const category = cr?.category || getDefaultCategoryForCredential(credential);
     const shouldUseHostCardPadding =
-        !credential || getVCDisplayCardVariant(credential) !== 'ribbon';
+        !credential || getVCDisplayCardVariant(credential, category) !== 'ribbon';
 
     return (
         <IonPage>

--- a/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
+++ b/packages/learn-card-base/src/components/vcmodal/VCModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getVCDisplayCardVariant } from '@learncard/react';
 
 import {
     IonContent,
@@ -171,17 +172,20 @@ export const VCClaim: React.FC<{
     }
 
     const isCertificate = vc?.display?.displayType === 'certificate';
+    const shouldUseHostCardPadding = !vc || getVCDisplayCardVariant(vc) !== 'ribbon';
 
     return (
         <IonPage>
             <IonContent
-                className="flex items-center justify-center ion-padding boost-cms-preview"
+                className={`flex items-center justify-center ion-padding boost-cms-preview ${
+                    shouldUseHostCardPadding ? '' : '[&::part(scroll)]:px-0'
+                }`}
                 fullscreen
             >
                 <IonRow
-                    className={`flex flex-col items-center justify-center px-6 ${
-                        isCertificate ? 'pt-14 md:pt-20' : ''
-                    }`}
+                    className={`flex flex-col items-center justify-center ${
+                        shouldUseHostCardPadding ? 'px-6' : ''
+                    } ${isCertificate ? 'pt-14 md:pt-20' : ''}`}
                 >
                     <div className="flex items-center justify-center w-full mb-2 vc-preview-modal-safe-area">
                         {!isCertificate && (
@@ -351,17 +355,21 @@ export const VCModal = ({
     };
 
     const isCertificate = vc?.display?.displayType === 'certificate';
+    const shouldUseHostCardPadding =
+        !credential || getVCDisplayCardVariant(credential) !== 'ribbon';
 
     return (
         <IonPage>
             <IonContent
-                className="flex items-center justify-center ion-padding boost-cms-preview"
+                className={`flex items-center justify-center ion-padding boost-cms-preview ${
+                    shouldUseHostCardPadding ? '' : '[&::part(scroll)]:px-0'
+                }`}
                 fullscreen
             >
                 <IonRow
-                    className={`flex flex-col items-center justify-center px-6 ${
-                        isCertificate ? 'pt-14 md:pt-20' : ''
-                    }`}
+                    className={`flex flex-col items-center justify-center ${
+                        shouldUseHostCardPadding ? 'px-6' : ''
+                    } ${isCertificate ? 'pt-14 md:pt-20' : ''}`}
                 >
                     {!isCertificate && (
                         <div className="flex items-center justify-center mb-2 vc-preview-modal-safe-area">

--- a/packages/react-learn-card/src/assets/styles/main.css
+++ b/packages/react-learn-card/src/assets/styles/main.css
@@ -377,7 +377,8 @@
  */
 .vc-display-card-ribbon-safe-area {
     box-sizing: border-box;
-    padding-inline: 38px;
+    /* Hosts that already reserve ribbon-tail space can set this custom property to 0px. */
+    padding-inline: var(--vc-display-card-ribbon-safe-area, 38px);
 }
 
 .vc-toggle-side-button {

--- a/packages/react-learn-card/src/assets/styles/main.css
+++ b/packages/react-learn-card/src/assets/styles/main.css
@@ -371,6 +371,15 @@
     font-family: 'Mouse Memoirs';
 }
 
+/*
+ * Ribbon tails extend 30px beyond the card. Keep that overhang plus an 8px
+ * visible gutter inside VCDisplayCard2 so every preview host gets the same fit.
+ */
+.vc-display-card-ribbon-safe-area {
+    box-sizing: border-box;
+    padding-inline: 38px;
+}
+
 .vc-toggle-side-button {
     background-color: #00000099;
 }

--- a/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 
 interface FitTextProps {
     text: string;
@@ -8,6 +8,8 @@ interface FitTextProps {
     maxFontSize?: number;
 }
 
+const FIT_GUTTER_PX = 16;
+
 const FitText: React.FC<FitTextProps> = ({
     text,
     width,
@@ -15,67 +17,57 @@ const FitText: React.FC<FitTextProps> = ({
     minFontSize = 10,
     maxFontSize = 100,
 }) => {
-    const textRef = useRef<HTMLDivElement>(null);
-    let animationFrameId: number | null = null;
+    const containerRef = useRef<HTMLDivElement>(null);
+    const textRef = useRef<HTMLSpanElement>(null);
 
-    const adjustFontSize = () => {
-        if (textRef.current) {
-            const currentFontSize = parseFloat(
-                window.getComputedStyle(textRef.current).getPropertyValue('font-size')
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        const textElement = textRef.current;
+        if (!container || !textElement) return;
+
+        const fitText = () => {
+            textElement.style.fontSize = `${maxFontSize}px`;
+            textElement.style.whiteSpace = 'nowrap';
+
+            const availableWidth = Math.max(container.clientWidth - FIT_GUTTER_PX, 0);
+            const requiredWidth = textElement.scrollWidth;
+            if (!availableWidth || !requiredWidth) return;
+
+            const fittedFontSize = Math.min(
+                maxFontSize,
+                Math.max(minFontSize, Math.floor((availableWidth / requiredWidth) * maxFontSize))
             );
 
-            // Need to calculate spacing based on nowrap to prevent thrashing
-            textRef.current.style.whiteSpace = 'nowrap';
-            const parentWidth = (textRef.current.parentNode as any)?.clientWidth;
-            const scrollWidth = textRef.current.scrollWidth || textRef.current.offsetWidth;
+            textElement.style.fontSize = `${fittedFontSize}px`;
+            textElement.style.whiteSpace =
+                fittedFontSize === minFontSize && textElement.scrollWidth > availableWidth
+                    ? 'normal'
+                    : 'nowrap';
+        };
 
-            // Sometimes scrollWidth can temporarily be 0. If so, just try again next frame
-            if (scrollWidth === 0) {
-                if (animationFrameId !== null) {
-                    cancelAnimationFrame(animationFrameId);
-                }
+        fitText();
 
-                animationFrameId = requestAnimationFrame(adjustFontSize);
+        const resizeObserver = new ResizeObserver(fitText);
+        resizeObserver.observe(container);
 
-                return;
-            }
-
-            const newFontSize = Math.min(
-                Math.max((parentWidth / scrollWidth) * currentFontSize, minFontSize),
-                maxFontSize
-            );
-
-            textRef.current.style.fontSize = `${newFontSize}px`;
-            textRef.current.style.whiteSpace = newFontSize === minFontSize ? 'normal' : 'nowrap';
-        }
-    };
-
-    const handleResize = () => {
-        if (animationFrameId !== null) {
-            cancelAnimationFrame(animationFrameId);
-        }
-
-        animationFrameId = requestAnimationFrame(adjustFontSize);
-    };
-
-    useEffect(() => {
-        window.addEventListener('resize', handleResize);
-        adjustFontSize();
+        let isMounted = true;
+        document.fonts?.ready.then(() => {
+            if (isMounted) fitText();
+        });
 
         return () => {
-            window.removeEventListener('resize', handleResize);
-            if (animationFrameId !== null) {
-                cancelAnimationFrame(animationFrameId);
-            }
+            isMounted = false;
+            resizeObserver.disconnect();
         };
-    }, [text]);
+    }, [maxFontSize, minFontSize, text, width]);
 
     return (
-        <div style={{ width }} className={`text-center ${className}`}>
-            <span
-                className={`text-[${minFontSize}px] transition-[font-size] whitespace-nowrap`}
-                ref={textRef}
-            >
+        <div
+            ref={containerRef}
+            style={{ width, maxWidth: '100%' }}
+            className={`text-center ${className}`}
+        >
+            <span className="inline-block whitespace-nowrap transition-[font-size]" ref={textRef}>
                 {text}
             </span>
         </div>

--- a/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
@@ -61,7 +61,15 @@ const FitText: React.FC<FitTextProps> = ({
 
         // Device rotation and responsive layouts change the container without
         // necessarily changing the text or receiving a window resize event.
-        const resizeObserver = new ResizeObserver(fitText);
+        let lastObservedWidth: number | undefined;
+        const resizeObserver = new ResizeObserver(([entry]) => {
+            const observedWidth = entry?.contentRect.width;
+
+            if (observedWidth === undefined || observedWidth === lastObservedWidth) return;
+
+            lastObservedWidth = observedWidth;
+            fitText();
+        });
         resizeObserver.observe(container);
 
         // Web fonts can alter the measured glyph width after the first layout.

--- a/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
@@ -42,12 +42,19 @@ const FitText: React.FC<FitTextProps> = ({
             const requiredWidth = textElement.scrollWidth;
             if (!availableWidth || !requiredWidth) return;
 
-            const fittedFontSize = Math.min(
+            let fittedFontSize = Math.min(
                 maxFontSize,
                 Math.max(minFontSize, Math.floor((availableWidth / requiredWidth) * maxFontSize))
             );
 
             textElement.style.fontSize = `${fittedFontSize}px`;
+
+            // Font metrics and browser rounding are not perfectly linear. Verify
+            // the estimate so a one-pixel overflow cannot silently clip a title.
+            while (textElement.scrollWidth > availableWidth && fittedFontSize > minFontSize) {
+                fittedFontSize -= 1;
+                textElement.style.fontSize = `${fittedFontSize}px`;
+            }
 
             // Preserve the single-line ribbon treatment whenever possible.
             // Extremely long titles may wrap only after reaching the minimum.
@@ -61,26 +68,33 @@ const FitText: React.FC<FitTextProps> = ({
 
         // Device rotation and responsive layouts change the container without
         // necessarily changing the text or receiving a window resize event.
-        let lastObservedWidth: number | undefined;
-        const resizeObserver = new ResizeObserver(([entry]) => {
-            const observedWidth = entry?.contentRect.width;
+        let resizeObserver: ResizeObserver | undefined;
+        if (typeof ResizeObserver !== 'undefined') {
+            let lastObservedWidth: number | undefined;
+            resizeObserver = new ResizeObserver(([entry]) => {
+                const observedWidth = entry?.contentRect.width;
 
-            if (observedWidth === undefined || observedWidth === lastObservedWidth) return;
+                if (observedWidth === undefined || observedWidth === lastObservedWidth) return;
 
-            lastObservedWidth = observedWidth;
-            fitText();
-        });
-        resizeObserver.observe(container);
+                lastObservedWidth = observedWidth;
+                fitText();
+            });
+            resizeObserver.observe(container);
+        }
 
         // Web fonts can alter the measured glyph width after the first layout.
         let isMounted = true;
-        document.fonts?.ready.then(() => {
-            if (isMounted) fitText();
-        });
+        document.fonts?.ready
+            .then(() => {
+                if (isMounted) fitText();
+            })
+            .catch(() => {
+                // The initial synchronous measurement remains a safe fallback.
+            });
 
         return () => {
             isMounted = false;
-            resizeObserver.disconnect();
+            resizeObserver?.disconnect();
         };
     }, [maxFontSize, minFontSize, text, width]);
 
@@ -90,7 +104,7 @@ const FitText: React.FC<FitTextProps> = ({
             style={{ width, maxWidth: '100%' }}
             className={`text-center ${className}`}
         >
-            <span className="block w-full whitespace-nowrap" ref={textRef}>
+            <span className="inline-block max-w-full whitespace-nowrap" ref={textRef}>
                 {text}
             </span>
         </div>

--- a/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/FitText.tsx
@@ -8,8 +8,14 @@ interface FitTextProps {
     maxFontSize?: number;
 }
 
-const FIT_GUTTER_PX = 16;
+// Keep fitted text slightly inside the measured edge to account for borders,
+// subpixel rounding, and glyph overhang on narrow screens.
+const FIT_GUTTER_PX = 12;
 
+/**
+ * Shrinks a single-line label to fit its container, wrapping only when the
+ * text still cannot fit at the configured minimum font size.
+ */
 const FitText: React.FC<FitTextProps> = ({
     text,
     width,
@@ -26,6 +32,9 @@ const FitText: React.FC<FitTextProps> = ({
         if (!container || !textElement) return;
 
         const fitText = () => {
+            // Measure from the maximum size each time so repeated resizes do not
+            // compound a previously calculated font size. Font-size transitions
+            // are intentionally avoided so scrollWidth reflects this size immediately.
             textElement.style.fontSize = `${maxFontSize}px`;
             textElement.style.whiteSpace = 'nowrap';
 
@@ -39,6 +48,9 @@ const FitText: React.FC<FitTextProps> = ({
             );
 
             textElement.style.fontSize = `${fittedFontSize}px`;
+
+            // Preserve the single-line ribbon treatment whenever possible.
+            // Extremely long titles may wrap only after reaching the minimum.
             textElement.style.whiteSpace =
                 fittedFontSize === minFontSize && textElement.scrollWidth > availableWidth
                     ? 'normal'
@@ -47,9 +59,12 @@ const FitText: React.FC<FitTextProps> = ({
 
         fitText();
 
+        // Device rotation and responsive layouts change the container without
+        // necessarily changing the text or receiving a window resize event.
         const resizeObserver = new ResizeObserver(fitText);
         resizeObserver.observe(container);
 
+        // Web fonts can alter the measured glyph width after the first layout.
         let isMounted = true;
         document.fonts?.ready.then(() => {
             if (isMounted) fitText();
@@ -67,7 +82,7 @@ const FitText: React.FC<FitTextProps> = ({
             style={{ width, maxWidth: '100%' }}
             className={`text-center ${className}`}
         >
-            <span className="inline-block whitespace-nowrap transition-[font-size]" ref={textRef}>
+            <span className="block w-full whitespace-nowrap" ref={textRef}>
                 {text}
             </span>
         </div>

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -158,7 +158,6 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
     const setIsFront = setIsFrontOverride ?? _setIsFront;
 
     const [headerHeight, setHeaderHeight] = useState(100); // 79 is the height if the header is one line
-    const [headerWidth, setHeaderWidth] = useState(0);
 
     const headerRef = useRef<HTMLHeadingElement>(null);
 
@@ -167,7 +166,6 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         //   Probably because of the interaction with FitText
         setTimeout(() => {
             setHeaderHeight(headerRef.current?.clientHeight || 100);
-            setHeaderWidth(headerRef.current?.clientWidth ?? 0);
         }, 10);
     });
 
@@ -351,7 +349,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                                 text={_title ?? ''}
                                 maxFontSize={32}
                                 minFontSize={20}
-                                width={((headerWidth ?? 290) - 40).toString()}
+                                width="100%"
                                 className={headerFitTextClassName}
                             />
                         </h1>
@@ -390,7 +388,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                                     text={_title ?? ''}
                                     maxFontSize={32}
                                     minFontSize={20}
-                                    width={((headerWidth ?? 290) - 40).toString()}
+                                    width="100%"
                                     className={headerFitTextClassName}
                                 />
                             </h1>

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -43,6 +43,32 @@ export type CredentialIconType = {
     color?: string;
 };
 
+export type VCDisplayCardVariant = 'ribbon' | 'award' | 'certificate' | 'id';
+
+/**
+ * Returns the visual branch VCDisplayCard2 will render. Preview hosts use this
+ * to preserve their specialized-card spacing while the ribbon card owns its
+ * wider horizontal safe area.
+ */
+export const getVCDisplayCardVariant = (
+    credential?: VC | BoostAchievementCredential,
+    categoryType?: LCCategoryEnum | string,
+    formattedDisplayType?: string
+): VCDisplayCardVariant => {
+    const resolvedDisplayType = (
+        credential?.display?.displayType ?? formattedDisplayType
+    )?.toLocaleLowerCase();
+
+    if (categoryType === LCCategoryEnum.meritBadge || resolvedDisplayType === 'award') {
+        return 'award';
+    }
+
+    if (resolvedDisplayType === 'certificate') return 'certificate';
+    if (resolvedDisplayType === 'id' || categoryType === LCCategoryEnum.id) return 'id';
+
+    return 'ribbon';
+};
+
 export type VCDisplayCard2Props = {
     categoryType?: LCCategoryEnum;
     credential: VC | BoostAchievementCredential;
@@ -213,10 +239,13 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
 
     const _title = titleOverride || title;
 
-    const resolvedDisplayType =
-        credential?.display?.displayType ?? formattedDisplayType?.toLocaleLowerCase();
+    const displayCardVariant = getVCDisplayCardVariant(
+        credential,
+        categoryType,
+        formattedDisplayType
+    );
 
-    if (categoryType === LCCategoryEnum.meritBadge || resolvedDisplayType === 'award') {
+    if (displayCardVariant === 'award') {
         return (
             <MeritBadgeDisplayCard
                 credential={credential}
@@ -250,7 +279,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         );
     }
 
-    if (resolvedDisplayType === 'certificate') {
+    if (displayCardVariant === 'certificate') {
         return (
             <CertificateDisplayCard
                 credential={credential}
@@ -282,7 +311,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                 onVerifierClick={onVerifierClick}
             />
         );
-    } else if (resolvedDisplayType === 'id' || categoryType === 'ID') {
+    } else if (displayCardVariant === 'id') {
         return (
             <div>
                 <VCIDDisplayCard
@@ -323,7 +352,7 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         'vc-card-header-main-title text-[#18224E] pt-[3px] leading-[80%] text-[32px]';
 
     return (
-        <Flipper className="w-full" flipKey={isFront}>
+        <Flipper className="vc-display-card-ribbon-safe-area w-full" flipKey={isFront}>
             <Flipped flipId="card">
                 <section
                     className="vc-display-card font-poppins flex flex-col items-center border-solid border-[5px] border-white rounded-[30px] z-10 min-h-[800px] max-w-[400px] relative bg-white shadow-3xl"

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -157,17 +157,28 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
     const isFront = isFrontOverride ?? _isFront;
     const setIsFront = setIsFrontOverride ?? _setIsFront;
 
-    const [headerHeight, setHeaderHeight] = useState(100); // 79 is the height if the header is one line
+    const [headerHeight, setHeaderHeight] = useState(79);
 
     const headerRef = useRef<HTMLHeadingElement>(null);
 
     useLayoutEffect(() => {
-        // Needs a small setTimeout otherwise it'll be wrong sometimes with multiline header.
-        //   Probably because of the interaction with FitText
-        setTimeout(() => {
-            setHeaderHeight(headerRef.current?.clientHeight || 100);
-        }, 10);
-    });
+        const header = headerRef.current;
+        if (!header) return;
+
+        // Keep the ribbon tails aligned when a long title makes the center
+        // section taller than its normal single-line height.
+        const updateHeaderHeight = () => setHeaderHeight(header.clientHeight || 79);
+        const resizeObserver = new ResizeObserver(updateHeaderHeight);
+
+        updateHeaderHeight();
+        resizeObserver.observe(header);
+
+        return () => resizeObserver.disconnect();
+    }, []);
+
+    // The tails start 10px below the center ribbon and visually overlap its
+    // lower border, so they are slightly shorter than the measured header.
+    const ribbonEndHeight = Math.max(headerHeight - 4, 75).toString();
 
     let worstVerificationStatus = verificationItems.reduce(
         (
@@ -323,14 +334,14 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
                         <RibbonEnd
                             side="left"
                             className="absolute left-[-30px] top-[50px] z-0"
-                            height={'75'}
+                            height={ribbonEndHeight}
                         />
                     </Flipped>
                     <Flipped inverseFlipId="card">
                         <RibbonEnd
                             side="right"
                             className="absolute right-[-30px] top-[50px] z-0"
-                            height={'75'}
+                            height={ribbonEndHeight}
                         />
                     </Flipped>
 

--- a/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/VCDisplayCard2.tsx
@@ -194,9 +194,11 @@ export const VCDisplayCard2: React.FC<VCDisplayCard2Props> = ({
         // Keep the ribbon tails aligned when a long title makes the center
         // section taller than its normal single-line height.
         const updateHeaderHeight = () => setHeaderHeight(header.clientHeight || 79);
-        const resizeObserver = new ResizeObserver(updateHeaderHeight);
 
         updateHeaderHeight();
+        if (typeof ResizeObserver === 'undefined') return;
+
+        const resizeObserver = new ResizeObserver(updateHeaderHeight);
         resizeObserver.observe(header);
 
         return () => resizeObserver.disconnect();

--- a/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/FitText.test.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/FitText.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+import FitText from '../FitText';
+
+let resizeObserverCallback: ResizeObserverCallback;
+let clientWidth = 212;
+let scrollWidth = 400;
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+
+class ResizeObserverMock {
+    constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallback = callback;
+    }
+
+    observe = observe;
+    disconnect = disconnect;
+    unobserve = vi.fn();
+}
+
+describe('FitText', () => {
+    let clientWidthSpy: MockInstance<[], number>;
+    let scrollWidthSpy: MockInstance<[], number>;
+
+    beforeEach(() => {
+        clientWidth = 212;
+        scrollWidth = 400;
+        observe.mockClear();
+        disconnect.mockClear();
+
+        vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+        clientWidthSpy = vi
+            .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+            .mockImplementation(() => clientWidth);
+        scrollWidthSpy = vi
+            .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+            .mockImplementation(() => scrollWidth);
+    });
+
+    afterEach(() => {
+        clientWidthSpy.mockRestore();
+        scrollWidthSpy.mockRestore();
+        vi.unstubAllGlobals();
+    });
+
+    test('refits only when the observed width changes', () => {
+        const { container, getByText } = render(
+            <FitText text="A responsive ribbon title" width="100%" maxFontSize={100} />
+        );
+
+        const observedElement = container.firstElementChild as Element;
+
+        resizeObserverCallback(
+            [
+                {
+                    contentRect: { width: 200, height: 40 },
+                    target: observedElement,
+                } as ResizeObserverEntry,
+            ],
+            {} as ResizeObserver
+        );
+        const readsAfterFirstResize = scrollWidthSpy.mock.calls.length;
+
+        resizeObserverCallback(
+            [
+                {
+                    contentRect: { width: 200, height: 80 },
+                    target: observedElement,
+                } as ResizeObserverEntry,
+            ],
+            {} as ResizeObserver
+        );
+
+        expect(scrollWidthSpy).toHaveBeenCalledTimes(readsAfterFirstResize);
+
+        clientWidth = 172;
+        resizeObserverCallback(
+            [
+                {
+                    contentRect: { width: 160, height: 80 },
+                    target: observedElement,
+                } as ResizeObserverEntry,
+            ],
+            {} as ResizeObserver
+        );
+
+        expect(scrollWidthSpy.mock.calls.length).toBeGreaterThan(readsAfterFirstResize);
+        expect(getByText('A responsive ribbon title').style.fontSize).toBe('40px');
+    });
+
+    test('wraps only after reaching the minimum font size', () => {
+        clientWidth = 112;
+        scrollWidth = 1_200;
+
+        const { getByText } = render(
+            <FitText
+                text="An exceptionally long ribbon title"
+                width="100%"
+                minFontSize={10}
+                maxFontSize={100}
+            />
+        );
+        const textElement = getByText('An exceptionally long ribbon title');
+
+        expect(textElement.style.fontSize).toBe('10px');
+        expect(textElement.style.whiteSpace).toBe('normal');
+    });
+});

--- a/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/FitText.test.tsx
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/FitText.test.tsx
@@ -40,7 +40,10 @@ describe('FitText', () => {
             .mockImplementation(() => clientWidth);
         scrollWidthSpy = vi
             .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
-            .mockImplementation(() => scrollWidth);
+            .mockImplementation(function () {
+                const fontSize = Number.parseFloat(this.style.fontSize) || 100;
+                return (scrollWidth * fontSize) / 100;
+            });
     });
 
     afterEach(() => {
@@ -110,5 +113,28 @@ describe('FitText', () => {
 
         expect(textElement.style.fontSize).toBe('10px');
         expect(textElement.style.whiteSpace).toBe('normal');
+    });
+
+    test('keeps the maximum font size when the text fits', () => {
+        clientWidth = 350;
+        scrollWidth = 200;
+
+        const { getByText } = render(
+            <FitText text="Short title" width="100%" minFontSize={10} maxFontSize={32} />
+        );
+
+        expect(getByText('Short title').style.fontSize).toBe('32px');
+    });
+
+    test('still fits when ResizeObserver is unavailable', () => {
+        vi.stubGlobal('ResizeObserver', undefined);
+        clientWidth = 350;
+        scrollWidth = 200;
+
+        const { getByText } = render(
+            <FitText text="Short title" width="100%" minFontSize={10} maxFontSize={32} />
+        );
+
+        expect(getByText('Short title').style.fontSize).toBe('32px');
     });
 });

--- a/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/VCDisplayCard2Variant.test.ts
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/VCDisplayCard2Variant.test.ts
@@ -3,7 +3,8 @@ import type { VC } from '@learncard/types';
 import { getVCDisplayCardVariant } from '../VCDisplayCard2';
 import { LCCategoryEnum } from '../../../types';
 
-const credentialWithDisplayType = (displayType: string): VC => ({ display: { displayType } } as VC);
+const credentialWithDisplayType = (displayType: string): VC =>
+    ({ display: { displayType } } as unknown as VC);
 
 describe('getVCDisplayCardVariant', () => {
     it('uses the ribbon layout for a generic credential', () => {
@@ -16,6 +17,7 @@ describe('getVCDisplayCardVariant', () => {
             'certificate'
         );
         expect(getVCDisplayCardVariant(credentialWithDisplayType('id'))).toBe('id');
+        expect(getVCDisplayCardVariant(credentialWithDisplayType('ID'))).toBe('id');
     });
 
     it('uses category metadata when display metadata is absent', () => {

--- a/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/VCDisplayCard2Variant.test.ts
+++ b/packages/react-learn-card/src/components/VCDisplayCard2/__tests__/VCDisplayCard2Variant.test.ts
@@ -1,0 +1,29 @@
+import type { VC } from '@learncard/types';
+
+import { getVCDisplayCardVariant } from '../VCDisplayCard2';
+import { LCCategoryEnum } from '../../../types';
+
+const credentialWithDisplayType = (displayType: string): VC => ({ display: { displayType } } as VC);
+
+describe('getVCDisplayCardVariant', () => {
+    it('uses the ribbon layout for a generic credential', () => {
+        expect(getVCDisplayCardVariant({} as VC)).toBe('ribbon');
+    });
+
+    it('detects each specialized display type', () => {
+        expect(getVCDisplayCardVariant(credentialWithDisplayType('award'))).toBe('award');
+        expect(getVCDisplayCardVariant(credentialWithDisplayType('certificate'))).toBe(
+            'certificate'
+        );
+        expect(getVCDisplayCardVariant(credentialWithDisplayType('id'))).toBe('id');
+    });
+
+    it('uses category metadata when display metadata is absent', () => {
+        expect(getVCDisplayCardVariant({} as VC, LCCategoryEnum.meritBadge)).toBe('award');
+        expect(getVCDisplayCardVariant({} as VC, LCCategoryEnum.id)).toBe('id');
+    });
+
+    it('uses the formatted display type as a final fallback', () => {
+        expect(getVCDisplayCardVariant({} as VC, undefined, 'Certificate')).toBe('certificate');
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

[LC-1979](https://welibrary.atlassian.net/browse/LC-1979)

Improves credential ribbon previews on narrow mobile screens by keeping ribbon edges within the viewport and allowing long titles to wrap cleanly. The update also standardizes responsive spacing anywhere `VCDisplayCard` or `VCDisplayCard2` is rendered across LearnCard and Scouts.

## What Changed

### Responsive ribbon titles

-   Refactored `FitText` to measure titles synchronously with `useLayoutEffect`.
-   Added `ResizeObserver` support so titles are recalculated when their container changes size.
-   Titles shrink to the configured minimum font size before wrapping.
-   Added a small measurement gutter to prevent glyphs from being clipped on narrow screens.
-   Made ribbon tail height follow wrapped header height.

### Consistent preview spacing

-   Added a shared `getVCDisplayCardVariant` helper for ribbon, award, certificate, and ID layouts.
-   Moved the generic ribbon's horizontal safe area into `VCDisplayCard2`.
-   Preserved existing host padding for specialized credential layouts.
-   Applied the same behavior across:
    -   Claim flows
    -   Boost previews
    -   Shared credential previews
    -   Credential modals
    -   LearnCard and Scouts

### Claim credential backdrop

-   Updated the claim credential preview backdrop to improve contrast between the ribbon and the surrounding page.

### Tests

-   Added unit coverage for credential display variant resolution.

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

<img width="436" height="934" alt="Screenshot 2026-07-28 at 2 32 40 PM" src="https://github.com/user-attachments/assets/5d0d1f83-59a9-4752-b3dc-652fd4ea194e" />

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

-   [ ] Confirm ribbon titles don't clip on mobile devices
-   [ ] Confirm long ribbon titles wrap without clipping.
-   [ ] Confirm ribbon tails retain visible screen-edge padding on narrow devices.
-   [ ] Confirm award, certificate, and ID layouts retain their existing spacing.
-   [ ] Check claim, earned, managed, shared, and boost preview surfaces.

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [X] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication


[LC-1979]: https://welibrary.atlassian.net/browse/LC-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement responsive credential card padding logic based on visual variant to maintain consistent spacing across preview hosts.

Main changes:
- Introduced `getVCDisplayCardVariant()` export to determine card layout type (ribbon/award/certificate/id) and refactored variant detection throughout codebase
- Replaced hardcoded padding with dynamic padding logic using `shouldUseHostCardPadding` variable computed from card variant
- Enhanced FitText component with ResizeObserver for responsive single-line ribbon title fitting and added comprehensive test coverage

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
