### PR TITLE
chore: [LC-2063] - Sync Capgo Channels across Prod + Staging

### DIFF
--- a/.changeset/tidy-cats-sync.md
+++ b/.changeset/tidy-cats-sync.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+Keep staging Capgo channels version-pinned to the native production channel.

--- a/.github/workflows/capgo-staging.yml
+++ b/.github/workflows/capgo-staging.yml
@@ -1,9 +1,15 @@
 name: CapGo Staging Deploy
 
 # When a PR is merged into main (or anything else pushes to main), upload an
-# OTA bundle to the Capgo `staging` channel for the LearnCard app. Skipped on
-# release commits — those go through deploy.yml's production pipeline and
-# upload to the version-pinned channel (e.g. `1.0.7`).
+# OTA bundle to a staging variant of the LearnCard app's configured Capgo
+# channel (e.g. `1.0.9-staging`). Skipped on release commits — those go through
+# deploy.yml's production pipeline and upload to the configured production
+# channel (e.g. `1.0.9`).
+#
+# Both channel names come from `CapacitorUpdater.defaultChannel` in
+# capacitor.config.ts. The staging suffix keeps unreleased `main` bundles away
+# from production devices, while the shared version prefix starts a fresh
+# staging channel whenever native compatibility requires a channel bump.
 #
 # The bundle is built with the *production* tenant config (no `--stage staging`
 # overlay), so it targets prod auth (web3auth) + prod APIs. This is deliberate:
@@ -32,6 +38,7 @@ jobs:
         outputs:
             should_deploy: ${{ steps.gate.outputs.should_deploy }}
             bundle_version: ${{ steps.version.outputs.bundle_version }}
+            channel: ${{ steps.channel.outputs.channel }}
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v7
@@ -85,8 +92,15 @@ jobs:
                   SHORT_SHA="${GITHUB_SHA::7}"
                   echo "bundle_version=${BASE_VERSION}-staging.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
+            - name: Compute version-pinned staging channel
+              id: channel
+              if: steps.gate.outputs.should_deploy == 'true'
+              run: |
+                  DEFAULT_CHANNEL=$(bun tools/capgo/getCapgoChannel.js --app lca)
+                  echo "channel=${DEFAULT_CHANNEL}-staging" >> "$GITHUB_OUTPUT"
+
     upload:
-        name: Upload to staging channel
+        name: Upload staging bundle
         needs: decide
         if: needs.decide.outputs.should_deploy == 'true'
         uses: ./.github/workflows/capgo-upload.yml
@@ -98,7 +112,7 @@ jobs:
             package_json: apps/learn-card-app/package.json
             node_modules_path: node_modules
             environment: learn-card-app-staging
-            channel: staging
+            channel: ${{ needs.decide.outputs.channel }}
             tenant: learncard
             self_assign: 'true'
         secrets:

--- a/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
+++ b/apps/learn-card-app/src/components/versionInfoModal/VersionInfoModal.tsx
@@ -125,7 +125,6 @@ const PLATFORM_LABELS: Record<Platform, string> = {
     web: 'Web',
 };
 
-const STAGING_CHANNEL = 'staging';
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 const PR_RE = /^pr-(\d+)$/;
 const CHANNELS_CACHE_TTL_MS = 60_000;
@@ -206,7 +205,8 @@ const compareSemverDesc = (a: string, b: string): number => {
  * into the four UI buckets. The production stream is semver-named (e.g. `1.0.7`),
  * so the channel matching the build-time `__CAPGO_DEFAULT_CHANNEL__` define is the
  * "Latest" production row; any other semver channels are older production versions
- * (newest first). `staging` and `pr-<n>` channels get their own sections.
+ * (newest first). The staging stream shares the native compatibility prefix
+ * (`<productionChannel>-staging`), and `pr-<n>` channels get their own sections.
  */
 const groupChannels = (
     channels: { name: string }[],
@@ -216,6 +216,7 @@ const groupChannels = (
     const prPreviews: ChannelOption[] = [];
     let productionLatest: ChannelOption | undefined;
     let staging: ChannelOption | undefined;
+    const stagingChannel = productionChannel ? `${productionChannel}-staging` : undefined;
 
     const semverChannels = channels
         .map(c => c.name)
@@ -252,7 +253,7 @@ const groupChannels = (
     }
 
     for (const { name } of channels) {
-        if (name === STAGING_CHANNEL) {
+        if (name === stagingChannel) {
             staging = {
                 value: name,
                 label: 'Staging',


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

## Summary

- Derive the staging Capgo channel from `CapacitorUpdater.defaultChannel`.
- Append `-staging` to preserve separation from production.
- Update the in-app channel picker to use the same derived staging channel.
- Ensure native channel bumps automatically create a matching staging stream.

Example:

- Production: `1.0.9`
- Staging: `1.0.9-staging`

## Why

The previous rolling `staging` channel could receive bundles built against newer native dependencies, potentially breaking older installed builds. Version-pinning staging keeps it aligned with production’s native compatibility boundary without exposing staging bundles to production users.

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [X] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [X] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [ ] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Synchronize Capgo staging channels across production and staging environments by version-pinning them to production channel names.

Main changes:
- Remove hardcoded `STAGING_CHANNEL` constant; compute staging channel dynamically as `${productionChannel}-staging`
- Update GitHub workflow to calculate version-pinned staging channel name and pass it to upload job
- Enhance documentation explaining staging channel naming scheme tied to native compatibility versioning

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
