### PR TITLE
fix: [LC-1968] Open AI Insights chats on desktop

### DIFF
--- a/.changeset/green-cats-chat.md
+++ b/.changeset/green-cats-chat.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+Open AI Insights prompt chats on desktop and allow them to reopen after dismissal.

--- a/.changeset/green-cats-chat.md
+++ b/.changeset/green-cats-chat.md
@@ -1,5 +1,6 @@
 ---
 "learn-card-app": patch
+"learn-card-base": patch
 ---
 
-Open AI Insights prompt chats on desktop and allow them to reopen after dismissal.
+Open AI Insights prompt chats on desktop, allow them to reopen after dismissal, and surface chat startup failures.

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
@@ -1,0 +1,104 @@
+import React, { type ReactNode } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AiSessionTopicsContainer from './AiSessionTopicsContainer';
+
+const mocks = vi.hoisted(() => ({
+    newModal: vi.fn(),
+    closeAllModals: vi.fn(),
+    setChatBotSelected: vi.fn(),
+    resetStore: vi.fn(),
+    clearNewCreds: vi.fn(),
+    replace: vi.fn(),
+    chatBotSelected: 'newTopic' as string | null,
+}));
+
+vi.mock('react-router-dom', () => ({
+    useHistory: () => ({ replace: mocks.replace }),
+    useLocation: () => ({ search: '' }),
+}));
+
+vi.mock('../../hooks/useAiSession', () => ({
+    default: () => ({ openNewAiSessionModal: vi.fn() }),
+}));
+
+vi.mock('learn-card-base/stores/newCredsStore', () => ({
+    newCredsStore: { set: { clearNewCreds: mocks.clearNewCreds } },
+}));
+
+vi.mock('learn-card-base/hooks/useDeviceTypeByWidth', () => ({
+    useDeviceTypeByWidth: () => ({ isDesktop: true, isMobile: false }),
+}));
+
+vi.mock('learn-card-base', () => ({
+    ModalTypes: { Right: 'right' },
+    useGetCredentialList: () => ({
+        data: { pages: [{ records: [] }] },
+        isLoading: false,
+    }),
+    useModal: () => ({
+        newModal: mocks.newModal,
+        closeAllModals: mocks.closeAllModals,
+    }),
+}));
+
+vi.mock('../ai-feature-gate/AiFeatureGate', () => ({
+    AiFeatureGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../pages/ai-sessions/AiSessionsPage', () => ({
+    default: () => <div>AI Sessions</div>,
+}));
+
+vi.mock('../new-ai-session/NewAiSessionContainer', () => ({
+    default: () => <div>New AI Session</div>,
+}));
+
+vi.mock('../../stores/chatBotStore', () => ({
+    chatBotStore: {
+        useTracked: { chatBotSelected: () => mocks.chatBotSelected },
+        set: {
+            setChatBotSelected: (step: string | null) => {
+                mocks.setChatBotSelected(step);
+                mocks.chatBotSelected = step;
+            },
+            resetStore: mocks.resetStore,
+        },
+    },
+}));
+
+describe('AiSessionTopicsContainer', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.chatBotSelected = 'newTopic';
+    });
+
+    it('opens a selected AI chat on desktop', async () => {
+        render(<AiSessionTopicsContainer />);
+
+        await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(1));
+    });
+
+    it('can reopen after the modal is dismissed', async () => {
+        const { rerender } = render(<AiSessionTopicsContainer />);
+
+        await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(1));
+
+        const { onClose } = mocks.newModal.mock.calls[0]?.[1] as {
+            onClose?: () => void;
+        };
+
+        expect(onClose).toBeTypeOf('function');
+        act(() => onClose?.());
+        rerender(<AiSessionTopicsContainer />);
+
+        expect(mocks.resetStore).not.toHaveBeenCalled();
+        expect(mocks.setChatBotSelected).toHaveBeenCalledWith(null);
+
+        mocks.chatBotSelected = 'newTopic';
+        rerender(<AiSessionTopicsContainer />);
+
+        await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(2));
+    });
+});

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
@@ -104,6 +104,21 @@ describe('AiSessionTopicsContainer', () => {
         expect(modal.props.existingTopics).toEqual(mocks.existingTopics);
     });
 
+    it('closes the modal when starting over', async () => {
+        render(<AiSessionTopicsContainer />);
+
+        await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(1));
+
+        const modal = mocks.newModal.mock.calls[0]?.[0] as ReactElement<{
+            handleStartOver: () => void;
+        }>;
+        act(() => modal.props.handleStartOver());
+
+        expect(mocks.closeAllModals).toHaveBeenCalledTimes(1);
+        expect(mocks.resetStore).toHaveBeenCalledTimes(1);
+        expect(mocks.setChatBotSelected).toHaveBeenCalledWith(null);
+    });
+
     it('can reopen after the modal is dismissed', async () => {
         const { rerender } = render(<AiSessionTopicsContainer />);
 

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { type ReactElement, type ReactNode } from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -12,12 +12,16 @@ const mocks = vi.hoisted(() => ({
     clearNewCreds: vi.fn(),
     replace: vi.fn(),
     chatBotSelected: 'newTopic' as string | null,
+    topicsLoading: false,
+    existingTopics: [] as { uri: string }[],
 }));
 
 vi.mock('react-router-dom', () => ({
     useHistory: () => ({ replace: mocks.replace }),
     useLocation: () => ({ search: '' }),
 }));
+
+vi.mock('../../paraglide/messages.js', () => ({ m: {} }));
 
 vi.mock('../../hooks/useAiSession', () => ({
     default: () => ({ openNewAiSessionModal: vi.fn() }),
@@ -34,8 +38,8 @@ vi.mock('learn-card-base/hooks/useDeviceTypeByWidth', () => ({
 vi.mock('learn-card-base', () => ({
     ModalTypes: { Right: 'right' },
     useGetCredentialList: () => ({
-        data: { pages: [{ records: [] }] },
-        isLoading: false,
+        data: { pages: [{ records: mocks.existingTopics }] },
+        isLoading: mocks.topicsLoading,
     }),
     useModal: () => ({
         newModal: mocks.newModal,
@@ -72,12 +76,32 @@ describe('AiSessionTopicsContainer', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.chatBotSelected = 'newTopic';
+        mocks.topicsLoading = false;
+        mocks.existingTopics = [];
     });
 
     it('opens a selected AI chat on desktop', async () => {
         render(<AiSessionTopicsContainer />);
 
         await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(1));
+    });
+
+    it('waits for existing topics before opening the modal', async () => {
+        mocks.topicsLoading = true;
+        const { rerender } = render(<AiSessionTopicsContainer />);
+
+        expect(mocks.newModal).not.toHaveBeenCalled();
+
+        mocks.existingTopics = [{ uri: 'urn:topic:existing' }];
+        mocks.topicsLoading = false;
+        rerender(<AiSessionTopicsContainer />);
+
+        await waitFor(() => expect(mocks.newModal).toHaveBeenCalledTimes(1));
+
+        const modal = mocks.newModal.mock.calls[0]?.[0] as ReactElement<{
+            existingTopics: { uri: string }[];
+        }>;
+        expect(modal.props.existingTopics).toEqual(mocks.existingTopics);
     });
 
     it('can reopen after the modal is dismissed', async () => {

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import queryString from 'query-string';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -35,23 +35,23 @@ export const AiSessionTopicsContainer: React.FC = () => {
     const { isDesktop } = useDeviceTypeByWidth();
 
     const { data: topics, isLoading: topicsLoading } = useGetCredentialList('AI Topic');
-    const existingTopics = topics?.pages?.[0]?.records || [];
+    const existingTopics = useMemo(() => topics?.pages?.[0]?.records ?? [], [topics]);
 
     const chatBotSelected = chatBotStore.useTracked.chatBotSelected();
     const setChatBotSelected = chatBotStore.set.setChatBotSelected;
 
     // const [chatBotSelected, setChatBotSelected] = useState<NewAiSessionStepEnum | null>(null);
-    const handleSetChatBotSelected = (chatBotType: NewAiSessionStepEnum) => {
+    const handleSetChatBotSelected = useCallback((chatBotType: NewAiSessionStepEnum) => {
         setChatBotSelected(chatBotType);
-    };
-    const handleStartOver = () => {
+    }, []);
+    const handleStartOver = useCallback(() => {
         chatBotStore.set.resetStore();
         setChatBotSelected(null);
-    };
-    const handleModalClose = () => {
+    }, []);
+    const handleModalClose = useCallback(() => {
         setChatBotSelected(null);
         setIsModalOpen(false);
-    };
+    }, []);
 
     const { openNewAiSessionModal } = useAiSession();
 
@@ -81,25 +81,24 @@ export const AiSessionTopicsContainer: React.FC = () => {
         newCredsStore.set.clearNewCreds('AI Topic');
     }, []);
 
-    const newAiSessionComponent = (
-        <NewAiSessionContainer
-            existingTopics={existingTopics}
-            showAiAppSelector
-            shortCircuitStep={chatBotSelected}
-            handleStartOver={handleStartOver}
-        />
-    );
-
     useEffect(() => {
         if (!chatBotSelected) {
             if (isModalOpen) setIsModalOpen(false);
             return;
         }
 
-        if (isModalOpen) return;
+        // Ionic stores the React element passed to newModal rather than re-rendering
+        // it with this component. Wait for topics so the modal does not permanently
+        // capture the loading render's empty list.
+        if (topicsLoading || isModalOpen) return;
 
         newModal(
-            newAiSessionComponent,
+            <NewAiSessionContainer
+                existingTopics={existingTopics}
+                showAiAppSelector
+                shortCircuitStep={chatBotSelected}
+                handleStartOver={handleStartOver}
+            />,
             {
                 hideButton: true,
                 onClose: handleModalClose,
@@ -110,7 +109,15 @@ export const AiSessionTopicsContainer: React.FC = () => {
             }
         );
         setIsModalOpen(true);
-    }, [isModalOpen, chatBotSelected, newModal]);
+    }, [
+        chatBotSelected,
+        existingTopics,
+        handleModalClose,
+        handleStartOver,
+        isModalOpen,
+        newModal,
+        topicsLoading,
+    ]);
 
     return (
         <AiFeatureGate>

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
@@ -17,7 +17,7 @@ import { chatBotStore } from '../../stores/chatBotStore';
 import { useModal, ModalTypes } from 'learn-card-base';
 
 export const AiSessionTopicsContainer: React.FC = () => {
-    const { newModal } = useModal({
+    const { newModal, closeAllModals } = useModal({
         desktop: ModalTypes.Right,
         mobile: ModalTypes.Right,
     });
@@ -45,9 +45,10 @@ export const AiSessionTopicsContainer: React.FC = () => {
         setChatBotSelected(chatBotType);
     }, []);
     const handleStartOver = useCallback(() => {
+        closeAllModals();
         chatBotStore.set.resetStore();
         setChatBotSelected(null);
-    }, []);
+    }, [closeAllModals]);
     const handleModalClose = useCallback(() => {
         setChatBotSelected(null);
         setIsModalOpen(false);

--- a/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
+++ b/apps/learn-card-app/src/components/ai-sessions/AiSessionTopicsContainer.tsx
@@ -17,7 +17,7 @@ import { chatBotStore } from '../../stores/chatBotStore';
 import { useModal, ModalTypes } from 'learn-card-base';
 
 export const AiSessionTopicsContainer: React.FC = () => {
-    const { newModal, closeAllModals } = useModal({
+    const { newModal } = useModal({
         desktop: ModalTypes.Right,
         mobile: ModalTypes.Right,
     });
@@ -31,8 +31,8 @@ export const AiSessionTopicsContainer: React.FC = () => {
     const startNewSession: boolean = _startNewSession === 'true';
     const shortCircuitStep: NewAiSessionStepEnum = _shortCircuitStep as NewAiSessionStepEnum;
 
-    const [isMobileModalOpen, setIsMobileModalOpen] = useState<boolean>(false);
-    const { isDesktop, isMobile } = useDeviceTypeByWidth();
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+    const { isDesktop } = useDeviceTypeByWidth();
 
     const { data: topics, isLoading: topicsLoading } = useGetCredentialList('AI Topic');
     const existingTopics = topics?.pages?.[0]?.records || [];
@@ -47,6 +47,10 @@ export const AiSessionTopicsContainer: React.FC = () => {
     const handleStartOver = () => {
         chatBotStore.set.resetStore();
         setChatBotSelected(null);
+    };
+    const handleModalClose = () => {
+        setChatBotSelected(null);
+        setIsModalOpen(false);
     };
 
     const { openNewAiSessionModal } = useAiSession();
@@ -87,27 +91,26 @@ export const AiSessionTopicsContainer: React.FC = () => {
     );
 
     useEffect(() => {
-        if (isMobile && !isMobileModalOpen && chatBotSelected) {
-            newModal(
-                newAiSessionComponent,
-                {
-                    hideButton: true,
-                },
-                {
-                    mobile: ModalTypes.Right,
-                    desktop: ModalTypes.Right,
-                }
-            );
-            setIsMobileModalOpen(true);
+        if (!chatBotSelected) {
+            if (isModalOpen) setIsModalOpen(false);
             return;
         }
 
-        if (isMobileModalOpen && isDesktop && chatBotSelected) {
-            closeAllModals();
-            setIsMobileModalOpen(false);
-            return;
-        }
-    }, [isMobile, isMobileModalOpen, isDesktop, chatBotSelected]);
+        if (isModalOpen) return;
+
+        newModal(
+            newAiSessionComponent,
+            {
+                hideButton: true,
+                onClose: handleModalClose,
+            },
+            {
+                mobile: ModalTypes.Right,
+                desktop: ModalTypes.Right,
+            }
+        );
+        setIsModalOpen(true);
+    }, [isModalOpen, chatBotSelected, newModal]);
 
     return (
         <AiFeatureGate>

--- a/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.test.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AiInsightsErrorHandler from './AiInsightsErrorHandler';
@@ -7,7 +7,6 @@ import { AiSessionMode } from './newAiSession.helpers';
 
 const mocks = vi.hoisted(() => ({
     aiError: null as { at: number; code?: string } | null,
-    showErrorModal: vi.fn(),
 }));
 
 vi.mock('@nanostores/react', () => ({
@@ -18,13 +17,8 @@ vi.mock('learn-card-base/stores/nanoStores/chatStore', () => ({
     lastAiError: {},
 }));
 
-vi.mock('learn-card-base/stores/nanoStores/ErrorModalStore', () => ({
-    showErrorModal: mocks.showErrorModal,
-}));
-
 describe('AiInsightsErrorHandler', () => {
     beforeEach(() => {
-        vi.clearAllMocks();
         mocks.aiError = null;
         vi.spyOn(Date, 'now').mockReturnValue(1_000);
     });
@@ -37,9 +31,9 @@ describe('AiInsightsErrorHandler', () => {
         mocks.aiError = { at: 1_001, code: 'insufficient_quota' };
         rerender(<AiInsightsErrorHandler active mode={AiSessionMode.insights} />);
 
-        expect(mocks.showErrorModal).toHaveBeenCalledWith(
-            'Something went wrong',
-            'Please try your request again.'
+        expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'AI chat is temporarily unavailable. Please try again later.'
         );
     });
 
@@ -48,7 +42,7 @@ describe('AiInsightsErrorHandler', () => {
 
         render(<AiInsightsErrorHandler active mode={AiSessionMode.insights} />);
 
-        expect(mocks.showErrorModal).not.toHaveBeenCalled();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 
     it('does not show the Insights error modal for tutor sessions', () => {
@@ -57,6 +51,6 @@ describe('AiInsightsErrorHandler', () => {
         mocks.aiError = { at: 1_001, code: 'server_error' };
         rerender(<AiInsightsErrorHandler active mode={AiSessionMode.tutor} />);
 
-        expect(mocks.showErrorModal).not.toHaveBeenCalled();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 });

--- a/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.test.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AiInsightsErrorHandler from './AiInsightsErrorHandler';
+import { AiSessionMode } from './newAiSession.helpers';
+
+const mocks = vi.hoisted(() => ({
+    aiError: null as { at: number; code?: string } | null,
+    showErrorModal: vi.fn(),
+}));
+
+vi.mock('@nanostores/react', () => ({
+    useStore: () => mocks.aiError,
+}));
+
+vi.mock('learn-card-base/stores/nanoStores/chatStore', () => ({
+    lastAiError: {},
+}));
+
+vi.mock('learn-card-base/stores/nanoStores/ErrorModalStore', () => ({
+    showErrorModal: mocks.showErrorModal,
+}));
+
+describe('AiInsightsErrorHandler', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.aiError = null;
+        vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    });
+
+    it('shows a friendly error for an active Insights request', () => {
+        const { rerender } = render(
+            <AiInsightsErrorHandler active mode={AiSessionMode.insights} />
+        );
+
+        mocks.aiError = { at: 1_001, code: 'insufficient_quota' };
+        rerender(<AiInsightsErrorHandler active mode={AiSessionMode.insights} />);
+
+        expect(mocks.showErrorModal).toHaveBeenCalledWith(
+            'Something went wrong',
+            'Please try your request again.'
+        );
+    });
+
+    it('ignores errors from before the Insights chat became active', () => {
+        mocks.aiError = { at: 999, code: 'server_error' };
+
+        render(<AiInsightsErrorHandler active mode={AiSessionMode.insights} />);
+
+        expect(mocks.showErrorModal).not.toHaveBeenCalled();
+    });
+
+    it('does not show the Insights error modal for tutor sessions', () => {
+        const { rerender } = render(<AiInsightsErrorHandler active mode={AiSessionMode.tutor} />);
+
+        mocks.aiError = { at: 1_001, code: 'server_error' };
+        rerender(<AiInsightsErrorHandler active mode={AiSessionMode.tutor} />);
+
+        expect(mocks.showErrorModal).not.toHaveBeenCalled();
+    });
+});

--- a/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { IonIcon } from '@ionic/react';
+import { alertCircleOutline } from 'ionicons/icons';
 import { useStore } from '@nanostores/react';
 
 import { lastAiError } from 'learn-card-base/stores/nanoStores/chatStore';
-import { showErrorModal } from 'learn-card-base/stores/nanoStores/ErrorModalStore';
 
 import { AiSessionMode } from './newAiSession.helpers';
 
@@ -12,7 +13,7 @@ export const AiInsightsErrorHandler: React.FC<{
 }> = ({ active, mode }) => {
     const aiError = useStore(lastAiError);
     const activeSinceRef = useRef<number | null>(null);
-    const handledErrorAtRef = useRef<number | null>(null);
+    const [visibleErrorAt, setVisibleErrorAt] = useState<number | null>(null);
 
     useEffect(() => {
         if (active && mode === AiSessionMode.insights) {
@@ -21,7 +22,7 @@ export const AiInsightsErrorHandler: React.FC<{
         }
 
         activeSinceRef.current = null;
-        handledErrorAtRef.current = null;
+        setVisibleErrorAt(null);
     }, [active, mode]);
 
     useEffect(() => {
@@ -33,16 +34,35 @@ export const AiInsightsErrorHandler: React.FC<{
             !aiError ||
             activeSince === null ||
             aiError.at < activeSince ||
-            aiError.at === handledErrorAtRef.current
+            aiError.at === visibleErrorAt
         ) {
             return;
         }
 
-        handledErrorAtRef.current = aiError.at;
-        showErrorModal('Something went wrong', 'Please try your request again.');
-    }, [active, aiError, mode]);
+        setVisibleErrorAt(aiError.at);
+    }, [active, aiError, mode, visibleErrorAt]);
 
-    return null;
+    if (visibleErrorAt === null) return null;
+
+    return (
+        <div className="absolute inset-x-4 top-[calc(80px+env(safe-area-inset-top))] z-[100]">
+            <div
+                role="alert"
+                className="p-3 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-2.5 shadow-soft-bottom"
+            >
+                <IonIcon
+                    icon={alertCircleOutline}
+                    className="text-red-400 text-lg mt-0.5 shrink-0"
+                />
+                <div>
+                    <p className="text-sm font-semibold text-red-700">Something went wrong</p>
+                    <p className="text-sm text-red-700 leading-relaxed">
+                        AI chat is temporarily unavailable. Please try again later.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
 };
 
 export default AiInsightsErrorHandler;

--- a/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/AiInsightsErrorHandler.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react';
+import { useStore } from '@nanostores/react';
+
+import { lastAiError } from 'learn-card-base/stores/nanoStores/chatStore';
+import { showErrorModal } from 'learn-card-base/stores/nanoStores/ErrorModalStore';
+
+import { AiSessionMode } from './newAiSession.helpers';
+
+export const AiInsightsErrorHandler: React.FC<{
+    active: boolean;
+    mode: AiSessionMode;
+}> = ({ active, mode }) => {
+    const aiError = useStore(lastAiError);
+    const activeSinceRef = useRef<number | null>(null);
+    const handledErrorAtRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (active && mode === AiSessionMode.insights) {
+            activeSinceRef.current ??= Date.now();
+            return;
+        }
+
+        activeSinceRef.current = null;
+        handledErrorAtRef.current = null;
+    }, [active, mode]);
+
+    useEffect(() => {
+        const activeSince = activeSinceRef.current;
+
+        if (
+            !active ||
+            mode !== AiSessionMode.insights ||
+            !aiError ||
+            activeSince === null ||
+            aiError.at < activeSince ||
+            aiError.at === handledErrorAtRef.current
+        ) {
+            return;
+        }
+
+        handledErrorAtRef.current = aiError.at;
+        showErrorModal('Something went wrong', 'Please try your request again.');
+    }, [active, aiError, mode]);
+
+    return null;
+};
+
+export default AiInsightsErrorHandler;

--- a/apps/learn-card-app/src/components/new-ai-session/LearnCardAiChatBot/LearnCardAiChatBot.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/LearnCardAiChatBot/LearnCardAiChatBot.tsx
@@ -20,6 +20,7 @@ import AiChatLoading from './AiChatLoading';
 import AiSessionPlan from './AiSessionPlan';
 import AiSessionLoader from '../AiSessionLoader';
 import { MessageWithQuestions, StreamingMessage } from './MessageWithQuestions';
+import ChatBotTypingIndicator from '../NewAiSessionChatBot/helpers/TypingIndicator';
 
 import {
     messages,
@@ -107,6 +108,7 @@ export const LearnCardAiChatBot: React.FC<LearnCardAiChatBotProps> = ({
     const isEnding = useStore(isEndingSession);
     const showEndingLoader = useStore(showEndingSessionLoader);
     const loading = useStore(isLoading);
+    const typing = useStore(isTyping);
     const authState = useStore(auth);
     const streaming = useStore(streamingMessage);
     const aiError = useStore(lastAiError);
@@ -431,12 +433,11 @@ export const LearnCardAiChatBot: React.FC<LearnCardAiChatBotProps> = ({
                                     {messagesToShow.map((msg, index) => {
                                         const isLastUser = index === lastUserIdx;
                                         const isTail = index === messagesToShow.length - 1;
-                                        // Reserve viewport space on whatever is the last rendered block.
-                                        // When streaming, that's the StreamingMessage below; otherwise
-                                        // it's the tail message wrapper. Keeps the user bubble pinned
-                                        // to the top without creating a gap before the assistant reply.
+                                        // Reserve viewport space on whichever block renders last.
+                                        // Streaming and typing indicators own this space while active;
+                                        // otherwise the tail message keeps the latest user bubble pinned.
                                         const pinStyle =
-                                            isTail && !streaming && viewportAllowance > 0
+                                            isTail && !streaming && !typing && viewportAllowance > 0
                                                 ? {
                                                       minHeight: `${Math.max(
                                                           0,
@@ -472,6 +473,26 @@ export const LearnCardAiChatBot: React.FC<LearnCardAiChatBotProps> = ({
                                             }
                                         >
                                             <StreamingMessage aiApp={aiApp} />
+                                        </div>
+                                    )}
+
+                                    {typing && !streaming && (
+                                        <div
+                                            role="status"
+                                            aria-label="AI is responding"
+                                            className="w-full transition-opacity duration-150"
+                                            style={
+                                                viewportAllowance > 0
+                                                    ? {
+                                                          minHeight: `${Math.max(
+                                                              0,
+                                                              viewportAllowance - 24
+                                                          )}px`,
+                                                      }
+                                                    : undefined
+                                            }
+                                        >
+                                            <ChatBotTypingIndicator />
                                         </div>
                                     )}
                                 </div>

--- a/apps/learn-card-app/src/components/new-ai-session/NewAiSessionContainer.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/NewAiSessionContainer.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import ExistingAiSessionChatBotContainer from './NewAiSessionChatBot/ExistingAiSessionChatBotContainer';
 import NewAiAppSessionChatBotContainer from './NewAiSessionChatBot/NewAiAppSessionChatBotContainer';
 import NewAiSessionChatBotContainer from './NewAiSessionChatBot/NewAiSessionChatBotContainer';
 import AiSessionTypeSelector from './AiSessionTypeSelector/AiSessionTypeSelector';
+import AiInsightsErrorHandler from './AiInsightsErrorHandler';
 
 import { useDeviceTypeByWidth, LaunchPadAppListItem } from 'learn-card-base';
 
@@ -34,13 +35,9 @@ export const NewAiSessionContainer: React.FC<{
     const activeStep = chatBotStore.useTracked.activeStep();
     const setActiveStep = chatBotStore.set.setActiveStep;
 
-    // const [activeStep, setActiveStep] = useState<NewAiSessionStepEnum>(
-    //     NewAiSessionStepEnum.topicSelector
-    // );
-
     const startInternalAiChatBot = chatBotStore.useTracked.startInternalAiChatBot();
     const setStartInternalAiChatBot = chatBotStore.set.setStartInternalAiChatBot;
-    // const [startInternalAiChatBot, setStartInternalAiChatBot] = useState<boolean>(false);
+    const mode = chatBotStore.useTracked.mode();
 
     useEffect(() => {
         if (shortCircuitStep) {
@@ -112,6 +109,7 @@ export const NewAiSessionContainer: React.FC<{
         <div
             className={`h-full bg-transparent relative flex items-center flex-col justify-end ${containerStyles}`}
         >
+            <AiInsightsErrorHandler active={startInternalAiChatBot} mode={mode} />
             {step}
         </div>
     );

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
@@ -319,16 +319,20 @@ describe('chat session startup', () => {
         );
     });
 
-    it('ignores untagged startup frames after a request is accepted', async () => {
+    it('accepts an untagged startup error from the current socket', async () => {
         const start = startTopic('Algebra');
         const socket = await openLatestSocket();
         await start;
         socket.receive({ event: 'session_start_accepted', requestId: 'request-current' });
-        socket.receive({ error: 'stale provider failed' });
+        socket.receive({ error: 'provider failed' });
 
-        expect(isLoading.get()).toBe(true);
-        expect(isTyping.get()).toBe(true);
-        expect(mocks.showErrorModal).not.toHaveBeenCalled();
+        expect(isLoading.get()).toBe(false);
+        expect(isTyping.get()).toBe(false);
+        expect(lastAiError.get()).toMatchObject({ code: 'provider failed' });
+        expect(mocks.showErrorModal).toHaveBeenCalledWith(
+            'Something went wrong',
+            'Please try starting the session again.'
+        );
     });
 
     it('accepts an untagged Insights error after a correlated topic startup', async () => {
@@ -346,6 +350,10 @@ describe('chat session startup', () => {
         const insightsStart = startInsightsSession('Career options');
         const insightsSocket = await openLatestSocket();
         await insightsStart;
+        insightsSocket.receive({
+            event: 'session_start_accepted',
+            requestId: 'request-insights',
+        });
         insightsSocket.receive({ error: 'Insufficient credits' });
 
         expect(lastAiError.get()).toMatchObject({ code: 'Insufficient credits' });

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
@@ -59,7 +59,7 @@ class FakeWebSocket {
         this.sent.push(payload);
     }
 
-    receive(payload: Record<string, unknown>) {
+    receive(payload: unknown) {
         this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>);
     }
 }
@@ -553,5 +553,57 @@ describe('chat session startup', () => {
             'Something went wrong',
             'Please try starting the session again.'
         );
+    });
+
+    it('ends a silent Insights response with friendly feedback after 32 seconds', async () => {
+        const start = startInsightsSession('Career fit');
+        const socket = await openLatestSocket();
+        await start;
+        socket.receive({ event: 'insights_ready', threadId: 'thread-insights' });
+        socket.receive({ event: 'assistant_typing', threadId: 'thread-insights' });
+
+        await vi.advanceTimersByTimeAsync(31_999);
+        expect(isTyping.get()).toBe(true);
+        expect(lastAiError.get()).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(isLoading.get()).toBe(false);
+        expect(isTyping.get()).toBe(false);
+        expect(lastAiError.get()).toMatchObject({ code: 'startup_timeout' });
+    });
+
+    it('keeps Insights typing feedback visible across an automatic reconnect', async () => {
+        const start = startInsightsSession('Career fit');
+        const socket = await openLatestSocket();
+        await start;
+        socket.receive({ event: 'insights_ready', threadId: 'thread-insights' });
+        socket.receive({ event: 'assistant_typing', threadId: 'thread-insights' });
+
+        socket.close();
+        await Promise.resolve();
+
+        expect(isTyping.get()).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        const reconnectedSocket = FakeWebSocket.instances.at(-1);
+
+        expect(reconnectedSocket).not.toBe(socket);
+        reconnectedSocket?.open();
+        expect(isTyping.get()).toBe(true);
+
+        reconnectedSocket?.receive({ done: true, threadId: 'thread-insights' });
+        expect(isTyping.get()).toBe(false);
+    });
+
+    it('does not time out an Insights response after its first content frame', async () => {
+        const start = startInsightsSession('Career fit');
+        const socket = await openLatestSocket();
+        await start;
+        socket.receive({ event: 'insights_ready', threadId: 'thread-insights' });
+        socket.receive('Here is what I found.');
+
+        await vi.advanceTimersByTimeAsync(32_000);
+
+        expect(lastAiError.get()).toBeNull();
     });
 });

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
@@ -74,6 +74,7 @@ const {
     currentThreadId,
     disconnectWebSocket,
     isLoading,
+    lastAiError,
     isTyping,
     messages,
     planReady,
@@ -83,6 +84,7 @@ const {
     resetChatStores,
     sendMessage,
     sessionEnded,
+    startInsightsSession,
     startTopic,
     threads,
 } = await import('./chatStore');
@@ -327,6 +329,28 @@ describe('chat session startup', () => {
         expect(isLoading.get()).toBe(true);
         expect(isTyping.get()).toBe(true);
         expect(mocks.showErrorModal).not.toHaveBeenCalled();
+    });
+
+    it('accepts an untagged Insights error after a correlated topic startup', async () => {
+        const topicStart = startTopic('Algebra');
+        const topicSocket = await openLatestSocket();
+        await topicStart;
+        topicSocket.receive({ event: 'session_start_accepted', requestId: 'request-topic' });
+        topicSocket.receive({
+            event: 'plan_ready',
+            requestId: 'request-topic',
+            threadId: 'thread-topic',
+            title: 'Algebra',
+        });
+
+        const insightsStart = startInsightsSession('Career options');
+        const insightsSocket = await openLatestSocket();
+        await insightsStart;
+        insightsSocket.receive({ error: 'Insufficient credits' });
+
+        expect(lastAiError.get()).toMatchObject({ code: 'Insufficient credits' });
+        expect(isLoading.get()).toBe(false);
+        expect(isTyping.get()).toBe(false);
     });
 
     it('ignores completion frames for another browser session', async () => {

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
@@ -227,6 +227,7 @@ const beginSessionStartWatchdog = () => {
         isLoading.set(false);
         isTyping.set(false);
         planStreamActive.set(false);
+        lastAiError.set({ at: Date.now(), code: 'startup_timeout' });
         showErrorModal('Something went wrong', 'Please try starting the session again.');
     }, SESSION_START_WATCHDOG_MS);
 };
@@ -792,6 +793,7 @@ export function connectWebSocket() {
             /* -------------------------------------------------- */
 
             if (data.assistantMessage) {
+                clearSessionStartWatchdog();
                 const { questions } = JSON.parse(
                     data.assistantMessage.tool_calls?.[0]?.function?.arguments
                 );
@@ -837,6 +839,7 @@ export function connectWebSocket() {
             }
 
             if (data.done) {
+                clearSessionStartWatchdog();
                 // Flush any pending streaming tokens before committing
                 if (streamRaf != null) {
                     cancelAnimationFrame(streamRaf);
@@ -889,6 +892,7 @@ export function connectWebSocket() {
             /* -------------------------------------------------- */
 
             if (typeof data === 'string') {
+                clearSessionStartWatchdog();
                 streamBuffer += data;
                 scheduleFlush();
                 isLoading.set(false);
@@ -940,11 +944,14 @@ export function connectWebSocket() {
         }
         streamingId = null;
 
-        isTyping.set(false);
-        isLoading.set(false);
         ws = null;
 
         const shouldTryReconnect = shouldReconnect && reconnectAttempts < MAX_RECONNECT_ATTEMPTS;
+
+        if (!shouldTryReconnect) {
+            isTyping.set(false);
+            isLoading.set(false);
+        }
 
         if (shouldTryReconnect) {
             reconnectAttempts++;
@@ -1302,6 +1309,8 @@ export async function startInsightsSession(topic: string, initialText?: string) 
     }
 
     const firstMessage = (initialText?.trim() || `Let's do insights on: ${topic}`).trim();
+
+    beginSessionStartWatchdog();
 
     ws!.send(
         JSON.stringify({

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
@@ -146,6 +146,8 @@ export const hasThreadEnded = (thread: Thread | undefined): boolean =>
  * plan/messages/streaming state don't bleed into the new one.
  */
 export function resetChatSessionStores() {
+    clearSessionStartWatchdog();
+    currentSessionStartRequestId = null;
     messages.set([]);
     streamingMessage.set(null);
     if (streamRaf != null) {

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
@@ -755,7 +755,11 @@ export function connectWebSocket() {
             }
 
             if (data.error) {
-                if (!isCurrentSessionStartFrame(data.requestId)) return;
+                if (
+                    typeof data.requestId === 'string' &&
+                    !isCurrentSessionStartFrame(data.requestId)
+                )
+                    return;
                 const isStartupPending = startupWatchdog !== undefined;
                 clearSessionStartWatchdog();
                 log.error('Error:', data.error);


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Fixes: LC-1968

#### 📚 What is the context and goal of this PR?

AI Insights prompt launches were setting up the chat state correctly, but the `/ai/topics` route only opened the selected chat modal on mobile. On desktop, people landed on the AI Sessions list and the exploration never started.

This opens the selected chat modal at every breakpoint and clears the route-level modal latch when it closes so another prompt can launch without a reload.

#### 🥴 TL; RL:

AI Insights prompts now open the chat on desktop instead of stopping at the sessions list.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Open short-circuited AI chats in the existing right-side modal on desktop and mobile.
- Clear the selected-chat/modal state on dismissal so the next prompt can reopen it.
- Cover desktop launch and dismiss → reopen behavior with focused regression tests.

#### 🛠 Important tradeoffs made:

I kept modal dismissal separate from the full chat reset. The chat header already owns server-side Insights shutdown and store cleanup; resetting from the modal callback would clear the thread before that shutdown can finish.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Sign in on a desktop browser and open AI Insights.
2. Enter a question or choose one of the suggested prompts.
3. Verify the app navigates to AI Sessions and immediately opens the chat with that prompt.
4. Dismiss the chat, return to AI Insights, and launch another prompt.
5. Verify the second chat opens without reloading the app.

#### 📱 🖥 Which devices would you like help testing on?

Chromium desktop is the primary regression path. A Safari desktop and mobile sanity check would also be helpful.

#### 🧪 Code Coverage

Added focused component tests for desktop launch and dismiss → reopen. OMP ran the focused Vitest file and targeted ESLint successfully. The full app build currently stops on an unrelated missing Paraglide export in `CheckListItem.tsx` (`passport.buildMyLearnCard.steps.resumeDescription`).

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

No documentation changes are needed. This restores the existing AI Insights launch flow without changing a public API or introducing a new workflow.

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

— OMP
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix AI Insights chat modal opening on desktop, support modal reopening after dismissal, and surface startup errors to users.

Main changes:
- Refactored AiSessionTopicsContainer modal lifecycle to support desktop and allow reopening after dismissal with useCallback and isModalOpen state
- Added AiInsightsErrorHandler component to display startup failures with friendly messaging in Insights mode only
- Enhanced WebSocket error handling and session startup watchdog to properly track and surface errors with improved reconnection state management

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
