### PR TITLE
fix: [LC-2066] - iOS 18 boost card header collapse

### DIFF
--- a/.changeset/boost-card-thumb-width-ios.md
+++ b/.changeset/boost-card-thumb-width-ios.md
@@ -1,0 +1,16 @@
+---
+'@learncard/react': patch
+---
+
+Fix boost/credential grid card header collapsing on iOS 18 (LC-2066)
+
+The thumbnail wrapper added in #1366 for the revoked/suspended grayscale
+treatment had no width of its own and relied on the card `<button>` stretching
+it. iOS 18 WebKit lays a bare block child of a `<button>` flex container out
+shrink-to-fit (UA `align-items: flex-start` per the HTML spec), so the badge —
+which sizes itself with `width: 100%` — collapsed to the width of its 116px
+circle: the header artwork stopped spanning the card and the options ("...")
+button appeared to push it aside instead of overlaying it. iOS 26+ and desktop
+engines compute `align-items: normal` and stretch the wrapper, which is why
+the bug only appeared on older devices. The wrapper is now explicitly
+`width: 100%` (verified by A/B on an iOS 18.1 simulator).

--- a/packages/react-learn-card/src/components/BoostGenericCard/BoostGenericCard.tsx
+++ b/packages/react-learn-card/src/components/BoostGenericCard/BoostGenericCard.tsx
@@ -104,8 +104,9 @@ export const BoostGenericCard: React.FC<BoostGenericCardProps> = ({
                     (UA align-items: flex-start per the HTML spec), so without it the
                     badge collapses to its 116px circle and the header artwork stops
                     running under the options button. iOS 26+/desktop engines compute
-                    align-items: normal and stretch, which masks the bug (LC-2066). */}
-                <div style={{ width: '100%', ...inactiveMediaStyle }}>
+                    align-items: normal and stretch, which masks the bug (LC-2066).
+                    width is spread last so nothing can ever override it. */}
+                <div style={{ ...inactiveMediaStyle, width: '100%' }}>
                     {customThumbComponent || (
                         <section className={defaultThumbClass}>
                             {thumbImgSrc?.trim() ? (

--- a/packages/react-learn-card/src/components/BoostGenericCard/BoostGenericCard.tsx
+++ b/packages/react-learn-card/src/components/BoostGenericCard/BoostGenericCard.tsx
@@ -98,8 +98,14 @@ export const BoostGenericCard: React.FC<BoostGenericCardProps> = ({
                 onClick={handleInnerClick}
             >
                 {/* Thumbnail — filter on the wrapper so it desaturates a
-                    customThumbComponent too, not just the default thumb section. */}
-                <div style={inactiveMediaStyle}>
+                    customThumbComponent too, not just the default thumb section.
+                    The explicit width is load-bearing on iOS 18 WebKit: a bare block
+                    child of a <button> flex container is laid out shrink-to-fit there
+                    (UA align-items: flex-start per the HTML spec), so without it the
+                    badge collapses to its 116px circle and the header artwork stops
+                    running under the options button. iOS 26+/desktop engines compute
+                    align-items: normal and stretch, which masks the bug (LC-2066). */}
+                <div style={{ width: '100%', ...inactiveMediaStyle }}>
                     {customThumbComponent || (
                         <section className={defaultThumbClass}>
                             {thumbImgSrc?.trim() ? (

--- a/packages/react-learn-card/src/components/BoostGenericCard/__tests__/BoostGenericCard.thumb.test.tsx
+++ b/packages/react-learn-card/src/components/BoostGenericCard/__tests__/BoostGenericCard.thumb.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { BoostGenericCard } from '../BoostGenericCard';
+
+/**
+ * LC-2066 regression guard.
+ *
+ * The thumbnail wrapper added for the revoked/suspended grayscale treatment
+ * (#1366) sits directly inside the card's `<button>`. On iOS 18 WebKit a bare
+ * block child of a <button> flex container is laid out shrink-to-fit (UA
+ * `align-items: flex-start` per the HTML spec), so the badge — which sizes
+ * itself with `width: 100%` — collapses to the width of its 116px circle and
+ * the header artwork no longer runs under the absolutely-positioned options
+ * ("...") button. iOS 26+/desktop engines compute `align-items: normal` and
+ * stretch the wrapper, which masks the bug. The wrapper must therefore carry
+ * its own explicit width. Verified by A/B on an iOS 18.1 simulator:
+ * without width the wrapper measures 116px, with it 160px.
+ */
+describe('BoostGenericCard thumbnail wrapper', () => {
+    const getThumbWrapper = (container: HTMLElement) => {
+        const badge = container.querySelector('[data-testid="thumb-child"]');
+        expect(badge).not.toBeNull();
+
+        return badge!.parentElement as HTMLElement;
+    };
+
+    test('gives the custom thumbnail wrapper an explicit full width', () => {
+        const { container } = render(
+            <BoostGenericCard
+                title="Camp Counselor"
+                customThumbComponent={<div data-testid="thumb-child" style={{ width: '100%' }} />}
+                optionsTriggerOnClick={() => {}}
+            />
+        );
+
+        expect(getThumbWrapper(container).style.width).toBe('100%');
+    });
+
+    test('keeps the explicit width when the credential is revoked', () => {
+        const { container } = render(
+            <BoostGenericCard
+                title="Camp Counselor"
+                customThumbComponent={<div data-testid="thumb-child" style={{ width: '100%' }} />}
+                optionsTriggerOnClick={() => {}}
+                lifecycleStatus="revoked"
+            />
+        );
+
+        const wrapper = getThumbWrapper(container);
+
+        expect(wrapper.style.width).toBe('100%');
+        // The grayscale treatment must survive alongside the width.
+        expect(wrapper.style.filter).toContain('grayscale');
+    });
+});


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Fixes: [LC-2066](https://welibrary.atlassian.net/browse/LC-2066)

#### 📚 What is the context and goal of this PR?


Fix regression on ios18 with boost earned card view:
<img width="828" height="1792" alt="IMG_2643" src="https://github.com/user-attachments/assets/58591629-9306-4368-851c-adc23fa497fe" />




Fixed:

<img width="439" height="971" alt="Screenshot 2026-08-03 at 12 45 47 PM" src="https://github.com/user-attachments/assets/ab780fce-97e0-42db-8c34-c2895a6e3f47" />

<img width="472" height="960" alt="Screenshot 2026-08-03 at 12 45 39 PM" src="https://github.com/user-attachments/assets/1e1bcfd6-2a01-44d0-8371-4c14cfb0332c" />




https://www.loom.com/share/f6fcc79706bb41f3a00da6abb5851e49


<img width="386" height="733" alt="Screenshot 2026-08-01 at 5 25 52 AM" src="https://github.com/user-attachments/assets/0b564e51-5970-4b86-bd8e-31d194412cd2" />



Native build 20.0.62 regressed the boost/credential grid cards on **iOS 18 devices**: the badge header collapses to ~116px instead of spanning the 160px card, so the options ("…") button appears to push the badge aside instead of overlaying it. Desktop, iOS 26, and every current simulator render fine, which made this painful to triage.

Root cause: #1366 wrapped the card thumbnail in a bare `<div style={inactiveMediaStyle}>` (for the revoked/suspended grayscale treatment) sitting directly inside the card's `<button>` flex container. Before that change, the button's direct child was `CredentialBadgeNew`'s root, which carries `w-full`. iOS 18 WebKit lays a bare block child of a `<button>` out **shrink-to-fit** (UA `align-items: flex-start` per the HTML spec), so the wrapper collapses to the badge circle's `!w-[116px]`. iOS 26+ and desktop engines compute `align-items: normal` and stretch, masking the bug.

#### 🥴 TL; RL:

One-line fix: give the thumbnail wrapper an explicit `width: 100%`, restoring the pre-#1366 invariant. A/B verified on an iOS 18.1 simulator — bare wrapper = 116px (broken, pixel-identical to the bug screenshots), `width: 100%` = 160px (correct). iOS 26.4 renders both variants identically, confirming why the bug was invisible everywhere else.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

| Variant | iOS 18.1 | iOS 26.4 |
| --- | --- | --- |
| bare wrapper (before) | **116px — header collapsed** | 160px (masked) |
| `width: 100%` (after) | **160px — correct** | 160px |

#### 🛠 Important tradeoffs made:

- Inline style rather than a `w-full` class, matching the existing convention in this file: the consumer app's Tailwind does not scan `packages/react-learn-card/src`, so utility classes here have no backing rule.
- The width is spread *after* `inactiveMediaStyle` so nothing can ever override it — the width is the load-bearing invariant. (`mediaStyle` only carries `filter` today, so this is defensive, not behavioral.)

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. On an **iOS 18 device** (or simulator: `xcrun simctl list runtimes` → create a device on an iOS 18.x runtime — an iOS 26 simulator will NOT reproduce the before-state), open the app on this branch.
2. Go to any category page (e.g. Experiences/Portfolio) → **Earned** tab → card (grid) view.
3. Verify the badge artwork spans the full card width and the "…" button overlays the header's top-right corner.
4. Verify a revoked/suspended credential still renders grayscale with the status pill (the wrapper also carries that treatment).
5. Sanity-check the same screens on iOS 26 / desktop — no visual change expected there.

⚠️ QA note: `navigator.userAgent` reports `OS 18_7` even on iOS 26 (Safari freezes the UA's OS token) — do not use the UA string to confirm which runtime you're on.

#### 📱 🖥 Which devices would you like help testing on?

iOS Native (**iOS 18.x specifically**) — that's the only environment where the bug manifests. iOS 26 native + desktop browsers as no-change controls.

#### 🧪 Code Coverage

Added `BoostGenericCard.thumb.test.tsx` — regression guard asserting the thumbnail wrapper carries an explicit `width: 100%` in both active and revoked states (jsdom can't reproduce the iOS 18 layout itself, so the test pins the invariant that prevents it). Full `@learncard/react` suite: 22 files / 92 tests passing.

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [x] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

One-property rendering fix; no API or flow changes. The non-obvious constraint (why the width is load-bearing on iOS 18 WebKit) is documented in a comment at the fix site and in the regression test header. Full investigation log lives in [LC-2066](https://welibrary.atlassian.net/browse/LC-2066).

# ✅ PR Checklist

-   [x] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LC-2066]: https://welibrary.atlassian.net/browse/LC-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2066]: https://welibrary.atlassian.net/browse/LC-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix iOS 18 WebKit flex layout bug causing boost card thumbnail wrapper to collapse, preventing header artwork from spanning correctly.

Main changes:
- Added explicit `width: 100%` to thumbnail wrapper div to prevent shrink-to-fit layout on iOS 18 WebKit
- Added regression test verifying thumbnail wrapper width persists with and without grayscale filter
- Updated inline comment documenting iOS spec difference (align-items: flex-start vs normal) causing layout variance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
