### PR TITLE
fix: OpenAPI base URL

### DIFF
--- a/.changeset/huge-ducks-punch.md
+++ b/.changeset/huge-ducks-punch.md
@@ -1,0 +1,8 @@
+---
+"@learncard/network-brain-service": patch
+"@learncard/lca-api-service": patch
+"@learncard/learn-cloud-service": patch
+"@learncard/simple-signing-service": patch
+---
+
+fix: OpenAPI base URL

--- a/services/learn-card-network/brain-service/src/openapi.ts
+++ b/services/learn-card-network/brain-service/src/openapi.ts
@@ -8,7 +8,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
     title: 'LearnCloud Network API',
     description: 'API for interacting with LearnCloud Network',
     version: '1.0.0',
-    baseUrl: '../api',
+    baseUrl: '/api',
     docsUrl: 'https://docs.learncard.com',
     tags: [
         'Profiles',

--- a/services/learn-card-network/brain-service/test/openapi.spec.ts
+++ b/services/learn-card-network/brain-service/test/openapi.spec.ts
@@ -14,4 +14,8 @@ describe('OpenAPI generation', () => {
 
         expect(paths).toContain('/boost/skills/search');
     });
+
+    it('exposes a root-relative server URL that resolves on any tenant domain', () => {
+        expect(openApiDocument.servers?.[0]?.url).toBe('/api');
+    });
 });

--- a/services/learn-card-network/lca-api/src/openapi.ts
+++ b/services/learn-card-network/lca-api/src/openapi.ts
@@ -8,7 +8,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
     title: 'LearnCard App API',
     description: 'This is the API for interacting with a LearnCard App API',
     version: '1.0.0',
-    baseUrl: '../api',
+    baseUrl: '/api',
     docsUrl: 'https://docs.learncard.com',
     tags: ['Notifications', 'AI', 'Utilities', 'Signing Authority', 'Credentials'],
 });

--- a/services/learn-card-network/learn-cloud-service/src/openapi.ts
+++ b/services/learn-card-network/learn-cloud-service/src/openapi.ts
@@ -8,7 +8,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
     title: 'LearnCloud Storage API',
     description: 'API for interacting with LearnCloud Storage',
     version: '1.0.0',
-    baseUrl: '../api',
+    baseUrl: '/api',
     docsUrl: 'https://docs.learncard.com',
     tags: ['Storage', 'Index', 'User', 'Custom Storage', 'Utilities'],
 });

--- a/services/learn-card-network/learn-cloud-service/test/openapi.spec.ts
+++ b/services/learn-card-network/learn-cloud-service/test/openapi.spec.ts
@@ -17,4 +17,8 @@ describe('OpenAPI generation', () => {
         expect(paths).toContain('/custom-storage/update');
         expect(paths).toContain('/custom-storage/delete');
     });
+
+    it('exposes a root-relative server URL that resolves on any tenant domain', () => {
+        expect(openApiDocument.servers?.[0]?.url).toBe('/api');
+    });
 });

--- a/services/learn-card-network/simple-signing-service/src/openapi.ts
+++ b/services/learn-card-network/simple-signing-service/src/openapi.ts
@@ -8,7 +8,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
     title: 'LearnCard App API',
     description: 'This is the API for interacting with a LearnCard App API',
     version: '1.0.0',
-    baseUrl: '../api',
+    baseUrl: '/api',
     docsUrl: 'https://docs.learncard.com',
     tags: ['Notifications', 'AI', 'Utilities', 'Signing Authority', 'Credentials'],
 });


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Our Scouts partners reported that the copy-paste curl samples in our API docs don't work. The docs were showing:

```
curl https://staging.scoutnetwork.org/../api/profile/create
```

That `/../` makes the request fail. It should be:

```
curl https://staging.scoutnetwork.org/api/profile/create
```

The cause is the `baseUrl` we hand to `generateOpenApiDocument`. It was set to the relative path `'../api'`, which gets written into the OpenAPI document's `servers[0].url` verbatim. The docs UI (Scalar) doesn't resolve `..` the way a browser would — it just pastes the value into the URL, so the `..` leaks through into every code sample.

Changing it to `'/api'` fixes it. All four network services had the same literal copy-pasted, so all four are fixed here.

#### 🥴 TL; RL:

`baseUrl: '../api'` → `baseUrl: '/api'` in four `openapi.ts` files, plus a one-line test guarding it. Fixes broken curl samples in the API docs.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

The fix, one line each:

- `services/learn-card-network/brain-service/src/openapi.ts`
- `services/learn-card-network/lca-api/src/openapi.ts`
- `services/learn-card-network/learn-cloud-service/src/openapi.ts`
- `services/learn-card-network/simple-signing-service/src/openapi.ts`

A regression guard added to the two services that already have an `openapi.spec.ts`, plus a changeset patching all four.

`/api` is the right value because in every one of these services the docs page and the API sit side by side at the root of the host — `basePath: '/api'` plus a `GET /docs` route in `docker-entry.ts`, matching `ANY /api/{trpc+}` and `GET /docs` in `serverless.yml`. A root-relative path resolves correctly against whatever domain is serving the docs, so this works for `staging.scoutnetwork.org`, `network.learncard.com`, and localhost with no per-tenant config.

#### 🛠 Important tradeoffs made:

Root-relative means we're assuming these services stay mounted at the root of their host. If one ever ends up behind a path prefix (say a load balancer routing `/brain/*`), `/api` would point at the wrong place. Building an absolute URL from the incoming request host would survive that, but it's more moving parts than this bug warrants, and nothing is deployed that way today.

Worth knowing: **the OpenAPI document is built once at module load**, so staging keeps serving the old value until these services are redeployed.

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

Fastest check is the test:

```bash
cd services/learn-card-network/learn-cloud-service && bun run test -- run test/openapi.spec.ts
```

To see the actual docs page, bring the services up from `apps/learn-card-app`:

```bash
bun run dev:services
```

Then for each service — brain on `4000`, learn-cloud on `4100`, lca-api on `5100`:

1. Check the generated document:

    ```bash
    curl -s http://localhost:4000/docs/openapi.json | jq '.servers'
    ```

    Expect `[{ "url": "/api" }]`. On `main` this is `"../api"`.

2. Open `http://localhost:4000/docs`, pick any endpoint, and look at the Shell Curl sample. The URL should read `http://localhost:4000/api/...` with no `/../` in it.

3. Run that curl. It should reach the endpoint (a 401 without a token is fine — the point is that it routes).

After this deploys to staging, the original report can be confirmed with:

```bash
curl -s https://staging.scoutnetwork.org/docs/openapi.json | jq '.servers'
```

#### 📱 🖥 Which devices would you like help testing on?

Any browser — it's the docs page.

#### 🧪 Code Coverage

`brain-service` and `learn-cloud-service` already have an `openapi.spec.ts` that asserts on the generated document, so the guard is one line added to each:

```ts
it('exposes a root-relative server URL that resolves on any tenant domain', () => {
    expect(openApiDocument.servers?.[0]?.url).toBe('/api');
});
```

I checked it actually catches the regression rather than just passing — putting `'../api'` back fails with `expected '../api' to be '/api'`, and both files pass with the fix in place.

`lca-api` and `simple-signing-service` have no `openapi.spec.ts` at all, so they're fixed but unguarded. Happy to add the files if reviewers want the symmetry; it seemed like more scope than this fix needed.

I also verified by hand against the real generator, since the open question was whether a root-relative value would be accepted at all:

| `baseUrl` | `servers[0].url` | Naive concat | Spec-correct resolve |
| --- | --- | --- | --- |
| `../api` | `../api` | `...org../api/profile/create` ❌ | `...org/api/profile/create` ✅ |
| `/api` | `/api` | `...org/api/profile/create` ✅ | `...org/api/profile/create` ✅ |

Two takeaways: the generator passes the value straight through without validating or rewriting it, so `/api` is safe; and `/api` lands correctly whether a client naively concatenates or properly resolves the URL. `../api` only worked under the second, which is exactly why the docs UI got it wrong.

# Documentation

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

No docs changes needed. No endpoints, params, or behaviour changed — the docs were advertising the wrong base URL for endpoints that already worked. I checked `docs/` for the bad URL and it doesn't appear there, so nothing downstream to correct.

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication
