### PR TITLE
fix: unblock Android CI by patching in-app-review's proguard file

### DIFF
--- a/apps/learn-card-app/android/app/capacitor.build.gradle
+++ b/apps/learn-card-app/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-in-app-review')
     implementation project(':capacitor-community-media')
     implementation project(':capacitor-community-sqlite')
     implementation project(':capacitor-firebase-analytics')

--- a/apps/learn-card-app/android/app/src/main/assets/capacitor.plugins.json
+++ b/apps/learn-card-app/android/app/src/main/assets/capacitor.plugins.json
@@ -1,5 +1,9 @@
 [
 	{
+		"pkg": "@capacitor-community/in-app-review",
+		"classpath": "com.getcapacitor.community.inappreview.InAppReviewPlugin"
+	},
+	{
 		"pkg": "@capacitor-community/media",
 		"classpath": "com.getcapacitor.community.media.MediaPlugin"
 	},

--- a/apps/learn-card-app/android/capacitor.settings.gradle
+++ b/apps/learn-card-app/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-in-app-review'
+project(':capacitor-community-in-app-review').projectDir = new File('../../../node_modules/@capacitor-community/in-app-review/android')
+
 include ':capacitor-community-media'
 project(':capacitor-community-media').projectDir = new File('../../../node_modules/@capacitor-community/media/android')
 

--- a/bun.lock
+++ b/bun.lock
@@ -2181,6 +2181,7 @@
   },
   "patchedDependencies": {
     "libsodium-wrappers@0.7.16": "patches/libsodium-wrappers@0.7.16.patch",
+    "@capacitor-community/in-app-review@8.0.0": "patches/@capacitor-community%2Fin-app-review@8.0.0.patch",
     "capacitor-plugin-safe-area@5.0.0": "patches/capacitor-plugin-safe-area@5.0.0.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     },
     "patchedDependencies": {
         "capacitor-plugin-safe-area@5.0.0": "patches/capacitor-plugin-safe-area@5.0.0.patch",
-        "libsodium-wrappers@0.7.16": "patches/libsodium-wrappers@0.7.16.patch"
+        "libsodium-wrappers@0.7.16": "patches/libsodium-wrappers@0.7.16.patch",
+        "@capacitor-community/in-app-review@8.0.0": "patches/@capacitor-community%2Fin-app-review@8.0.0.patch"
     }
 }

--- a/patches/@capacitor-community%2Fin-app-review@8.0.0.patch
+++ b/patches/@capacitor-community%2Fin-app-review@8.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 5858af7ea3646759657733f3f76d8de54b2d6d71..7e90472e56a41a191106883672862e414fe75f72 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -31,7 +31,7 @@ android {
+     buildTypes {
+         release {
+             minifyEnabled false
+-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
++            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+         }
+     }
+     lintOptions {


### PR DESCRIPTION
## Problem

The **Android** leg of `fastlane-upload-to-appetize` (and `fastlane-deploy-native-apps`) has failed on **every run since Aug 4**. iOS is unaffected. Gradle dies at *configuration* time, before compiling anything:

```
* What went wrong:
A problem occurred evaluating project ':capacitor-community-in-app-review'.
> `getDefaultProguardFile('proguard-android.txt')` is no longer supported since it
  includes `-dontoptimize`, which prevents R8 from performing many optimizations.
  Instead use `getDefaultProguardFile('proguard-android-optimize.txt')`...
```

## Root cause — a two-PR collision

1. **#1434** (LC-1973, Jul 29) bumped AGP `8.13.2 → 9.3.0`. AGP 9.x turns `getDefaultProguardFile('proguard-android.txt')` from a warning into a hard error. That PR already had to patch `capacitor-plugin-safe-area` for this exact reason — see `patches/capacitor-plugin-safe-area@5.0.0.patch`. Nothing else in the tree used it, so builds stayed green.
2. **#1442** (LC-2064 App Review Prompt, Aug 4) added `@capacitor-community/in-app-review@8.0.0`, whose `android/build.gradle:34` still references `proguard-android.txt`. `cap sync` pulls it in as a subproject → AGP 9.3.0 rejects it.

Last green run: [30846999061](https://github.com/learningeconomy/LearnCard/actions/runs/30846999061) (Aug 3). First red: [30944186957](https://github.com/learningeconomy/LearnCard/actions/runs/30944186957) — the #1442 merge itself.

`8.0.0` is the latest published version; there is no upstream release with this fixed.

## Fix

`bun patch` the plugin to use `proguard-android-optimize.txt`, mirroring the existing safe-area patch.

Also commits the capacitor sync output that #1442 left stale — the plugin was missing from `capacitor.settings.gradle`, `capacitor.build.gradle`, and `capacitor.plugins.json` (CI regenerates these, which is why the breakage only showed up there and not in the committed tree).

## Verification

Ran locally against the same toolchain CI uses (JDK 21, AGP 9.3.0, Gradle 9.5.0, compileSdk 36):

- **Negative control** — reverted the patch in `node_modules`, ran `./gradlew :app:tasks` → reproduced the CI error verbatim, `BUILD FAILED in 45s`.
- **Patch applies from a clean install** — `rm -rf` the plugin + `bun install` → `proguard-android-optimize.txt` present, so CI picks it up automatically.
- **Positive test** — `./gradlew assembleRelease` → **`BUILD SUCCESSFUL in 2m 52s`**, 1150 tasks, produced `app-release-unsigned.apk` (53.8 MB).

One caveat: the local `assembleRelease` used a stub `webDir` (the real `bun run build` needs the workspace packages built first). Web assets have no bearing on the Gradle configuration failure this fixes, but the definitive check is CI going green on this branch.

Draft until CI confirms.