### PR TITLE
fix: [LC-2078] - 🐞 Fix toast status icons and text overflow

### DIFF
--- a/.changeset/shaky-ravens-bet.md
+++ b/.changeset/shaky-ravens-bet.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: [LC-2078] - 🐞 Fix toast status icons and text overflow

--- a/apps/learn-card-app/src/hooks/useUploadFile.test.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.test.tsx
@@ -67,7 +67,7 @@ vi.mock('./useUploadVcFromText', () => ({
 
 import { createRawArtifactVC, getFileInfo, useUploadFile } from './useUploadFile';
 import { addCertificateAttachment } from './certificateAttachment';
-import { UploadTypesEnum } from 'learn-card-base';
+import { ToastTypeEnum, UploadTypesEnum } from 'learn-card-base';
 
 const createChangeEvent = (files: File[]): React.ChangeEvent<HTMLInputElement> =>
     ({ target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>);
@@ -146,6 +146,63 @@ describe('useUploadFile certificate uploads', () => {
         expect(credential.rawArtifact.data).toBe('data:application/pdf;base64,Y2VydGlmaWNhdGU=');
         expect(credential.rawArtifact).not.toHaveProperty('url');
         expect(JSON.stringify(credential['@context'])).not.toContain('rawArtifactUrl');
+    });
+});
+
+describe('useUploadFile toast options', () => {
+    beforeEach(() => {
+        initWalletMock.mockReset();
+        logErrorMock.mockReset();
+        presentToastMock.mockReset();
+        refetchQueriesMock.mockReset();
+        initWalletMock.mockResolvedValue({
+            id: { did: () => 'did:key:test' },
+            invoke: { issueCredential: vi.fn().mockResolvedValue({}) },
+            store: {
+                LearnCloud: { uploadEncrypted: vi.fn().mockResolvedValue('credential-uri') },
+            },
+            index: {
+                LearnCloud: {
+                    get: vi.fn().mockResolvedValue([]),
+                    add: vi.fn().mockResolvedValue(undefined),
+                },
+            },
+        });
+    });
+
+    it('keeps the no-credentials error visible until it is dismissed', async () => {
+        vi.useFakeTimers();
+
+        try {
+            const { result } = renderHook(() => useUploadFile(UploadTypesEnum.Resume));
+            const rawArtifactCredential = {
+                rawArtifact: { fileName: 'Katie_Kempton_Resume.pdf' },
+            };
+
+            await act(async () => {
+                await result.current.storeSelectedCredentials(
+                    [],
+                    rawArtifactCredential,
+                    UploadTypesEnum.Resume
+                );
+                vi.advanceTimersByTime(100);
+            });
+
+            expect(presentToastMock).toHaveBeenCalledWith(
+                'No credentials could be extracted from this file.',
+                {
+                    title: 'Resume "Katie_Kempton_Resume.pdf" saved',
+                    hasDismissButton: true,
+                    type: ToastTypeEnum.Error,
+                    hasX: true,
+                    duration: 5000,
+                    autoDismiss: false,
+                }
+            );
+        } finally {
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
     });
 });
 

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -597,7 +597,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         }.`,
                         {
                             title: `${typeLabel} ${fileList} saved`,
-                            ...SUCCESS_TOAST_OPTIONS,
+                            ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
                         }
                     );
                 } else {
@@ -688,7 +688,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                 if (totalCredentials === 0) {
                     presentToast(`No credentials could be extracted from this file.`, {
                         title: `${typeLabel} ${fileList} saved`,
-                        ...SUCCESS_TOAST_OPTIONS,
+                        ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
                     });
                 } else {
                     presentToast(`Successfully added to ${categoryList}.`, {
@@ -834,7 +834,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         }.`,
                         {
                             title: `${typeLabel} ${fileList} saved`,
-                            ...SUCCESS_TOAST_OPTIONS,
+                            ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
                         }
                     );
                 } else {

--- a/apps/learn-card-app/src/hooks/useUploadFile.tsx
+++ b/apps/learn-card-app/src/hooks/useUploadFile.tsx
@@ -598,6 +598,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         {
                             title: `${typeLabel} ${fileList} saved`,
                             ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
+                            autoDismiss: false,
                         }
                     );
                 } else {
@@ -689,6 +690,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                     presentToast(`No credentials could be extracted from this file.`, {
                         title: `${typeLabel} ${fileList} saved`,
                         ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
+                        autoDismiss: false,
                     });
                 } else {
                     presentToast(`Successfully added to ${categoryList}.`, {
@@ -835,6 +837,7 @@ export const useUploadFile = (uploadType: UploadTypesEnum) => {
                         {
                             title: `${typeLabel} ${fileList} saved`,
                             ...FILE_UPLOAD_ERROR_TOAST_OPTIONS,
+                            autoDismiss: false,
                         }
                     );
                 } else {

--- a/packages/learn-card-base/src/components/toast/Toast.test.tsx
+++ b/packages/learn-card-base/src/components/toast/Toast.test.tsx
@@ -20,12 +20,17 @@ describe('Toast', () => {
         const longMessage =
             'No credentials could be extracted from this file because its contents were not recognized.';
 
-        toastStore.set.presentToast(longMessage, {
-            title: longTitle,
-            type: ToastTypeEnum.Error,
-            hasCheckmark: true,
-            hasX: true,
-            autoDismiss: false,
+        // Bypass the public actions to verify the render-level guard against malformed shared state.
+        toastStore.set.state(state => {
+            state.message = longMessage;
+            state.options = {
+                ...state.options,
+                title: longTitle,
+                type: ToastTypeEnum.Error,
+                hasCheckmark: true,
+                hasX: true,
+                autoDismiss: false,
+            };
         });
 
         render(<Toast />);
@@ -35,6 +40,8 @@ describe('Toast', () => {
 
         expect(screen.getByTestId('toast-error-icon')).toBeTruthy();
         expect(screen.queryByTestId('toast-success-icon')).toBeNull();
+
+        // jsdom cannot measure overflow; these classes are proxies for the required layout behavior.
         expect(title.className).toContain('[overflow-wrap:anywhere]');
         expect(message.className).toContain('[overflow-wrap:anywhere]');
         expect(message.parentElement?.className).toContain('min-w-0');

--- a/packages/learn-card-base/src/components/toast/Toast.test.tsx
+++ b/packages/learn-card-base/src/components/toast/Toast.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { toastStore, ToastTypeEnum } from '../../stores/toastStore';
+import { Toast } from './Toast';
+
+describe('Toast', () => {
+    afterEach(() => {
+        cleanup();
+        toastStore.set.dismissToast();
+    });
+
+    it('shows one status icon and wraps long content inside the toast', () => {
+        const longTitle =
+            'Resume "Katie_Kempton_Resume_GPA_4.0_with_an_uninterrupted_filename.pdf" saved';
+        const longMessage =
+            'No credentials could be extracted from this file because its contents were not recognized.';
+
+        toastStore.set.presentToast(longMessage, {
+            title: longTitle,
+            type: ToastTypeEnum.Error,
+            hasCheckmark: true,
+            hasX: true,
+            autoDismiss: false,
+        });
+
+        render(<Toast />);
+
+        const title = screen.getByText(longTitle);
+        const message = screen.getByText(longMessage);
+
+        expect(screen.getByTestId('toast-error-icon')).toBeTruthy();
+        expect(screen.queryByTestId('toast-success-icon')).toBeNull();
+        expect(title.className).toContain('[overflow-wrap:anywhere]');
+        expect(message.className).toContain('[overflow-wrap:anywhere]');
+        expect(message.parentElement?.className).toContain('min-w-0');
+    });
+});

--- a/packages/learn-card-base/src/components/toast/Toast.tsx
+++ b/packages/learn-card-base/src/components/toast/Toast.tsx
@@ -19,7 +19,7 @@ export const Toast = () => {
 
         const timer = setTimeout(() => {
             dismissToast();
-        }, options.duration ?? 3000);
+        }, options.duration);
 
         return () => clearTimeout(timer);
     }, [message, options.duration, options.autoDismiss]);
@@ -28,10 +28,10 @@ export const Toast = () => {
 
     const isError = options.type === ToastTypeEnum.Error;
     const toastTextColor = isError ? 'text-white' : 'text-grayscale-900';
-    const showX = Boolean(options.hasX && (!options.hasCheckmark || isError));
+    const showX = Boolean(options.hasX);
     const showCheckmark = Boolean(options.hasCheckmark && !showX);
 
-    const zIndex = options.zIndex ?? 999999;
+    const zIndex = options.zIndex;
 
     return (
         <AnimatePresence>

--- a/packages/learn-card-base/src/components/toast/Toast.tsx
+++ b/packages/learn-card-base/src/components/toast/Toast.tsx
@@ -28,6 +28,8 @@ export const Toast = () => {
 
     const isError = options.type === ToastTypeEnum.Error;
     const toastTextColor = isError ? 'text-white' : 'text-grayscale-900';
+    const showX = Boolean(options.hasX && (!options.hasCheckmark || isError));
+    const showCheckmark = Boolean(options.hasCheckmark && !showX);
 
     const zIndex = options.zIndex ?? 999999;
 
@@ -80,28 +82,36 @@ export const Toast = () => {
                                 >
                                     <X className="text-grayscale-900 h-[15px] w-[15px] min-w-[15px] min-h-[15px]" />
                                 </button>
-                                <div className="flex items-center justify-between min-h-[40px]">
-                                    <div className="flex items-center justify-start">
-                                        {options.hasCheckmark && (
-                                            <div className="flex items-center justify-center rounded-full bg-emerald-700 p-1 mr-4">
+                                <div className="flex min-w-0 items-center justify-between gap-3 min-h-[40px]">
+                                    <div className="flex min-w-0 flex-1 items-center justify-start">
+                                        {showCheckmark && (
+                                            <div
+                                                data-testid="toast-success-icon"
+                                                className="flex shrink-0 items-center justify-center rounded-full bg-emerald-700 p-1 mr-4"
+                                            >
                                                 <Checkmark className="text-white h-[25px] w-[25px]" />
                                             </div>
                                         )}
-                                        {options.hasX && (
-                                            <div className="flex items-center justify-center rounded-full bg-red-700 p-1 mr-4">
+                                        {showX && (
+                                            <div
+                                                data-testid="toast-error-icon"
+                                                className="flex shrink-0 items-center justify-center rounded-full bg-red-700 p-1 mr-4"
+                                            >
                                                 <X className="text-white h-[25px] w-[25px]" />
                                             </div>
                                         )}
-                                        <div className="flex flex-col">
+                                        <div className="flex min-w-0 flex-1 flex-col">
                                             {options.title && (
                                                 <h4
-                                                    className={`text-sm font-semibold text-left ${toastTextColor}`}
+                                                    className={`text-sm font-semibold text-left whitespace-normal break-words [overflow-wrap:anywhere] ${toastTextColor}`}
                                                 >
                                                     {options.title}
                                                 </h4>
                                             )}
 
-                                            <p className={`text-sm text-left ${toastTextColor}`}>
+                                            <p
+                                                className={`text-sm text-left whitespace-normal break-words [overflow-wrap:anywhere] ${toastTextColor}`}
+                                            >
                                                 {message}
                                             </p>
                                         </div>
@@ -111,7 +121,7 @@ export const Toast = () => {
                                         <button
                                             type="button"
                                             onClick={dismissToast}
-                                            className="border border-grayscale-200 border-solid p-3 rounded-full h-[45px] w-[45px] hidden items-center justify-center bg-white phone:flex"
+                                            className="shrink-0 border border-grayscale-200 border-solid p-3 rounded-full h-[45px] w-[45px] hidden items-center justify-center bg-white phone:flex"
                                         >
                                             <X className="text-grayscale-900 h-[20px] w-[20px]" />
                                         </button>

--- a/packages/learn-card-base/src/hooks/useToast.tsx
+++ b/packages/learn-card-base/src/hooks/useToast.tsx
@@ -1,9 +1,6 @@
-import { toastStore } from 'learn-card-base/stores/toastStore';
+import { toastStore } from '../stores/toastStore';
 
-export enum ToastTypeEnum {
-    Success = 'success',
-    Error = 'error',
-}
+export { ToastTypeEnum } from '../stores/toastStore';
 
 export const useToast = () => {
     const presentToast = toastStore.set.presentToast;

--- a/packages/learn-card-base/src/stores/toastStore.test.ts
+++ b/packages/learn-card-base/src/stores/toastStore.test.ts
@@ -7,6 +7,10 @@ describe('toastStore', () => {
         toastStore.set.dismissToast();
     });
 
+    it('keeps the fully specified defaults immutable', () => {
+        expect(Object.isFrozen(DEFAULT_TOAST_OPTIONS)).toBe(true);
+    });
+
     it('does not carry options from one toast into the next', () => {
         toastStore.set.presentToast('Saved', {
             type: ToastTypeEnum.Success,
@@ -43,6 +47,20 @@ describe('toastStore', () => {
             hasCheckmark: true,
             hasX: true,
         });
+
+        expect(toastStore.get.options()).toMatchObject({
+            hasCheckmark: true,
+            hasX: false,
+        });
+    });
+
+    it('lets a partial icon update replace the current status icon', () => {
+        toastStore.set.presentToast('Failed', {
+            type: ToastTypeEnum.Error,
+            hasX: true,
+        });
+
+        toastStore.set.setOptions({ hasCheckmark: true });
 
         expect(toastStore.get.options()).toMatchObject({
             hasCheckmark: true,

--- a/packages/learn-card-base/src/stores/toastStore.test.ts
+++ b/packages/learn-card-base/src/stores/toastStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_TOAST_OPTIONS, toastStore, ToastTypeEnum } from './toastStore';
+
+describe('toastStore', () => {
+    beforeEach(() => {
+        toastStore.set.dismissToast();
+    });
+
+    it('does not carry options from one toast into the next', () => {
+        toastStore.set.presentToast('Saved', {
+            type: ToastTypeEnum.Success,
+            hasCheckmark: true,
+            autoDismiss: false,
+        });
+
+        toastStore.set.presentToast('Failed', {
+            type: ToastTypeEnum.Error,
+            hasX: true,
+        });
+
+        expect(toastStore.get.options()).toEqual({
+            ...DEFAULT_TOAST_OPTIONS,
+            type: ToastTypeEnum.Error,
+            hasX: true,
+        });
+    });
+
+    it('keeps status icons mutually exclusive', () => {
+        toastStore.set.presentToast('Failed', {
+            type: ToastTypeEnum.Error,
+            hasCheckmark: true,
+            hasX: true,
+        });
+
+        expect(toastStore.get.options()).toMatchObject({
+            hasCheckmark: false,
+            hasX: true,
+        });
+
+        toastStore.set.presentToast('Saved', {
+            type: ToastTypeEnum.Success,
+            hasCheckmark: true,
+            hasX: true,
+        });
+
+        expect(toastStore.get.options()).toMatchObject({
+            hasCheckmark: true,
+            hasX: false,
+        });
+    });
+});

--- a/packages/learn-card-base/src/stores/toastStore.tsx
+++ b/packages/learn-card-base/src/stores/toastStore.tsx
@@ -8,7 +8,7 @@ export enum ToastTypeEnum {
 
 export type Toast = {
     message: string | ReactNode;
-    options: ToastOptions;
+    options: ResolvedToastOptions;
 };
 
 export type ToastOptions = {
@@ -23,7 +23,9 @@ export type ToastOptions = {
     zIndex?: number;
 };
 
-export const DEFAULT_TOAST_OPTIONS: ToastOptions = {
+export type ResolvedToastOptions = Required<ToastOptions>;
+
+export const DEFAULT_TOAST_OPTIONS: Readonly<ResolvedToastOptions> = Object.freeze({
     title: '',
     className: '',
     duration: 3000,
@@ -33,10 +35,10 @@ export const DEFAULT_TOAST_OPTIONS: ToastOptions = {
     hasCheckmark: false,
     hasX: false,
     zIndex: 999999,
-};
+} satisfies ResolvedToastOptions);
 
-const normalizeToastOptions = (options: ToastOptions = {}): ToastOptions => {
-    const nextOptions = { ...DEFAULT_TOAST_OPTIONS, ...options };
+const normalizeToastOptions = (options: ToastOptions = {}): ResolvedToastOptions => {
+    const nextOptions: ResolvedToastOptions = { ...DEFAULT_TOAST_OPTIONS, ...options };
 
     if (nextOptions.hasCheckmark && nextOptions.hasX) {
         if (nextOptions.type === ToastTypeEnum.Error) {
@@ -49,6 +51,18 @@ const normalizeToastOptions = (options: ToastOptions = {}): ToastOptions => {
     return nextOptions;
 };
 
+const mergeToastOptions = (
+    currentOptions: ResolvedToastOptions,
+    options: ToastOptions
+): ResolvedToastOptions => {
+    const nextOptions: ToastOptions = { ...currentOptions, ...options };
+
+    if (options.hasCheckmark && options.hasX === undefined) nextOptions.hasX = false;
+    if (options.hasX && options.hasCheckmark === undefined) nextOptions.hasCheckmark = false;
+
+    return normalizeToastOptions(nextOptions);
+};
+
 export const toastStore = createStore('toastStore')(
     {
         message: '' as string | ReactNode,
@@ -59,13 +73,14 @@ export const toastStore = createStore('toastStore')(
     presentToast: (message: string | ReactNode, options?: ToastOptions) => {
         set.state(state => {
             state.message = message;
+            // A new toast must not inherit options customized for the previously active toast.
             state.options = normalizeToastOptions(options);
         });
     },
 
     setOptions: (options: ToastOptions) => {
         set.state(state => {
-            state.options = normalizeToastOptions({ ...state.options, ...options });
+            state.options = mergeToastOptions(state.options, options);
         });
     },
 

--- a/packages/learn-card-base/src/stores/toastStore.tsx
+++ b/packages/learn-card-base/src/stores/toastStore.tsx
@@ -23,57 +23,56 @@ export type ToastOptions = {
     zIndex?: number;
 };
 
+export const DEFAULT_TOAST_OPTIONS: ToastOptions = {
+    title: '',
+    className: '',
+    duration: 3000,
+    autoDismiss: true,
+    type: ToastTypeEnum.Success,
+    hasDismissButton: false,
+    hasCheckmark: false,
+    hasX: false,
+    zIndex: 999999,
+};
+
+const normalizeToastOptions = (options: ToastOptions = {}): ToastOptions => {
+    const nextOptions = { ...DEFAULT_TOAST_OPTIONS, ...options };
+
+    if (nextOptions.hasCheckmark && nextOptions.hasX) {
+        if (nextOptions.type === ToastTypeEnum.Error) {
+            nextOptions.hasCheckmark = false;
+        } else {
+            nextOptions.hasX = false;
+        }
+    }
+
+    return nextOptions;
+};
+
 export const toastStore = createStore('toastStore')(
     {
         message: '' as string | ReactNode,
-        options: {
-            title: '',
-            className: '',
-            duration: 3000,
-            autoDismiss: true,
-            type: ToastTypeEnum.Success,
-            hasDismissButton: false,
-            hasCheckmark: false,
-            hasX: false,
-            zIndex: 999999,
-        },
+        options: { ...DEFAULT_TOAST_OPTIONS },
     },
     { persist: { name: 'toastStore', enabled: false } }
 ).extendActions(set => ({
     presentToast: (message: string | ReactNode, options?: ToastOptions) => {
         set.state(state => {
             state.message = message;
-
-            state.options = {
-                ...state.options,
-                ...options,
-            };
+            state.options = normalizeToastOptions(options);
         });
     },
 
     setOptions: (options: ToastOptions) => {
         set.state(state => {
-            state.options = {
-                ...state.options,
-                ...options,
-            };
+            state.options = normalizeToastOptions({ ...state.options, ...options });
         });
     },
 
     dismissToast: () => {
         set.state(state => {
             state.message = '';
-            state.options = {
-                title: '',
-                className: '',
-                duration: 3000,
-                autoDismiss: true,
-                type: ToastTypeEnum.Success,
-                hasDismissButton: false,
-                hasCheckmark: false,
-                hasX: false,
-                zIndex: 999999,
-            };
+            state.options = { ...DEFAULT_TOAST_OPTIONS };
         });
     },
 }));


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

Toast options were merged with the previous toast's state. When a success and error toast appeared sequentially, the earlier status icon could remain enabled, causing both the success checkmark and error X to render together. Long filenames and messages could also overflow the toast because the content did not shrink or break unbroken text.

This PR resets toast options for every new toast, enforces mutually exclusive status icons, and keeps long content contained within the toast. Resume uploads that produce no extracted credentials now correctly use the error toast state.

> **Side note on the original report:** This notification was originally reported after a resume failed to parse. Further investigation confirmed that the resume and parser were not the issue—the OpenAI account had run out of tokens. Once tokens were available again, the same resume parsed successfully and generated credentials as expected. Although the parsing failure had a separate cause, it exposed broken notification behavior: conflicting status icons appeared and long content overflowed the toast. This PR fixes those notification issues.


#### 🥴 TL; RL:

-   Prevent success and error icons from appearing together.
-   Reset toast options between notifications so state cannot leak.
-   Wrap long titles, filenames, and messages inside the toast.
-   Add regression tests for sequential toasts, conflicting icon options, and long content.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

-   Added centralized default toast options and normalization in the toast store.
-   Added a render-level safeguard that selects only one status icon based on toast type.
-   Updated the toast flex layout with shrink constraints and anywhere text wrapping.
-   Changed all no-credentials upload outcomes to use the existing file-upload error options.

# Before 

<img width="443" height="186" alt="error" src="https://github.com/user-attachments/assets/eba97e98-ece2-45c8-8345-181521197a60" />

# After

<img width="437" height="172" alt="fix" src="https://github.com/user-attachments/assets/f51eed3c-1879-4c41-955b-c9a193e4e51a" />


#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

<!--- Please add QA steps someone can follow in order to verify this works. -->

1. Open **Build My LearnCard** and select **Add Resume**.
2. Upload a resume that successfully produces credentials and confirm the toast shows only the success checkmark.
3. Trigger an upload error before dismissing the success toast and confirm the replacement toast shows only the error X.
4. Upload a resume that contains no extractable credentials and confirm it displays as an error.
5. Repeat with a long filename and confirm the title and message wrap inside the toast without horizontal overflow.
6. Verify the dismiss button remains visible and usable on mobile widths.

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [X] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [X] New and existing **unit tests pass** locally with my changes
-   [ ] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [ ] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [X] I have thoughtfully considered the security implications of this change.
-   [X] This change does not expose new public facing endpoints that do not have authentication

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix toast notification status icon conflicts and text overflow issues in the learn-card-base and learn-card-app components.

Main changes:
- Implemented normalizeToastOptions in toastStore to ensure mutual exclusivity of status icons
- Added break-words and overflow-wrap CSS to Toast components to prevent text overflow
- Updated useUploadFile to use FILE_UPLOAD_ERROR_TOAST_OPTIONS for failed credential extractions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
