### PR TITLE
chore: Switch latest image to weekly interop canary

### DIFF
--- a/.github/workflows/openid4vc-interop.yml
+++ b/.github/workflows/openid4vc-interop.yml
@@ -68,6 +68,17 @@ jobs:
                   # Surface real-vendor failures rather than silently skipping.
                   CI: 'true'
 
+            - name: Record vendor image digests
+              if: always()
+              working-directory: tests/openid4vc-interop-e2e
+              # Ties a red canary run to the exact upstream build it
+              # tested — `latest` is mutable, digests are not.
+              run: |
+                  docker compose config --images | sort -u | while read -r img; do
+                      digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$img" 2>/dev/null || echo 'not pulled')
+                      echo "$img -> $digest"
+                  done
+
             - name: Dump docker compose logs on failure
               if: failure()
               working-directory: tests/openid4vc-interop-e2e

--- a/.github/workflows/openid4vc-interop.yml
+++ b/.github/workflows/openid4vc-interop.yml
@@ -8,6 +8,13 @@ name: OpenID4VC Interop Tests
 # The in-process suite (tests/openid4vc-e2e/) continues to run on
 # every PR via the normal `Test Runner` (nx affected) workflow — this
 # file is purely for the heavyweight, real-vendor tier.
+#
+# walt.id image strategy: PR runs use the known-good pin baked into
+# tests/openid4vc-interop-e2e/compose.yaml (WALTID_IMAGE_TAG default),
+# so PRs only fail on regressions on our side. The weekly scheduled
+# run overrides WALTID_IMAGE_TAG=latest as a canary for upstream
+# drift (e.g. the 2026-08-05 Crypto2 kid-resolution change) without
+# blocking PRs.
 
 on:
     pull_request:
@@ -18,18 +25,27 @@ on:
             - 'tests/openid4vc-e2e/**'
             - 'bun.lock'
             - '.github/workflows/openid4vc-interop.yml'
+    schedule:
+        # Weekly canary against waltid/*:latest (Mondays 06:00 UTC).
+        - cron: '0 6 * * 1'
     workflow_dispatch:
         inputs:
             branch:
                 description: 'Branch to test'
                 required: true
                 default: 'main'
+            waltid_tag:
+                description: 'walt.id image tag (empty = compose default pin, e.g. `latest` for canary)'
+                required: false
+                default: ''
 
 jobs:
     interop:
-        name: Interop (walt.id + Sphereon + EUDI)
+        name: Interop (walt.id + Sphereon + EUDI)${{ github.event_name == 'schedule' && ' — canary vs latest' || '' }}
         runs-on: ubuntu-latest
         timeout-minutes: 45
+        env:
+            WALTID_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || github.event.inputs.waltid_tag || '' }}
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v7

--- a/examples/openid4vc-playground/README.md
+++ b/examples/openid4vc-playground/README.md
@@ -179,7 +179,7 @@ For wallets on networks that can't reach your LAN (e.g. testing from a coffee sh
 The walt.id Docker stack probably isn't running. `cd ../../tests/openid4vc-interop-e2e && docker compose ps` should show two running services on ports 7002 (issuer) and 7003 (verifier).
 
 **"walt.id verifier returned URI with no state param"**
-walt.id schema drift. Check `compose.yaml` is using the version pinned by the e2e tests (currently `waltid/issuer-api:latest` and `waltid/verifier-api:latest`).
+walt.id schema drift. Check `compose.yaml` is using the pinned version from the e2e tests (the `WALTID_IMAGE_TAG` default in `tests/openid4vc-interop-e2e/compose.yaml`) — an unpinned `latest` may have drifted.
 
 **QR scans but nothing happens in the wallet**
 The wallet's deep-link handler probably isn't registered. On macOS, install the LearnCard iOS app (or LCA web) and re-scan; the OS prompt will offer to open in the wallet.

--- a/packages/plugins/openid4vc/README.md
+++ b/packages/plugins/openid4vc/README.md
@@ -460,7 +460,9 @@ All of these expose pre-authorized-code offers, so the harness works as-is.
 When you want deterministic iteration (same offer twice, offline, step-through debugging), run WaltID's issuer in Docker:
 
 ```bash
-docker run --rm -p 7002:7002 -p 7003:7003 waltid/issuer-api:latest
+# Use the same pinned tag as the interop tests (the WALTID_IMAGE_TAG
+# default in tests/openid4vc-interop-e2e/compose.yaml)
+docker run --rm -p 7002:7002 -p 7003:7003 waltid/issuer-api:0.23.0
 # in another terminal, POST an offer config to http://localhost:7002/...
 # then feed the returned offer URI to bun run try-offer
 ```

--- a/tests/openid4vc-interop-e2e/README.md
+++ b/tests/openid4vc-interop-e2e/README.md
@@ -332,6 +332,20 @@ for this reason; the deterministic version lives in
 on every inner JWT-VC against its `did:jwk` issuer key — 100%
 repeatable rejection on a single bit-flip.
 
+### 8. Strict kid-based issuer-key resolution (verifier, post-Crypto2)
+
+Since PR #1954 ("Crypto2", merged 2026-08-05), walt.id's verifier
+resolves the inner-VC issuer key strictly by the JWT header's `kid`:
+it must match a verification method in the issuer's DID document.
+Earlier builds (≤0.23.0) fell back to the first key in the document
+regardless of `kid`. A `did:jwk` document has exactly one
+verification method, `<did>#0`, so `createIssuerKey()` sets its
+`kid` to that value — walt.id embeds the supplied `kid` in every VC
+it signs, and any other value now fails verification with
+`Could not resolve issuer key`. The plugin's own signers were
+always compliant (`didToVerificationMethod`); only the harness's
+issuer key needed fixing.
+
 ## Architecture notes
 
 ### By-value URL rewriting
@@ -377,14 +391,32 @@ Ed25519 keypair per spec run so:
 
 ### Rotating the walt.id image
 
-The compose file pins `waltid/issuer-api:0.23.0` +
-`waltid/verifier-api:0.23.0`. The suite originally tracked `latest`
-to catch drift early, but the 2026-08-05 `latest` push (a
-`feat-portal2-dcapi` branch build) broke Ed25519 `did:jwk`
-issuer-key resolution in the verifier's `JwtSignaturePolicy`,
-failing `roundtrip.spec.ts` and `multi-credential.spec.ts` on every
-PR. When rotating to a newer tag, run the full suite locally first
+The walt.id image tag is parameterized via `WALTID_IMAGE_TAG`
+(compose default: a known-good pinned release). This splits the two
+concerns that a single `latest` pin used to conflate:
+
+-   **PR runs** use the pin — failures mean a regression on our
+    side, never upstream drift.
+-   **Weekly canary** (`.github/workflows/openid4vc-interop.yml`
+    schedule trigger) runs with `WALTID_IMAGE_TAG=latest` — failures
+    mean upstream drift, without blocking PRs.
+
+To reproduce a canary failure locally:
+
+```bash
+WALTID_IMAGE_TAG=latest bun run test:interop:e2e
+```
+
+When bumping the pin, run the suite against the candidate tag first
 and prefer immutable release tags over `latest` / `stable`.
+
+Drift caught so far: the 2026-08-05 `latest` push (built from
+walt-id/waltid-identity PR #1954, "Crypto2") made the verifier's
+issuer-key resolution strictly `kid`-aware. `createIssuerKey()`
+previously handed walt.id a random `kid`; the new resolver couldn't
+match it against the `did:jwk` document's sole `#0` verification
+method and rejected every VC with `Could not resolve issuer key`.
+Fixed by setting `kid` to `<did>#0` (see quirk 8 below).
 
 ## Troubleshooting
 

--- a/tests/openid4vc-interop-e2e/README.md
+++ b/tests/openid4vc-interop-e2e/README.md
@@ -401,9 +401,11 @@ concerns that a single `latest` pin used to conflate:
     schedule trigger) runs with `WALTID_IMAGE_TAG=latest` — failures
     mean upstream drift, without blocking PRs.
 
-To reproduce a canary failure locally:
+To reproduce a canary failure locally (the `pull` matters — without
+it you'll test whatever `latest` you cached weeks ago):
 
 ```bash
+WALTID_IMAGE_TAG=latest docker compose pull waltid-issuer waltid-verifier
 WALTID_IMAGE_TAG=latest bun run test:interop:e2e
 ```
 
@@ -416,7 +418,7 @@ issuer-key resolution strictly `kid`-aware. `createIssuerKey()`
 previously handed walt.id a random `kid`; the new resolver couldn't
 match it against the `did:jwk` document's sole `#0` verification
 method and rejected every VC with `Could not resolve issuer key`.
-Fixed by setting `kid` to `<did>#0` (see quirk 8 below).
+Fixed by setting `kid` to `<did>#0` (see quirk 8 above).
 
 ## Troubleshooting
 

--- a/tests/openid4vc-interop-e2e/compose.yaml
+++ b/tests/openid4vc-interop-e2e/compose.yaml
@@ -63,11 +63,11 @@ services:
             - oid4vc-interop
 
     waltid-issuer:
-        # Pinned: the 2026-08-05 `latest` push (feat-portal2-dcapi branch
-        # build) broke Ed25519 did:jwk issuer-key resolution in the
-        # verifier's JwtSignaturePolicy, failing the interop suite on
-        # every PR. 0.23.0 is the last known-good release tag.
-        image: waltid/issuer-api:0.23.0
+        # WALTID_IMAGE_TAG defaults to a known-good pin so PR runs only
+        # fail on regressions we introduce; the scheduled canary workflow
+        # overrides it with `latest` to catch upstream drift (see
+        # .github/workflows/openid4vc-interop.yml).
+        image: waltid/issuer-api:${WALTID_IMAGE_TAG:-0.23.0}
         container_name: oid4vc-interop-issuer
         # Share the host-bridge's netns so `localhost:4000` from inside
         # walt.id reaches brain-service on the host. See the comment
@@ -103,8 +103,7 @@ services:
             - oid4vc-interop
 
     waltid-verifier:
-        # Pinned alongside issuer-api — see comment above.
-        image: waltid/verifier-api:0.23.0
+        image: waltid/verifier-api:${WALTID_IMAGE_TAG:-0.23.0}
         container_name: oid4vc-interop-verifier
         # Shares the verifier-side bridge's netns so VPs signed by a
         # `did:web:localhost:4000:...` holder can be verified.

--- a/tests/openid4vc-interop-e2e/compose.yaml
+++ b/tests/openid4vc-interop-e2e/compose.yaml
@@ -46,7 +46,7 @@
 
 services:
     host-bridge-issuer:
-        image: alpine/socat
+        image: alpine/socat:1.8.1.3
         container_name: oid4vc-interop-host-bridge-issuer
         # Forward in-namespace localhost:4000 -> host's port 4000
         # (brain-service). socat's `fork` keeps each TCP connection in a
@@ -92,7 +92,7 @@ services:
             - ./config/issuer:/waltid-issuer-api/config:ro
 
     host-bridge-verifier:
-        image: alpine/socat
+        image: alpine/socat:1.8.1.3
         container_name: oid4vc-interop-host-bridge-verifier
         command: TCP-LISTEN:4000,fork,reuseaddr TCP:host.docker.internal:4000
         extra_hosts:
@@ -149,7 +149,7 @@ services:
     #     baseline; `direct_post.jwt` (encrypted JWE response) is
     #     out of scope for this slice.
     host-bridge-eudi:
-        image: alpine/socat
+        image: alpine/socat:1.8.1.3
         container_name: oid4vc-interop-host-bridge-eudi
         command: TCP-LISTEN:4000,fork,reuseaddr TCP:host.docker.internal:4000
         extra_hosts:

--- a/tests/openid4vc-interop-e2e/setup/walt-id-client.ts
+++ b/tests/openid4vc-interop-e2e/setup/walt-id-client.ts
@@ -58,12 +58,17 @@ export const createIssuerKey = async (): Promise<WaltidIssuerKey> => {
         throw new Error('Expected Ed25519 OKP keypair');
     }
 
-    const kid = `kid-${Math.random().toString(36).slice(2, 10)}`;
-
     // did:jwk embeds the *public* JWK.
     const did = `did:jwk:${b64url(
         JSON.stringify({ kty: pubJwk.kty, crv: pubJwk.crv, x: pubJwk.x })
     )}`;
+
+    // The kid MUST reference the did:jwk document's sole verification
+    // method (`#0`). walt.id embeds this kid in the JWT header of every
+    // VC it signs with this key; since PR #1954 ("Crypto2", 2026-08-05)
+    // its verifier resolves issuer keys strictly by kid, so a random
+    // kid fails with "Could not resolve issuer key".
+    const kid = `${did}#0`;
 
     return {
         jwk: {
@@ -119,9 +124,7 @@ export interface MintOfferOptions {
  * URI in `text/plain`, e.g.
  *   `openid-credential-offer://?credential_offer_uri=...`
  */
-export const mintWaltidOffer = async (
-    opts: MintOfferOptions
-): Promise<string> => {
+export const mintWaltidOffer = async (opts: MintOfferOptions): Promise<string> => {
     const {
         issuerBaseUrl,
         issuerKey,
@@ -327,9 +330,7 @@ export const resolveOfferToByValue = async (offerUri: string): Promise<string> =
 
     const res = await fetch(byRef);
     if (!res.ok) {
-        throw new Error(
-            `Failed to resolve credential_offer_uri ${byRef}: HTTP ${res.status}`
-        );
+        throw new Error(`Failed to resolve credential_offer_uri ${byRef}: HTTP ${res.status}`);
     }
 
     const offerJson = await res.json();

--- a/tests/openid4vc-interop-e2e/tests/issue.spec.ts
+++ b/tests/openid4vc-interop-e2e/tests/issue.spec.ts
@@ -44,8 +44,7 @@ const getPlugin = (mock: MockLearnCardHandle) => {
     // `plugin.foo(...)` without threading `learnCard` through.
     const bound: Record<string, (...args: any[]) => any> = {};
     for (const [name, fn] of Object.entries(plugin.methods)) {
-        bound[name] = (...args: any[]) =>
-            (fn as (...a: any[]) => any)(mock.learnCard, ...args);
+        bound[name] = (...args: any[]) => (fn as (...a: any[]) => any)(mock.learnCard, ...args);
     }
     return bound as any;
 };
@@ -84,6 +83,13 @@ describe('interop: OID4VCI issue flow against walt.id', () => {
 
         expect(header.alg).toBe('EdDSA');
         expect(typeof header.kid).toBe('string');
+
+        // Regression guard for walt.id quirk 8: the issuer kid MUST be
+        // the did:jwk verification method (`<did>#0`). PR runs pin a
+        // pre-Crypto2 walt.id that tolerates a mismatched kid, so
+        // without this assertion a regression here would only surface
+        // in the weekly `latest` canary — disguised as upstream drift.
+        expect(issuerKey.jwk.kid).toBe(`${issuerKey.did}#0`);
 
         // Signed by walt.id's issuer DID.
         expect(payload.iss).toBe(issuerKey.did);


### PR DESCRIPTION
## What

The interop suite started failing on every PR on 2026-08-05 with `Could not resolve issuer key for 'did:jwk:...'` from the walt.id verifier (`roundtrip.spec.ts` and `multi-credential.spec.ts`).

Root cause: the compose file tracked `waltid/*:latest`, and that day's `latest` push (walt-id/waltid-identity PR #1954, "Crypto2") made the verifier resolve issuer keys strictly by the JWT `kid` header. Our test harness handed walt.id an issuer key with a random `kid` (`kid-x7f3a2`-style) that matches nothing in the `did:jwk` document, which only has one verification method: `<did>#0`. Older builds ignored the mismatch and fell back to the first key; the new one rejects.

Three changes:

1. **Fix our side**: `createIssuerKey()` in `tests/openid4vc-interop-e2e/setup/walt-id-client.ts` now sets `kid` to `<did>#0`. This is the spec-correct value and works with both old and new walt.id resolvers. (The plugin itself was never affected — it already uses `didToVerificationMethod`.)
2. **Pin PR runs**: the walt.id image tag in `compose.yaml` is now `${WALTID_IMAGE_TAG:-0.23.0}`, so PR failures always mean a regression on our side, never upstream drift.
3. **Weekly canary**: the interop workflow gains a Monday 06:00 UTC schedule that runs the same suite with `WALTID_IMAGE_TAG=latest`, restoring the catch-drift-early property without blocking PRs. Canary failures on main already Slack-notify via the existing failure-notification workflow. A `waltid_tag` dispatch input lets you test any candidate tag manually (useful when bumping the pin).

## How to review

- `walt-id-client.ts`: the `kid` change is the only functional edit (plus two prettier-only reflows).
- `compose.yaml`: check the tag interpolation. `docker compose config` resolves to `0.23.0` with no env var, `latest` with `WALTID_IMAGE_TAG=latest`.
- `.github/workflows/openid4vc-interop.yml`: schedule trigger + job-level env. PR-triggered runs get an empty `WALTID_IMAGE_TAG`, which compose treats as unset.
- README documents the pin/canary split and records the incident as walt.id quirk #8.

To verify locally:

```bash
# pinned (what PRs run)
bun --filter @workspace/openid4vc-interop-e2e-tests run test:interop:e2e

# canary (what the weekly run does)
WALTID_IMAGE_TAG=latest bun --filter @workspace/openid4vc-interop-e2e-tests run test:interop:e2e
```

Both pass locally: 23 passed / 3 skipped against `latest`.
