### PR TITLE
fix: correct app version in web builds

### DIFF
--- a/.changeset/big-sails-shine.md
+++ b/.changeset/big-sails-shine.md
@@ -1,0 +1,6 @@
+---
+"learn-card-app": patch
+"scoutpass-app": patch
+---
+
+fix: Web Version #

--- a/apps/learn-card-app/vite.config.mts
+++ b/apps/learn-card-app/vite.config.mts
@@ -44,6 +44,20 @@ const { readDefaultChannel } = requireFromHere('../../tools/capgo/readDefaultCha
 };
 
 /**
+ * App version read directly from this app's package.json.
+ *
+ * Deliberately NOT `process.env.npm_package_version` — that env var reflects
+ * the package.json of the directory the build command was invoked from, so
+ * CI builds run from the monorepo root (`bunx nx build learn-card-app`) would
+ * bake in the root package's version (e.g. 1.0.1) instead of the app's.
+ */
+const packageVersion = (
+    JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf-8')) as {
+        version: string;
+    }
+).version;
+
+/**
  * Resolve a short build commit SHA at config-eval time.
  *
  * Source preference:
@@ -199,8 +213,8 @@ export default defineConfig(async ({ mode, command }) => {
             },
         },
         define: {
-            __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
-            __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+            __PACKAGE_VERSION__: JSON.stringify(packageVersion),
+            __APP_VERSION__: JSON.stringify(packageVersion),
             __BUILD_SHA__: JSON.stringify(resolveBuildSha()),
             __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
             __CAPGO_DEFAULT_CHANNEL__: JSON.stringify(

--- a/apps/scouts/vite.config.ts
+++ b/apps/scouts/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { readFileSync } from 'fs';
 
 import GlobalPolyfill from '@esbuild-plugins/node-globals-polyfill';
 import { defineConfig, loadEnv } from 'vite';
@@ -8,6 +9,16 @@ import react from '@vitejs/plugin-react-swc';
 import svgr from 'vite-plugin-svgr';
 import stdlibbrowser from 'node-stdlib-browser';
 import basicSsl from '@vitejs/plugin-basic-ssl';
+
+// App version read directly from this app's package.json.
+// Deliberately NOT `process.env.npm_package_version` — that reflects the package.json
+// of the directory the build was invoked from, so CI builds run from the monorepo root
+// would bake in the root package's version instead of the app's.
+const packageVersion = (
+    JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf-8')) as {
+        version: string;
+    }
+).version;
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), [
@@ -54,8 +65,8 @@ export default defineConfig(({ mode }) => {
                 ? JSON.stringify(env.LEARN_CLOUD_XAPI_URL)
                 : 'undefined',
             API_URL: env.API_URL ? JSON.stringify(env.API_URL) : 'undefined',
-            __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
-            __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+            __PACKAGE_VERSION__: JSON.stringify(packageVersion),
+            __APP_VERSION__: JSON.stringify(packageVersion),
             'process.version': '"1.0.0"',
             IS_PRODUCTION: env.NODE_ENV === 'production',
             SENTRY_ENV: env.SENTRY_ENV ? JSON.stringify(env.SENTRY_ENV) : '"scouts-development"',


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Related to: LC-2055 (fallout from #1357)

#### 📚 What is the context and goal of this PR?

Since #1357 moved deploys to CI, web builds of both learncard.app and staging.learncard.ai show **"V 1.0.1"** in the side menu instead of the real app version (e.g. 1.98.x).

Cause: both Vite configs baked the version from `process.env.npm_package_version`, which reflects the package.json of the directory the build command was invoked from. Netlify used to build with the app dir as the base, so it picked up the app's version. The CI workflow runs `bunx nx build <app>` from the repo root, so it picks up the root package.json version — `1.0.1`.

#### 🥴 TL; RL:

Web version display broke after moving builds to CI. Vite configs now read the version directly from each app's own `package.json` instead of an env var that depends on the invocation directory.

#### 💡 Feature Breakdown

- `apps/learn-card-app/vite.config.mts` — `__PACKAGE_VERSION__` / `__APP_VERSION__` now come from `readFileSync('./package.json')` (→ 1.98.x)
- `apps/scouts/vite.config.ts` — same fix (→ 1.90.x)

#### 🛠 Important tradeoffs made:

None. The version is now correct regardless of where the build is invoked from.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. From the repo root, run `bunx nx build learn-card-app` (same as CI)
2. Serve the build and open the side menu — the footer should show the version from `apps/learn-card-app/package.json` (1.98.x), not 1.0.1
3. Same check for scouts if desired

#### 📱 🖥 Which devices would you like help testing on?

Any browser — web only. Native builds are unaffected (they use the Capgo/native version).

#### 🧪 Code Coverage

No new tests — build-config-only change, verified by inspecting the built bundle. (Scouts' `tests/vite-config.test.ts` fails on main for an unrelated pre-existing reason.)

# Documentation

#### 📝 Documentation Checklist

-   [x] **Code comments/JSDoc** — comment in both configs explains why `npm_package_version` must not be used

#### 💭 Documentation Notes

Internal build fix, no API or user flow changes.

# ✅ PR Checklist

-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication
