### PR TITLE
LC-1950: replace ScoutPass fake revocation

### DIFF
--- a/.superpowers/sdd/2026-08-10-lc-1950-scoutpass-real-revocation/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-10-lc-1950-scoutpass-real-revocation/final-fix-report.md
@@ -1,0 +1,203 @@
+# LC-1950 final review fix report
+
+Date: 2026-08-10
+
+Scope: repository source and local test fixtures only; no live or production data was read or changed.
+
+## Outcome
+
+All nine Important final-review findings are fixed in one coordinated wave. The final Task 7 matrix is 99/99 tests across 11 files (the 84-test baseline plus 15 new regressions), the three required builds are green, the isolated Scout semantic type check is green, and all static/format/scope checks pass.
+
+## Per-finding RED, implementation, and GREEN evidence
+
+### 1. Resolved verification errors opened Scout gates
+
+-   RED: the focused shared hook run reported 1 failed and 4 passed; a resolved `VerificationCheck` containing `errors` returned `isError: false` instead of the expected `true`. The Scout decision coverage also demonstrated that an error-derived unavailable status must remain action-restricted.
+-   Implementation: `useCredentialStatus` still returns fail-open lifecycle data (`status: 'active'`) when verification resolves with errors, but now preserves `isError: true`. `useTroopIDStatus` consequently normalizes that result to unavailable rather than valid.
+-   GREEN: shared hook 5/5; Scout status/share and page-helper suites 22/22; the full shared/Scout matrix also passed.
+-   Files: `packages/learn-card-base/src/hooks/useCredentialStatus.ts`, `packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx`, `apps/scouts/src/pages/troop/troopIdStatus.helpers.ts`, `apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts`.
+
+### 2. Personal-row Share bypassed lifecycle gating
+
+-   RED: the focused Scout run failed the six restricted personal Share cases (missing, loading, error, pending, suspended, and revoked); only a resolved valid issuance may share.
+-   Implementation: `IdOptionsModal` now invokes the holder lifecycle adapter with the exact `credentialUri` and `issuanceState`. The Share row is rendered only when `canSharePersonalTroopId` receives a resolved valid status. This is independent of the parent-administrator protected-content bypass.
+-   GREEN: all seven personal Share decision cases passed inside the 18-case Scout status suite; the Scouts production build passed.
+-   Files: `apps/scouts/src/pages/troop/IdOptionsModal.tsx`, `apps/scouts/src/pages/troop/troopIdStatus.helpers.ts`, `apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts`.
+
+### 3. Sibling issuance state could override an exact credential URI
+
+-   RED: two focused data-flow assertions failed before implementation: an exact accepted URI could inherit the first pending sibling, and a present-but-unmatched exact URI could incorrectly fall back to a profile sibling.
+-   Implementation: `selectHolderRecipient` selects by exact credential URI whenever one is supplied. Profile fallback is used only when no exact holder URI exists.
+-   GREEN: exact-URI and fallback cases passed in `troopPage.helpers.test.ts` (4/4 file total with finding 4).
+-   Files: `apps/scouts/src/pages/troop/TroopPage.tsx`, `apps/scouts/src/pages/troop/troopPage.helpers.ts`, `apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts`.
+
+### 4. Pending-only member rows were unreachable
+
+-   RED: the focused data-flow assertion showed that accepted count `0` hid the member box despite a pending row.
+-   Implementation: visibility now uses `hasReachableMembers(totalCount, memberRows)`, keeping pending-only list/removal controls reachable while leaving the accepted count untouched.
+-   GREEN: both pending-only visibility and truly-empty hiding assertions passed.
+-   Files: `apps/scouts/src/pages/troop/TroopPageMembersBox.tsx`, `apps/scouts/src/pages/troop/troopPage.helpers.ts`, `apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts`.
+
+### 5. Group removal invalidated nonexistent React Query keys
+
+-   RED: 2/2 focused mutation tests failed after seeding actual `paginatedBoostRecipients` and `useCountBoostRecipients` consumer entries; neither real query became invalidated on success or failure.
+-   Implementation: the invalidation prefixes now match those actual consumers. Tests use real `QueryClient` cache entries and assert their `isInvalidated` state rather than spying on constants.
+-   GREEN: mutation suite 2/2 on both success and failure, and 13/13 in the full `learn-card-base` matrix.
+-   Files: `packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts`, `packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx`.
+
+### 6. Scout result type was an invalid subtype
+
+-   RED: temporarily restoring the old direct `extends CredentialStatusResult` declaration made the isolated semantic check fail with TS2430 because Scout replaces lifecycle `status`; the mutation was immediately reverted.
+-   Implementation: shared lifecycle option/result interfaces live in the dependency-light `credentialStatus.types.ts`; `TroopIdStatusResult` extends `Omit<CredentialStatusResult, 'status'>` and has an explicit compile-time independence assertion. A narrow project file makes this contract reproducible without unrelated application-wide baseline errors.
+-   GREEN: `bunx tsc --project apps/scouts/tsconfig.troop-status.json --pretty false` exited 0, and all builds passed.
+-   Files: `packages/learn-card-base/src/hooks/credentialStatus.types.ts`, `packages/learn-card-base/src/hooks/useCredentialStatus.ts`, `apps/scouts/src/pages/troop/troopIdStatus.types.ts`, `apps/scouts/src/pages/troop/TroopIdStatusButton.tsx`, `apps/scouts/tsconfig.troop-status.json`.
+
+### 7. Singular Bitstring failures falsely succeeded
+
+-   RED: the focused backend run failed both singular cases: an injected thrown update and an explicit `failed` result resolved successfully instead of rejecting. The focused run also proved notification would otherwise follow the false success path.
+-   Implementation: `revokeCredentialReceived` now returns false only when the graph credential was not found, throws `Failed to update credential status list` for an actual failed update, and preserves legacy `missing-entry` as success with a warning.
+-   GREEN: both singular cases reject with the expected message and do not notify; the existing missing-entry compatibility test and the full backend matrix pass.
+-   Files: `services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts`, `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts`.
+
+### 8. Legacy received-side revoked state/audit was ignored
+
+-   RED: the focused backend regression classified a received-side revoked fixture as newly revoked instead of already revoked and would assign a new sent-side audit timestamp.
+-   Implementation: the graph transition reads both sent and received status/timestamps. Either revoked status is already revoked; repair copies the effective original timestamp to the sent relationship and still reruns mandatory status/cleanup work.
+-   GREEN: the route reports the fixture only in `alreadyRevokedCredentialUris`, preserves the exact 2025 audit timestamp on both sides, reruns cleanup, and queues no notification.
+-   Files: `services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts`, `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts`.
+
+### 9. First partial graph transitions were never notified
+
+-   RED: two focused backend cases failed because cleanup-partial and Bitstring-partial first transitions omitted their failed URI from the consolidated notification.
+-   Implementation: the group route tracks first authoritative graph transitions independently from response success buckets. It notifies that transition set once even when mandatory side effects make the result partial; healing retries see an already-revoked graph state and cannot notify again.
+-   GREEN: both partial cases notify once with the transitioned URI, retry successfully as already revoked, do not notify twice, and the Bitstring retry now asserts the real revocation bit is set.
+-   Files: `services/learn-card-network/brain-service/src/routes/boosts.ts`, `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts`.
+
+## Focused TDD commands and results
+
+```bash
+bun run --cwd packages/learn-card-base test -- src/hooks/__tests__/useCredentialStatus.test.tsx
+# RED: 1 failed, 4 passed; GREEN: 5 passed
+
+bun test \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts \
+  apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts
+# RED: 9 failed, 13 passed; GREEN: 22 passed
+
+bun run --cwd packages/learn-card-base test -- \
+  src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+# RED: 2 failed; GREEN: 2 passed
+
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  --testTimeout=30000 test/revoke-boost-recipient-group.spec.ts \
+  -t 'singular revocation|legacy received-side|retries cleanup hooks|retries a failed status-list update'
+# RED: 5 failed, 7 skipped; GREEN: 5 passed, 7 skipped
+
+bunx tsc --project apps/scouts/tsconfig.troop-status.json --pretty false
+# Mutated old declaration: TS2430; restored Omit contract: exit 0
+```
+
+## Full Task 7 matrix
+
+```bash
+bun run --cwd packages/learn-card-base test -- \
+  src/hooks/__tests__/deriveLifecycleStatus.test.ts \
+  src/hooks/__tests__/useCredentialStatus.test.tsx \
+  src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+# 13 passed, 3 files
+
+bun run --cwd apps/learn-card-app test:unit -- \
+  src/hooks/__tests__/useCredentialStatus.test.ts
+# 5 passed, 1 file
+
+bun test \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts \
+  apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts \
+  apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts
+# 25 passed, 3 files
+
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  --testTimeout=30000 \
+  test/revoke-boost-recipient-group.spec.ts \
+  test/revoke-suspend-per-instance.spec.ts \
+  test/revoke-credential.spec.ts \
+  test/scouts-hierarchy.spec.ts
+# 56 passed, 4 files, exit 0, 174.39s
+```
+
+Aggregate: 99/99 tests across 11 files (84 baseline plus 15 new tests). Expected-only backend output consisted of DIDKit native fallback, deliberate missing-entry/suspension warnings, and the test-injected notification failure.
+
+## Builds and static acceptance
+
+```bash
+bun run --cwd packages/learn-card-types build
+# exit 0 — Build successful
+
+bun run --cwd packages/plugins/learn-card-network build
+# exit 0 — Build successful
+
+bunx nx build scouts
+# exit 0 — successfully built Scouts and its dependency graph
+
+bunx tsc --project apps/scouts/tsconfig.troop-status.json --pretty false
+# exit 0
+
+rg -n "useSyncRevokedCredentials" apps/scouts/src
+rg -n "isClaimedError|isAllError|useIsTroopIDRevokedFake" apps/scouts/src
+rg -n "removeBoostAdmin|updateBoostPermissions" apps/scouts/src/pages/troop/IdOptionsModal.tsx
+# all three: no matches (expected rg exit 1)
+
+git diff --check
+# exit 0, no output
+
+git diff -- package.json bun.lock bun.lockb yarn.lock package-lock.json pnpm-lock.yaml
+# exit 0, no output
+
+bunx prettier --check \
+  apps/scouts/src/pages/troop/IdOptionsModal.tsx \
+  apps/scouts/src/pages/troop/TroopIdStatusButton.tsx \
+  apps/scouts/src/pages/troop/TroopPage.tsx \
+  apps/scouts/src/pages/troop/TroopPageMembersBox.tsx \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts \
+  apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts \
+  apps/scouts/src/pages/troop/troopIdStatus.helpers.ts \
+  apps/scouts/src/pages/troop/troopIdStatus.types.ts \
+  apps/scouts/src/pages/troop/troopPage.helpers.ts \
+  apps/scouts/tsconfig.troop-status.json \
+  packages/learn-card-base/src/hooks/credentialStatus.types.ts \
+  packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx \
+  packages/learn-card-base/src/hooks/useCredentialStatus.ts \
+  packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx \
+  packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts \
+  services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts \
+  services/learn-card-network/brain-service/src/routes/boosts.ts \
+  services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
+# all matched files use Prettier code style
+```
+
+The first network-plugin build was mistakenly overlapped with the type-package build and observed stale generated output (`TS2305: RevokeBoostRecipientGroupResult`); rerunning it after the type build completed passed. The final required build order above is fully green. Scouts emitted only existing Sass deprecation, dynamic/static import, `eval`, and large-chunk warnings.
+
+## Final file set
+
+-   Scout runtime and tests: `IdOptionsModal.tsx`, `TroopIdStatusButton.tsx`, `TroopPage.tsx`, `TroopPageMembersBox.tsx`, `troopIdStatus.helpers.ts`, `troopIdStatus.types.ts`, `troopPage.helpers.ts`, `troopIdStatus.helpers.test.ts`, `troopPage.helpers.test.ts`, `tsconfig.troop-status.json`.
+-   Shared lifecycle/query runtime and tests: `credentialStatus.types.ts`, `useCredentialStatus.ts`, `useCredentialStatus.test.tsx`, `revokeBoostRecipientGroup.ts`, `revokeBoostRecipientGroup.test.tsx`.
+-   Backend runtime and tests: `credential/relationships/update.ts`, `routes/boosts.ts`, `revoke-boost-recipient-group.spec.ts`.
+
+## Self-review and scope audit
+
+-   Rechecked each of the nine findings against the final diff and its named regression.
+-   Lifecycle data remains fail-open `active`; verification error metadata keeps Scout unavailable/restricted.
+-   Personal Share uses the exact issuance and does not inherit parent-admin protected-content access.
+-   Exact URI selection takes precedence; pending-only rows remain reachable without changing counts.
+-   Query tests observe actual consumer cache records; backend tests exercise real route/graph behavior and real Bitstring healing.
+-   Singular thrown/failed updates reject; missing-entry compatibility remains a warned success.
+-   Legacy received-side revocation preserves the original effective audit time and remains repairable without notification.
+-   First graph transitions notify once even for partial side effects; healing retries do not duplicate.
+-   No dependency/lockfile, schema migration, data migration, or self-service Leave changes were made. Existing Leave code was inspected and remains untouched.
+-   No unrelated files, generated build output, or live data are included.
+
+## Residual concerns
+
+No automated finding remains open. Per the approved scope, rendered holder/member UI, Share/QR suppression, toast wording, and live offline behavior still require the documented manual release smoke test. Existing build warnings are unchanged and non-blocking.

--- a/apps/learn-card-app/src/hooks/__tests__/useCredentialStatus.test.ts
+++ b/apps/learn-card-app/src/hooks/__tests__/useCredentialStatus.test.ts
@@ -58,13 +58,13 @@ describe('deriveLifecycleStatus', () => {
         ).toBe('active');
     });
 
-    it('falls back to errors text when structured status is absent', () => {
+    it('fails open when structured status is absent, regardless of error text', () => {
         expect(
             deriveLifecycleStatus({ checks: [], warnings: [], errors: ['credential is revoked'] })
-        ).toBe('revoked');
+        ).toBe('active');
         expect(
             deriveLifecycleStatus({ checks: [], warnings: [], errors: ['credential is suspended'] })
-        ).toBe('suspended');
+        ).toBe('active');
     });
 
     it('returns active for an empty/undefined check (fail-open)', () => {

--- a/apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts
+++ b/apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts
@@ -1,2 +1,2 @@
-export { deriveLifecycleStatus } from 'learn-card-base';
-export type { CredentialLifecycleStatus } from 'learn-card-base';
+export { deriveLifecycleStatus } from 'learn-card-base/hooks/deriveLifecycleStatus';
+export type { CredentialLifecycleStatus } from 'learn-card-base/hooks/deriveLifecycleStatus';

--- a/apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts
+++ b/apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts
@@ -1,26 +1,2 @@
-import type { VerificationCheck } from '@learncard/types';
-
-export type CredentialLifecycleStatus = 'active' | 'revoked' | 'suspended';
-
-/**
- * Pure: map a raw VerificationCheck to a lifecycle status. Fails open to 'active'.
- *
- * Prefers the structured `status` entries (statusPurpose + isSet) when present;
- * falls back to scanning `errors` for older WASM builds that omit structured status.
- *
- * Kept in its own import-light module (type-only imports) so it can be unit-tested
- * without pulling in the `learn-card-base` barrel.
- */
-export const deriveLifecycleStatus = (
-    check: Partial<VerificationCheck> | undefined | null
-): CredentialLifecycleStatus => {
-    const entries = check?.status ?? [];
-    if (entries.some(e => e.statusPurpose === 'revocation' && e.isSet)) return 'revoked';
-    if (entries.some(e => e.statusPurpose === 'suspension' && e.isSet)) return 'suspended';
-
-    const errors = check?.errors ?? [];
-    if (errors.some(e => /revok/i.test(e))) return 'revoked';
-    if (errors.some(e => /suspend/i.test(e))) return 'suspended';
-
-    return 'active';
-};
+export { deriveLifecycleStatus } from 'learn-card-base';
+export type { CredentialLifecycleStatus } from 'learn-card-base';

--- a/apps/learn-card-app/src/hooks/useCredentialStatus.ts
+++ b/apps/learn-card-app/src/hooks/useCredentialStatus.ts
@@ -1,87 +1,14 @@
-import { useQuery } from '@tanstack/react-query';
-import { useWallet } from 'learn-card-base';
-import type { VC, VerificationCheck } from '@learncard/types';
+import type { VC } from '@learncard/types';
+import {
+    useCredentialStatus as useSharedCredentialStatus,
+    type CredentialLifecycleStatus,
+} from 'learn-card-base';
 
-import { deriveLifecycleStatus, CredentialLifecycleStatus } from './deriveLifecycleStatus';
+export type { CredentialLifecycleStatus } from 'learn-card-base';
+export { deriveLifecycleStatus } from 'learn-card-base';
 
-export type { CredentialLifecycleStatus } from './deriveLifecycleStatus';
-export { deriveLifecycleStatus } from './deriveLifecycleStatus';
-
-/**
- * Resolve a held credential's lifecycle status (revoked/suspended), cached by URI.
- *
- * Primary source is the authoritative backend status (the CREDENTIAL_SENT/RECEIVED
- * relationship status the issuer view + activity feed use). We prefer it over
- * client-side verifyCredential because the WASM status-list check enforces revocation
- * but does not reliably surface a *set suspension bit*, so a suspended credential would
- * otherwise render as active on the holder's card. Falls back to client verification
- * when the backend can't answer (e.g. self-issued creds with no CREDENTIAL_SENT edge, or
- * the network method being unavailable). Fail-open so an error never renders as revoked.
- */
 export const useCredentialStatus = (
     credential: VC | undefined,
     uri: string | undefined,
     enabled = true
-): CredentialLifecycleStatus => {
-    const { initWallet } = useWallet();
-
-    const { data } = useQuery({
-        // Keyed on `uri` only (not the credential object) by design: the URI is the
-        // credential's stable status identity, while the `credential` prop can change
-        // reference across renders (e.g. display-only `credentialWithEdits` merges) without
-        // affecting its revocation/suspension status. Re-verifying on those changes would
-        // be wasted work. Lifecycle mutations invalidate ['credentialStatus'] to force a
-        // refresh when the status actually changes.
-        queryKey: ['credentialStatus', uri],
-        enabled: enabled && !!credential && !!uri,
-        staleTime: 5 * 60 * 1000,
-        // The React Query cache is persisted (see FullApp), so without this a stale
-        // status (e.g. 'active' cached before a revoke/suspend) survives a hard refresh
-        // and only clears on logout. Always re-check on mount: the persisted value renders
-        // instantly, then the cheap authoritative backend query refreshes it.
-        refetchOnMount: 'always',
-        queryFn: async (): Promise<CredentialLifecycleStatus> => {
-            const wallet = await initWallet();
-
-            // 1) Authoritative backend status (source of truth for revoke/suspend).
-            try {
-                const getStatuses = (wallet as any)?.invoke?.getMyCredentialLifecycleStatuses as
-                    | ((options: {
-                          uris: string[];
-                      }) => Promise<Record<string, CredentialLifecycleStatus>>)
-                    | undefined;
-                const statuses = await getStatuses?.({ uris: [uri as string] });
-                const backendStatus = statuses?.[uri as string];
-                if (
-                    backendStatus === 'revoked' ||
-                    backendStatus === 'suspended' ||
-                    backendStatus === 'active'
-                ) {
-                    return backendStatus;
-                }
-            } catch {
-                // fall through to client verification
-            }
-
-            // 2) Fallback: client-side verification of the credential's status list.
-            try {
-                // prettify=false returns the raw VerificationCheck (with structured
-                // `status` entries). The exposed invoke type narrows the 3rd arg to
-                // `true`, so cast to reach the raw-result overload.
-                const verify = wallet?.invoke?.verifyCredential as
-                    | ((
-                          c: VC,
-                          options: Record<string, unknown>,
-                          prettify: boolean
-                      ) => Promise<VerificationCheck>)
-                    | undefined;
-                const check = await verify?.(credential as VC, {}, false);
-                return deriveLifecycleStatus(check);
-            } catch {
-                return 'active'; // fail-open
-            }
-        },
-    });
-
-    return data ?? 'active';
-};
+): CredentialLifecycleStatus => useSharedCredentialStatus({ credential, uri, enabled }).status;

--- a/apps/learn-card-app/src/hooks/useCredentialStatus.ts
+++ b/apps/learn-card-app/src/hooks/useCredentialStatus.ts
@@ -1,11 +1,9 @@
 import type { VC } from '@learncard/types';
-import {
-    useCredentialStatus as useSharedCredentialStatus,
-    type CredentialLifecycleStatus,
-} from 'learn-card-base';
+import { useCredentialStatus as useSharedCredentialStatus } from 'learn-card-base/hooks/useCredentialStatus';
+import type { CredentialLifecycleStatus } from 'learn-card-base/hooks/deriveLifecycleStatus';
 
-export type { CredentialLifecycleStatus } from 'learn-card-base';
-export { deriveLifecycleStatus } from 'learn-card-base';
+export type { CredentialLifecycleStatus } from 'learn-card-base/hooks/deriveLifecycleStatus';
+export { deriveLifecycleStatus } from 'learn-card-base/hooks/deriveLifecycleStatus';
 
 export const useCredentialStatus = (
     credential: VC | undefined,

--- a/apps/scouts/AGENTS.md
+++ b/apps/scouts/AGENTS.md
@@ -15,15 +15,14 @@ bun run dev              # Start frontend
 bun run docker-start     # Start backend services (Neo4j, brain-service)
 ```
 
-## Troop Credential Status
+## Troop credential lifecycle
 
-The `useTroopIDStatus` hook determines credential status:
-
-| Status      | Meaning                                        |
-| ----------- | ---------------------------------------------- |
-| `'valid'`   | User is in the claimed recipients list         |
-| `'pending'` | User is in all recipients but not claimed list |
-| `'revoked'` | User is not in either list                     |
+-   `learn-card-base/useCredentialStatus` is the shared authoritative holder lifecycle hook.
+-   `TroopIdStatusButton.tsx` adapts lifecycle plus explicit acceptance metadata for ScoutPass presentation.
+-   Earned views must pass a credential-record URI; managed views must not pass a Boost URI as a credential URI.
+-   Missing/query-error recipient data must never be interpreted as revocation.
+-   Administrator group removal uses `useRevokeBoostRecipientGroup`; the existing singular mutation remains per-instance.
+-   Revoked credentials remain visible. Do not mount deletion-based revoked-credential synchronization in ScoutPass.
 
 ## Key Files
 
@@ -44,12 +43,6 @@ The `useTroopIDStatus` hook determines credential status:
 -   **Troop-filtered**: `getPaginatedBoostRecipientsWithChildren()` → boost recipients
 
 ## ScoutPass-Specific Permissions
-
-### National Admin Troop View Access
-
-National admins may see "ID Revoked" when viewing troops they manage but don't own (because `useTroopIDStatus` checks the _current user_ as recipient).
-
-**Workaround**: `TroopPage.tsx` uses `hasParentAdminAccess` to bypass the `isRevokedOrPending` check. If a user has `canEditChildren` on the parent network boost, they see full troop details regardless.
 
 ### Network Admin Scout ID Issuance
 

--- a/apps/scouts/src/AppRouter.tsx
+++ b/apps/scouts/src/AppRouter.tsx
@@ -30,7 +30,6 @@ import {
     useModal,
     ModalTypes,
     useSyncConsentFlow,
-    useSyncRevokedCredentials,
     useIsCollapsed,
     LOGIN_REDIRECTS,
     lazyWithRetry,
@@ -111,7 +110,6 @@ const AppRouter: React.FC = () => {
     useSentryIdentify({ debug: !IS_PRODUCTION });
     useSetFirebaseAnalyticsUserId({ debug: false });
     useSyncConsentFlow(enablePrefetch);
-    useSyncRevokedCredentials(enablePrefetch);
 
     const { newModal: newBoostSelectModal, closeModal: closeBoostSelectModal } = useModal({
         mobile: ModalTypes.Cancel,

--- a/apps/scouts/src/components/boost/boost-earned-card/BoostEarnedIDCard.tsx
+++ b/apps/scouts/src/components/boost/boost-earned-card/BoostEarnedIDCard.tsx
@@ -139,10 +139,14 @@ export const BoostEarnedIDCard: React.FC<BoostEarnedIDCardProps> = ({
                         }
                         customDescription={customDescription}
                         titleOverride={cardTitle}
-                        qrCodeOnClick={() => {
-                            closePreviewModal();
-                            presentShareBoostLink();
-                        }}
+                        qrCodeOnClick={
+                            canShare
+                                ? () => {
+                                      closePreviewModal();
+                                      presentShareBoostLink();
+                                  }
+                                : undefined
+                        }
                         customBodyCardComponent={undefined as any}
                         customFooterComponent={undefined as any}
                         customIssueHistoryComponent={undefined as any}
@@ -205,7 +209,7 @@ export const BoostEarnedIDCard: React.FC<BoostEarnedIDCardProps> = ({
         credentialSubject = {},
     } = mappedInputs;
 
-    const { handlePresentBoostMenuModal } = useBoostMenu(
+    const { handlePresentBoostMenuModal, canShare } = useBoostMenu(
         credential as any,
         (uri || '') as string,
         credential as any,
@@ -293,12 +297,14 @@ export const BoostEarnedIDCard: React.FC<BoostEarnedIDCardProps> = ({
     const credentialComponentDisplay = isBoost ? BoostPreview : VCDisplayCardWrapper;
 
     const presentShareBoostLink = () => {
-        if (!credential) return;
+        if (!credential || !canShare) return;
 
         newPreviewModal(
             <ShareTroopIdModal
-                credential={(credential as any).boostCredential ?? credential}
-                uri={(credential as any).boostId ?? uri}
+                credential={
+                    (credential as VC & { boostCredential?: VC }).boostCredential ?? credential
+                }
+                uri={(credential as VC & { boostId?: string }).boostId ?? uri ?? ''}
             />,
             { sectionClassName: '!bg-transparent !shadow-none !max-w-[355px]' },
             { desktop: ModalTypes.Cancel, mobile: ModalTypes.Cancel }
@@ -363,10 +369,14 @@ export const BoostEarnedIDCard: React.FC<BoostEarnedIDCardProps> = ({
         <ErrorBoundary fallback={<div>Something went wrong</div>}>
             <IdDisplayContainer
                 showQRCode
-                handleQRCodeClick={() => {
-                    closePreviewModal();
-                    presentShareBoostLink();
-                }}
+                handleQRCodeClick={
+                    canShare
+                        ? () => {
+                              closePreviewModal();
+                              presentShareBoostLink();
+                          }
+                        : undefined
+                }
                 achievementType={cred?.credentialSubject?.achievement?.achievementType}
                 title={cardTitle}
                 subtitle={subtitle}
@@ -393,6 +403,8 @@ export const BoostEarnedIDCard: React.FC<BoostEarnedIDCardProps> = ({
                 idSleeveFooterClass={idSleeveFooterClass}
                 issueeThumbnail={issueeThumbnail}
                 cred={credential}
+                credentialUri={uri}
+                canShare={canShare}
                 boostPageViewMode={boostPageViewMode}
                 loading={showSkeleton}
             />

--- a/apps/scouts/src/components/boost/boost-options-menu/BoostOptionsMenu.tsx
+++ b/apps/scouts/src/components/boost/boost-options-menu/BoostOptionsMenu.tsx
@@ -23,6 +23,7 @@ type BoostOptionsMenuProps = {
     boostUri: string;
     menuType?: BoostMenuType;
     categoryType?: string;
+    showShareButton?: boolean;
 };
 
 const BoostOptionsMenu: React.FC<BoostOptionsMenuProps> = ({
@@ -36,6 +37,7 @@ const BoostOptionsMenu: React.FC<BoostOptionsMenuProps> = ({
     boostUri,
     menuType,
     categoryType,
+    showShareButton,
 }) => {
     const confirm = useConfirmation();
 
@@ -118,7 +120,7 @@ const BoostOptionsMenu: React.FC<BoostOptionsMenuProps> = ({
         });
     }
 
-    if (menuType === BoostMenuType.earned) {
+    if (menuType === BoostMenuType.earned && showShareButton) {
         boostMenuOptions.push({
             id: 2,
             title: 'Share',

--- a/apps/scouts/src/components/boost/hooks/useBoostMenu.tsx
+++ b/apps/scouts/src/components/boost/hooks/useBoostMenu.tsx
@@ -33,9 +33,15 @@ const useBoostMenu = (
     onDelete?: () => void
 ) => {
     const { isLoading } = useGetBoost(boost?.boostId);
-    const { status: credentialStatus } = useTroopIDStatus({ credential: boost });
-    const isRevokedOrPending = isCredentialActionRestricted(credentialStatus);
     const isTroopID = isTroopCategory(categoryType as BoostCategoryOptionsEnum);
+    const { status: credentialStatus, isLoading: statusLoading } = useTroopIDStatus({
+        credential: boost as unknown as VC,
+        credentialUri: boostUri,
+        enabled: menuType === BoostMenuType.earned && isTroopID,
+    });
+    const isRevokedOrPending = isCredentialActionRestricted(credentialStatus);
+    const canShare =
+        !isTroopID || (!statusLoading && !isCredentialActionRestricted(credentialStatus));
 
     const showDeleteButton = (!isLoading && isRevokedOrPending && isTroopID) || !isTroopID;
 
@@ -51,6 +57,8 @@ const useBoostMenu = (
     const { mutate: shareEarnedBoost } = useShareBoostMutation();
 
     const handleShareBoost = async () => {
+        if (!canShare) return false;
+
         try {
             const res = await shareEarnedBoost({
                 credential: boostCredential,
@@ -87,6 +95,7 @@ const useBoostMenu = (
                 handleShareBoost={handleShareBoost}
                 menuType={menuType}
                 categoryType={categoryType}
+                showShareButton={menuType === BoostMenuType.earned && canShare}
             />,
             { sectionClassName: '!max-w-[400px]' }
         );
@@ -96,6 +105,7 @@ const useBoostMenu = (
         handlePresentBoostMenuModal,
         handleShareBoost,
         handleDeleteBoost,
+        canShare,
     };
 };
 

--- a/apps/scouts/src/components/boost/hooks/useBoostMenu.tsx
+++ b/apps/scouts/src/components/boost/hooks/useBoostMenu.tsx
@@ -12,6 +12,7 @@ import {
     BoostCategoryOptionsEnum,
 } from 'learn-card-base';
 import { useTroopIDStatus } from '../../../pages/troop/TroopIdStatusButton';
+import { isCredentialActionRestricted } from '../../../pages/troop/troopIdStatus.helpers';
 
 import { isTroopCategory } from '../../../helpers/troop.helpers';
 
@@ -32,8 +33,8 @@ const useBoostMenu = (
     onDelete?: () => void
 ) => {
     const { isLoading } = useGetBoost(boost?.boostId);
-    const credentialStatus = useTroopIDStatus(boost, undefined, boost?.boostId);
-    const isRevokedOrPending = credentialStatus === 'revoked' || credentialStatus === 'pending';
+    const { status: credentialStatus } = useTroopIDStatus({ credential: boost });
+    const isRevokedOrPending = isCredentialActionRestricted(credentialStatus);
     const isTroopID = isTroopCategory(categoryType as BoostCategoryOptionsEnum);
 
     const showDeleteButton = (!isLoading && isRevokedOrPending && isTroopID) || !isTroopID;

--- a/apps/scouts/src/hooks/useTroopMembers.tsx
+++ b/apps/scouts/src/hooks/useTroopMembers.tsx
@@ -13,14 +13,17 @@ import {
 import { MemberTabsEnum } from '../pages/troop/TroopPageMembersBox';
 import { VC } from '@learncard/types';
 import { getLogger } from 'learn-card-base';
+import type { TroopIdIssuanceState } from '../pages/troop/troopIdStatus.helpers';
 const log = getLogger('use-troop-members');
 
-type MemberRow = {
+export type MemberRow = {
     name: string;
     image: string;
     profileId: string;
     type: 'Scout' | 'Leader' | 'Admin';
     boostUri: string;
+    credentialUri?: string;
+    issuanceState: TroopIdIssuanceState;
     isPersonalId: boolean;
     canManageId: boolean;
 };
@@ -51,9 +54,9 @@ export const useTroopMembers = (credential: VC, tab?: MemberTabsEnum, boostUri?:
     const { data: currentBoostCount } = useCountBoostRecipients(uri);
 
     const skipMembers = tab === undefined;
-    const { data: scoutRecipients } = useGetBoostRecipients(scoutBoostUri, !skipMembers);
-    const { data: leaderRecipients } = useGetBoostRecipients(troopBoostUri, !skipMembers);
-    const { data: currentBoostRecipients } = useGetBoostRecipients(uri, !skipMembers);
+    const { data: scoutRecipients } = useGetBoostRecipients(scoutBoostUri, !skipMembers, true);
+    const { data: leaderRecipients } = useGetBoostRecipients(troopBoostUri, !skipMembers, true);
+    const { data: currentBoostRecipients } = useGetBoostRecipients(uri, !skipMembers, true);
 
     const getBoostPermissionsAsync = async (profileId: string) => {
         const wallet = await initWallet();
@@ -80,6 +83,8 @@ export const useTroopMembers = (credential: VC, tab?: MemberTabsEnum, boostUri?:
                             image: scout.to.image ?? '',
                             type: 'Scout',
                             boostUri: scoutBoostUri,
+                            credentialUri: scout.uri,
+                            issuanceState: scout.received ? 'accepted' : 'pending',
                             isPersonalId: scout.to.profileId === myProfileId,
                             canManageId: false,
                         });
@@ -94,6 +99,8 @@ export const useTroopMembers = (credential: VC, tab?: MemberTabsEnum, boostUri?:
                             image: leader.to.image ?? '',
                             type: 'Leader',
                             boostUri: troopBoostUri,
+                            credentialUri: leader.uri,
+                            issuanceState: leader.received ? 'accepted' : 'pending',
                             isPersonalId: leader.to.profileId === myProfileId,
                             canManageId: false,
                         });
@@ -120,6 +127,8 @@ export const useTroopMembers = (credential: VC, tab?: MemberTabsEnum, boostUri?:
                                 image: recipient.to.image ?? '',
                                 type: 'Admin',
                                 boostUri: uri,
+                                credentialUri: recipient.uri,
+                                issuanceState: recipient.received ? 'accepted' : 'pending',
                                 isPersonalId: recipient.to.profileId === myProfileId,
                                 canManageId: Boolean(userPermissions?.canManage),
                             });
@@ -136,6 +145,8 @@ export const useTroopMembers = (credential: VC, tab?: MemberTabsEnum, boostUri?:
                             image: recipient.to.image ?? '',
                             type: 'Admin',
                             boostUri: uri,
+                            credentialUri: recipient.uri,
+                            issuanceState: recipient.received ? 'accepted' : 'pending',
                             isPersonalId: recipient.to.profileId === myProfileId,
                             canManageId: false,
                         });

--- a/apps/scouts/src/pages/ids/IdDisplayContainer.tsx
+++ b/apps/scouts/src/pages/ids/IdDisplayContainer.tsx
@@ -59,6 +59,8 @@ type IdDisplayContainerProps = {
     cred?: VC;
     showQRCode?: boolean;
     handleQRCodeClick?: () => void;
+    credentialUri?: string;
+    canShare?: boolean;
     boostPageViewMode?: BoostPageViewModeType;
     loading?: boolean;
 };
@@ -91,6 +93,8 @@ const IdDisplayContainer: React.FC<IdDisplayContainerProps> = ({
     cred,
     showQRCode = false,
     handleQRCodeClick = () => {},
+    credentialUri,
+    canShare = true,
     boostPageViewMode = BoostPageViewMode.Card,
     loading,
 }) => {
@@ -165,6 +169,7 @@ const IdDisplayContainer: React.FC<IdDisplayContainerProps> = ({
                         <div className="w-full absolute top-[30px] right-[35px]">
                             <TroopIdStatusButton
                                 credential={cred?.boostCredential ?? cred}
+                                credentialUri={credentialUri}
                                 skeletonStyles={{
                                     padding: '8px 14px 8px 14px',
                                     width: '100px',
@@ -278,6 +283,7 @@ const IdDisplayContainer: React.FC<IdDisplayContainerProps> = ({
                 newModal(
                     <TroopPage
                         credential={cred.boostCredential ?? cred}
+                        credentialUri={credentialUri}
                         handleShare={handleQRCodeClick}
                     />
                 );
@@ -375,7 +381,7 @@ const IdDisplayContainer: React.FC<IdDisplayContainerProps> = ({
                             mainClassName="!pt-[15px] pb-[22px] !items-start"
                             hideFooter
                         />
-                        {!loading && (
+                        {!loading && canShare && (
                             <button
                                 onClick={e => {
                                     e.stopPropagation();

--- a/apps/scouts/src/pages/troop/IdOptionsModal.tsx
+++ b/apps/scouts/src/pages/troop/IdOptionsModal.tsx
@@ -22,7 +22,7 @@ import {
 import { getScoutsRole } from '../../helpers/troop.helpers';
 import { VC } from '@learncard/types';
 import { LoadingSpinner } from 'learn-card-base/components/loaders/LoadingSpinner';
-import { getGroupRemovalOutcome } from './groupRemoval.helpers';
+import { getGroupRemovalOutcome, isRemovableGroupMemberRole } from './groupRemoval.helpers';
 import type { TroopIdIssuanceState } from './troopIdStatus.helpers';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('id-options-modal');
@@ -71,7 +71,7 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
     const role = getScoutsRole(credential);
     const troopOrNetwork =
         role === ScoutsRoleEnum.scout || role === ScoutsRoleEnum.leader ? 'Troop' : 'Network';
-    const isScoutMember = type === 'Scout' || type === 'Member';
+    const isRemovableGroupMember = isRemovableGroupMemberRole(type);
 
     const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
     const displayCredential =
@@ -208,7 +208,7 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
             {/* Remove Scout option - for troop leaders/admins removing non-admin members */}
             {!isPersonalId &&
                 (isTroopLeader || canManageId || hasGlobalAdminID) &&
-                isScoutMember && (
+                isRemovableGroupMember && (
                     <IdOptionRow
                         text={isRevoking ? 'Removing...' : `Remove from ${troopOrNetwork}`}
                         icon={isRevoking ? <LoadingSpinner /> : <PeaceIcon />}

--- a/apps/scouts/src/pages/troop/IdOptionsModal.tsx
+++ b/apps/scouts/src/pages/troop/IdOptionsModal.tsx
@@ -14,14 +14,16 @@ import {
     useGetCurrentUserTroopIds,
     useModal,
     useResolveBoost,
-    useRevokeBoostRecipient,
+    useRevokeBoostRecipientGroup,
     useToast,
     ToastTypeEnum,
     useWallet,
 } from 'learn-card-base';
 import { getScoutsRole } from '../../helpers/troop.helpers';
 import { VC } from '@learncard/types';
-import { PermissionsByRole } from '../../components/troopsCMS/troops.helpers';
+import { LoadingSpinner } from 'learn-card-base/components/loaders/LoadingSpinner';
+import { getGroupRemovalOutcome } from './groupRemoval.helpers';
+import type { TroopIdIssuanceState } from './troopIdStatus.helpers';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('id-options-modal');
 
@@ -34,6 +36,8 @@ type IdOptionsModalProps = {
     boostUri: string;
     handleShare: () => void;
     credential: VC;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
     type?: string;
 };
 
@@ -46,6 +50,8 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
     boostUri,
     handleShare,
     credential,
+    credentialUri,
+    issuanceState,
     type,
 }) => {
     const { initWallet } = useWallet();
@@ -60,22 +66,25 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
     const hasGlobalAdminID = troopIds?.isScoutGlobalAdmin;
     const isTroopLeader = troopIds?.isTroopLeader;
 
-    const { mutateAsync: revokeBoostRecipient, isPending: isRevoking } = useRevokeBoostRecipient();
+    const { mutateAsync: revokeGroup, isPending: isRevoking } = useRevokeBoostRecipientGroup();
 
     const role = getScoutsRole(credential);
     const troopOrNetwork =
         role === ScoutsRoleEnum.scout || role === ScoutsRoleEnum.leader ? 'Troop' : 'Network';
     const isScoutMember = type === 'Scout' || type === 'Member';
 
-    const { data: resolvedCredential } = useResolveBoost(boostUri);
-    const _credential = resolvedCredential ?? credential;
+    const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
+    const displayCredential =
+        resolvedCredential?.boostCredential ?? resolvedCredential ?? credential;
 
     const handleViewId = () => {
         closeModal();
         newModal(
             <ViewTroopIdModal
-                credential={_credential}
+                credential={displayCredential}
                 boostUri={boostUri}
+                credentialUri={credentialUri}
+                issuanceState={issuanceState}
                 handleShare={handleShare}
                 name={ownerName}
                 image={ownerImage}
@@ -87,28 +96,39 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
 
     const handleViewJson = () => {
         closeModal();
-        newModal(<ViewJsonModal boost={_credential} />, {
+        newModal(<ViewJsonModal boost={displayCredential} />, {
             sectionClassName: '!max-h-[90%] !mx-[20px]',
         });
     };
 
-    const handleRevokeScout = async () => {
+    const handleRemoveFromGroup = async (): Promise<void> => {
         await confirm({
             text: `Are you sure you want to remove ${ownerName} from ${credential?.name}?`,
             onConfirm: async () => {
                 try {
-                    await revokeBoostRecipient({
+                    const result = await revokeGroup({
                         boostUri,
                         recipientProfileId: ownerProfileId,
                     });
+
+                    if (getGroupRemovalOutcome(result) === 'partial') {
+                        presentToast(
+                            `Some IDs could not be revoked. Please try removing ${ownerName} again.`,
+                            { type: ToastTypeEnum.Error, hasDismissButton: true }
+                        );
+                        return;
+                    }
+
                     presentToast(`${ownerName} has been removed from ${credential?.name}`, {
                         type: ToastTypeEnum.Success,
+                        hasDismissButton: true,
                     });
                     closeAllModals();
                 } catch (error) {
-                    log.error('Failed to revoke scout:', error);
+                    log.error('Failed to remove group member', error);
                     presentToast(`Failed to remove ${ownerName}. Please try again.`, {
                         type: ToastTypeEnum.Error,
+                        hasDismissButton: true,
                     });
                 }
             },
@@ -121,6 +141,7 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
 
     const handleRevoke = async () => {
         const wallet = await initWallet();
+        void wallet;
 
         if (isPersonalId) {
             await confirm({
@@ -128,29 +149,6 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
                 onConfirm: () => {
                     log.debug('TODO revoke');
                     // closeAllModals();
-                },
-                cancelButtonClassName:
-                    'cancel-btn text-grayscale-900 bg-grayscale-200 py-2 rounded-[40px] font-bold px-2 w-[100px] ',
-                confirmButtonClassName:
-                    'confirm-btn bg-grayscale-900 text-white py-2 rounded-[40px] font-bold px-2 w-[100px]',
-            });
-        } else {
-            await confirm({
-                text: `Are you sure you want to remove ${ownerName} from ${credential?.name}?`,
-                onConfirm: async () => {
-                    const removedAdmin = await wallet?.invoke?.removeBoostAdmin(
-                        boostUri,
-                        ownerProfileId
-                    );
-
-                    const updates = PermissionsByRole.troop;
-                    const updatedPermissions = await wallet?.invoke?.updateBoostPermissions(
-                        boostUri,
-                        { ...updates },
-                        ownerProfileId
-                    );
-
-                    closeAllModals();
                 },
                 cancelButtonClassName:
                     'cancel-btn text-grayscale-900 bg-grayscale-200 py-2 rounded-[40px] font-bold px-2 w-[100px] ',
@@ -201,9 +199,10 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
             )}
             {!isPersonalId && (canManageId || hasGlobalAdminID) && type === 'Admin' && (
                 <IdOptionRow
-                    text={`Remove from ${troopOrNetwork}`}
-                    icon={<PeaceIcon />}
-                    onClick={handleRevoke}
+                    text={isRevoking ? 'Removing...' : `Remove from ${troopOrNetwork}`}
+                    icon={isRevoking ? <LoadingSpinner /> : <PeaceIcon />}
+                    onClick={handleRemoveFromGroup}
+                    disabled={isRevoking}
                 />
             )}
             {/* Remove Scout option - for troop leaders/admins removing non-admin members */}
@@ -211,9 +210,10 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
                 (isTroopLeader || canManageId || hasGlobalAdminID) &&
                 isScoutMember && (
                     <IdOptionRow
-                        text={`Remove from ${troopOrNetwork}`}
-                        icon={<PeaceIcon />}
-                        onClick={handleRevokeScout}
+                        text={isRevoking ? 'Removing...' : `Remove from ${troopOrNetwork}`}
+                        icon={isRevoking ? <LoadingSpinner /> : <PeaceIcon />}
+                        onClick={handleRemoveFromGroup}
+                        disabled={isRevoking}
                     />
                 )}
         </div>
@@ -224,13 +224,15 @@ type IdOptionRowProps = {
     text: string;
     icon: React.ReactNode;
     onClick: () => void;
+    disabled?: boolean;
 };
 
-const IdOptionRow: React.FC<IdOptionRowProps> = ({ text, icon, onClick }) => {
+const IdOptionRow: React.FC<IdOptionRowProps> = ({ text, icon, onClick, disabled = false }) => {
     return (
         <button
             onClick={onClick}
-            className="flex gap-[10px] items-center py-[10px] text-grayscale-900 border-b-[1px] border-grayscale-200 border-solid last:border-b-0 h-[56px]"
+            disabled={disabled}
+            className="flex gap-[10px] items-center py-[10px] text-grayscale-900 border-b-[1px] border-grayscale-200 border-solid last:border-b-0 h-[56px] disabled:opacity-40 disabled:cursor-not-allowed"
         >
             <span className="font-notoSans text-[17px]">{text}</span>
             <div className="ml-auto">{icon}</div>

--- a/apps/scouts/src/pages/troop/IdOptionsModal.tsx
+++ b/apps/scouts/src/pages/troop/IdOptionsModal.tsx
@@ -23,7 +23,8 @@ import { getScoutsRole } from '../../helpers/troop.helpers';
 import { VC } from '@learncard/types';
 import { LoadingSpinner } from 'learn-card-base/components/loaders/LoadingSpinner';
 import { getGroupRemovalOutcome, isRemovableGroupMemberRole } from './groupRemoval.helpers';
-import type { TroopIdIssuanceState } from './troopIdStatus.helpers';
+import { canSharePersonalTroopId, type TroopIdIssuanceState } from './troopIdStatus.helpers';
+import { useTroopIDStatus } from './TroopIdStatusButton';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('id-options-modal');
 
@@ -76,6 +77,18 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
     const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
     const displayCredential =
         resolvedCredential?.boostCredential ?? resolvedCredential ?? credential;
+    const { status: personalCredentialStatus, isLoading: personalLifecycleLoading } =
+        useTroopIDStatus({
+            credential: displayCredential,
+            credentialUri,
+            issuanceState,
+            enabled: isPersonalId && Boolean(credentialUri),
+        });
+    const canSharePersonalId = canSharePersonalTroopId({
+        isPersonalId,
+        lifecycleLoading: personalLifecycleLoading,
+        status: personalCredentialStatus,
+    });
 
     const handleViewId = () => {
         closeModal();
@@ -177,7 +190,7 @@ const IdOptionsModal: React.FC<IdOptionsModalProps> = ({
 
             <IdOptionRow text="View Troop ID" icon={<GreenScoutsIdCard />} onClick={handleViewId} />
 
-            {isPersonalId && (
+            {canSharePersonalId && (
                 <IdOptionRow
                     text="Share ID"
                     icon={<ReplyIcon size="30" filled={false} />}

--- a/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
+++ b/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect } from 'react';
 
 import { BoostSkeleton } from 'learn-card-base/components/boost/boostSkeletonLoaders/BoostSkeletons';
-
+import { useGetBoost, useCredentialStatus, type CredentialStatusResult } from 'learn-card-base';
 import useVerifyCredential from 'learn-card-base/hooks/useVerifyCredential';
-import { useGetBoost, useGetBoostRecipients, useGetCurrentLCNUser, useGetIDs } from 'learn-card-base';
+
+import { VC, VerificationStatusEnum } from '@learncard/types';
 
 import { isCredentialExpired } from '../../components/boost/boostHelpers';
-import { VC, VerificationStatusEnum } from '@learncard/types';
+import {
+    deriveTroopIdStatus,
+    type TroopIdCredentialStatus,
+    type TroopIdIssuanceState,
+} from './troopIdStatus.helpers';
 
 enum TroopIdStatusEnum {
     Valid,
@@ -14,129 +19,80 @@ enum TroopIdStatusEnum {
     Expired,
     Revoked,
     Pending,
+    Suspended,
+    Unavailable,
 }
 
-type TroopIdStatusButtonProps = {
+export interface TroopIdStatusButtonProps {
     credential: VC;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
+    lifecycleEnabled?: boolean;
     checkProof?: boolean;
     onClick?: () => void;
     skeletonStyles?: React.CSSProperties;
     isHidden?: boolean;
-    otherUserProfileID?: string;
-};
+}
 
-// Status type for credential state
-export type TroopIdCredentialStatus = 'valid' | 'pending' | 'revoked' | undefined;
+export interface UseTroopIdStatusOptions {
+    credential?: VC;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
+    enabled?: boolean;
+}
 
-/**
- * Check the status of a troop ID credential.
- * Returns: 'valid' (claimed), 'pending' (sent but not claimed), 'revoked', or undefined (loading)
- */
-export const useTroopIDStatus = (
-    credential: VC,
-    otherUserProfileID?: string,
-    boostUri?: string
-): TroopIdCredentialStatus => {
-    const { currentLCNUser } = useGetCurrentLCNUser();
-    const profileId = otherUserProfileID ?? currentLCNUser?.profileId;
-    const _boostUri = credential?.boostId || boostUri;
+export interface TroopIdStatusResult extends CredentialStatusResult {
+    status: TroopIdCredentialStatus | undefined;
+}
 
-    // Unconditional (rules of hooks) — used for pre-Feb-13 backcompat check below
-    const { data: walletIds } = useGetIDs();
+export const useTroopIDStatus = ({
+    credential,
+    credentialUri,
+    issuanceState = 'accepted',
+    enabled = true,
+}: UseTroopIdStatusOptions): TroopIdStatusResult => {
+    const lifecycle = useCredentialStatus({
+        credential,
+        uri: credentialUri,
+        enabled: enabled && Boolean(credentialUri),
+    });
 
-    // Query 1: Get claimed recipients only (default: includeUnacceptedBoosts=false)
-    const { 
-        data: claimedRecipients, 
-        isLoading: isLoadingClaimed, 
-        isError: isClaimedError 
-    } = useGetBoostRecipients(_boostUri, true, false);
-
-    // Query 2: Get all recipients including pending (includeUnacceptedBoosts=true)
-    const { 
-        data: allRecipients, 
-        isLoading: isLoadingAll, 
-        isError: isAllError 
-    } = useGetBoostRecipients(_boostUri, true, true);
-
-    // Still loading
-    if (isLoadingClaimed || isLoadingAll) return undefined;
-
-    // Error fetching - could be boost doesn't exist
-    if (isClaimedError || isAllError) return 'revoked';
-
-    // No data yet
-    if (!claimedRecipients || !allRecipients) return undefined;
-
-    // Check if user is in claimed recipients
-    const isInClaimedRecipients = claimedRecipients.some(r => r.to.profileId === profileId);
-    if (isInClaimedRecipients) return 'valid';
-
-    // Check if user is in all recipients (includes pending)
-    const isInAllRecipients = allRecipients.some(r => r.to.profileId === profileId);
-    if (isInAllRecipients) {
-        // Backcompat for pre-Feb-13 credentials: the old acceptance flow added credentials
-        // to the LearnCloud wallet index directly without calling acceptCredential on the
-        // brain-service, so CREDENTIAL_SENT exists but CREDENTIAL_RECEIVED was never created.
-        // If the credential is already in the user's local wallet, treat it as claimed.
-        // This is safe because revoked credentials are excluded from BOTH recipient queries
-        // (status='revoked' filter), so they show as 'revoked' — this check only fires for
-        // 'pending' and cannot accidentally override a real revocation.
-        // Only applies to the current user's own credentials (not admin viewing another user).
-        if (!otherUserProfileID && walletIds) {
-            const credBoostId = credential?.boostId;
-            const isInWallet =
-                credBoostId &&
-                walletIds.some(
-                    (id: any) => id?.boostId === credBoostId || id?.vc?.boostId === credBoostId
-                );
-            if (isInWallet) return 'valid';
-        }
-        return 'pending';
-    }
-
-    // Not in any list - revoked
-    return 'revoked';
-};
-
-// Legacy compatibility wrapper
-export const useIsTroopIDRevoked = (
-    credential: VC,
-    otherUserProfileID?: string,
-    boostUri?: string
-): boolean | undefined => {
-    const status = useTroopIDStatus(credential, otherUserProfileID, boostUri);
-    if (status === undefined) return undefined;
-    return status === 'revoked';
-};
-
-/** @deprecated Use useTroopIDStatus instead */
-export const useIsTroopIDRevokedFake = (
-    credential: VC,
-    _isError: boolean,
-    _error: any,
-    otherUserProfileID?: string,
-    boostUri?: string
-): boolean => {
-    const result = useIsTroopIDRevoked(credential, otherUserProfileID, boostUri);
-    return result ?? false;
+    return {
+        ...lifecycle,
+        status: deriveTroopIdStatus({
+            lifecycleStatus: lifecycle.status,
+            issuanceState,
+            isLoading: lifecycle.isLoading,
+        }),
+    };
 };
 
 const TroopIdStatusButton: React.FC<TroopIdStatusButtonProps> = ({
     credential,
+    credentialUri,
+    issuanceState,
+    lifecycleEnabled = true,
     checkProof = true,
     onClick,
     skeletonStyles,
     isHidden,
-    otherUserProfileID,
 }) => {
     const { verifyCredential, worstVerificationStatus } = useVerifyCredential(checkProof);
-    const { isLoading, error, isError } = useGetBoost(credential?.boostId);
+    const { isLoading: isProofLoading } = useGetBoost(credential?.boostId);
+    const {
+        status: credentialStatus,
+        isLoading: isLifecycleLoading,
+        isError: isLifecycleError,
+    } = useTroopIDStatus({
+        credential,
+        credentialUri,
+        issuanceState,
+        enabled: lifecycleEnabled,
+    });
 
     useEffect(() => {
         verifyCredential(credential);
     }, [checkProof, credential]);
-
-    const credentialStatus = useTroopIDStatus(credential, otherUserProfileID);
 
     let status: TroopIdStatusEnum = TroopIdStatusEnum.Valid;
     if (isCredentialExpired(credential)) {
@@ -146,8 +102,12 @@ const TroopIdStatusButton: React.FC<TroopIdStatusButtonProps> = ({
         worstVerificationStatus !== VerificationStatusEnum.Success
     ) {
         status = TroopIdStatusEnum.Invalid;
+    } else if (isLifecycleError) {
+        status = TroopIdStatusEnum.Unavailable;
     } else if (credentialStatus === 'revoked') {
         status = TroopIdStatusEnum.Revoked;
+    } else if (credentialStatus === 'suspended') {
+        status = TroopIdStatusEnum.Suspended;
     } else if (credentialStatus === 'pending') {
         status = TroopIdStatusEnum.Pending;
     }
@@ -175,13 +135,21 @@ const TroopIdStatusButton: React.FC<TroopIdStatusButtonProps> = ({
             text = 'Pending Acceptance';
             buttonColor = 'bg-amber-500';
             break;
+        case TroopIdStatusEnum.Suspended:
+            text = 'ID Suspended';
+            buttonColor = 'bg-amber-500';
+            break;
+        case TroopIdStatusEnum.Unavailable:
+            text = 'Status Unavailable';
+            buttonColor = 'bg-amber-500';
+            break;
     }
 
     if (isHidden) return <></>;
 
     return (
         <>
-            {isLoading ? (
+            {isProofLoading || isLifecycleLoading ? (
                 <BoostSkeleton
                     containerClassName="rounded-full w-full flex items-center justify-end relative"
                     skeletonStyles={skeletonStyles}

--- a/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
+++ b/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { BoostSkeleton } from 'learn-card-base/components/boost/boostSkeletonLoaders/BoostSkeletons';
-import { useGetBoost, useCredentialStatus, type CredentialStatusResult } from 'learn-card-base';
+import { useGetBoost, useCredentialStatus } from 'learn-card-base';
 import useVerifyCredential from 'learn-card-base/hooks/useVerifyCredential';
 
 import { VC, VerificationStatusEnum } from '@learncard/types';
@@ -10,9 +10,9 @@ import { isCredentialExpired } from '../../components/boost/boostHelpers';
 import {
     deriveTroopIdStatus,
     shouldShowTroopIdStatus,
-    type TroopIdCredentialStatus,
     type TroopIdIssuanceState,
 } from './troopIdStatus.helpers';
+import type { TroopIdStatusResult } from './troopIdStatus.types';
 
 enum TroopIdStatusEnum {
     Valid,
@@ -40,10 +40,6 @@ export interface UseTroopIdStatusOptions {
     credentialUri?: string;
     issuanceState?: TroopIdIssuanceState;
     enabled?: boolean;
-}
-
-export interface TroopIdStatusResult extends CredentialStatusResult {
-    status: TroopIdCredentialStatus | undefined;
 }
 
 export const useTroopIDStatus = ({

--- a/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
+++ b/apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
@@ -9,6 +9,7 @@ import { VC, VerificationStatusEnum } from '@learncard/types';
 import { isCredentialExpired } from '../../components/boost/boostHelpers';
 import {
     deriveTroopIdStatus,
+    shouldShowTroopIdStatus,
     type TroopIdCredentialStatus,
     type TroopIdIssuanceState,
 } from './troopIdStatus.helpers';
@@ -63,6 +64,8 @@ export const useTroopIDStatus = ({
             lifecycleStatus: lifecycle.status,
             issuanceState,
             isLoading: lifecycle.isLoading,
+            isError: lifecycle.isError,
+            lifecycleEnabled: enabled && Boolean(credentialUri),
         }),
     };
 };
@@ -145,7 +148,7 @@ const TroopIdStatusButton: React.FC<TroopIdStatusButtonProps> = ({
             break;
     }
 
-    if (isHidden) return <></>;
+    if (isHidden || !shouldShowTroopIdStatus({ lifecycleEnabled, credentialUri })) return <></>;
 
     return (
         <>

--- a/apps/scouts/src/pages/troop/TroopPage.tsx
+++ b/apps/scouts/src/pages/troop/TroopPage.tsx
@@ -26,7 +26,7 @@ import {
 } from 'learn-card-base';
 import { VC, VerificationItem, Boost } from '@learncard/types';
 import { useTroopIDStatus } from './TroopIdStatusButton';
-import { isCredentialActionRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
+import { isTroopIdContentRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
 
 type TroopPageProps = {
     credential: VC;
@@ -121,9 +121,11 @@ const TroopPage: React.FC<TroopPageProps> = ({
         issuanceState: holderIssuanceState,
         enabled: ownsCurrentId && Boolean(holderCredentialUri),
     });
-    const isRestricted =
-        !hasParentAdminAccess &&
-        (lifecycleLoading || isCredentialActionRestricted(credentialStatus));
+    const isRestricted = isTroopIdContentRestricted({
+        hasParentAdminAccess,
+        lifecycleLoading,
+        status: credentialStatus,
+    });
 
     const getScoutIdTypeFromBoost = (vc: VC) => {
         return vc?.credentialSubject?.achievement?.achievementType;

--- a/apps/scouts/src/pages/troop/TroopPage.tsx
+++ b/apps/scouts/src/pages/troop/TroopPage.tsx
@@ -26,16 +26,23 @@ import {
 } from 'learn-card-base';
 import { VC, VerificationItem, Boost } from '@learncard/types';
 import { useTroopIDStatus } from './TroopIdStatusButton';
-import { isCredentialActionRestricted } from './troopIdStatus.helpers';
+import { isCredentialActionRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
 
 type TroopPageProps = {
     credential: VC;
     boost?: Boost;
     boostUri?: string;
+    credentialUri?: string;
     handleShare: () => void;
 };
 
-const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri, boost }) => {
+const TroopPage: React.FC<TroopPageProps> = ({
+    credential,
+    handleShare,
+    boostUri,
+    boost,
+    credentialUri,
+}) => {
     const credentialRole = getScoutsRole(credential);
 
     // Get current user's actual permissions to determine if they have elevated access
@@ -78,18 +85,25 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
     const { verifyCredential } = useVerifyCredential();
 
     const currentUser = useGetCurrentLCNUser();
-    const { data: recipients } = useGetBoostRecipients(_boostUri);
+    const { data: recipients } = useGetBoostRecipients(_boostUri, true, true);
 
     const currentUserRecipient = recipients?.find(
         r => r.to.profileId === currentUser?.currentLCNUser?.profileId
     );
-    const ownsCurrentId = recipients ? !!currentUserRecipient : true; // default to true since that's the 99% case
+    const holderCredentialUri = credentialUri ?? currentUserRecipient?.uri;
+    const ownsCurrentId =
+        Boolean(credentialUri) || (recipients ? Boolean(currentUserRecipient) : true);
+    const holderIssuanceState: TroopIdIssuanceState = currentUserRecipient
+        ? currentUserRecipient.received
+            ? 'accepted'
+            : 'pending'
+        : 'accepted';
 
     // Use resolved credential from recipient uri
     //   Handles some problems when you drill down into an ID that you own
     //     e.g. If I open the global ID page -> Networks -> select a network which I own the network ID for
     //     then this will make it so that we're using the "earned" version of that credential (which has a valid proof)
-    const { data: resolvedCredential } = useResolveBoost(currentUserRecipient?.uri);
+    const { data: resolvedCredential } = useResolveBoost(holderCredentialUri);
     _credential = resolvedCredential?.boostCredential ?? _credential;
 
     const { credentialWithEdits, isError, error } = useGetCredentialWithEdits(
@@ -101,12 +115,15 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
         boostSearchStore.set.contextCredential(credentialWithEdits);
     }, [credentialWithEdits]);
 
-    // Check credential status (valid, pending, revoked)
-    const { status: credentialStatus } = useTroopIDStatus({ credential: _credential });
-    // Parent admins should always see content regardless of credential status
-    // (The old revocation logic is being deprecated and may incorrectly mark credentials)
-    const isRevokedOrPending =
-        !hasParentAdminAccess && isCredentialActionRestricted(credentialStatus);
+    const { status: credentialStatus, isLoading: lifecycleLoading } = useTroopIDStatus({
+        credential: _credential,
+        credentialUri: holderCredentialUri,
+        issuanceState: holderIssuanceState,
+        enabled: ownsCurrentId && Boolean(holderCredentialUri),
+    });
+    const isRestricted =
+        !hasParentAdminAccess &&
+        (lifecycleLoading || isCredentialActionRestricted(credentialStatus));
 
     const getScoutIdTypeFromBoost = (vc: VC) => {
         return vc?.credentialSubject?.achievement?.achievementType;
@@ -151,9 +168,11 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
                             handleShare={handleShare}
                             ownsCurrentId={ownsCurrentId}
                             boostUri={_boostUri}
+                            credentialUri={holderCredentialUri}
+                            issuanceState={holderIssuanceState}
                             handleShowIdDetails={() => setShowIdDetails(true)}
                         />
-                        {!isRevokedOrPending && (
+                        {!isRestricted && (
                             <>
                                 <TroopChildrenBox
                                     credential={credential}
@@ -180,7 +199,7 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
                 uri={_boostUri}
                 showIdDetails={showIdDetails}
                 handleShare={handleShare}
-                isRevoked={isRevokedOrPending}
+                isRestricted={isRestricted}
             />
         </section>
     );

--- a/apps/scouts/src/pages/troop/TroopPage.tsx
+++ b/apps/scouts/src/pages/troop/TroopPage.tsx
@@ -26,6 +26,7 @@ import {
 } from 'learn-card-base';
 import { VC, VerificationItem, Boost } from '@learncard/types';
 import { useTroopIDStatus } from './TroopIdStatusButton';
+import { isCredentialActionRestricted } from './troopIdStatus.helpers';
 
 type TroopPageProps = {
     credential: VC;
@@ -54,8 +55,8 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
     // Calculate if user has parent admin access (can view child troop details)
     // canEditChildren is a string: "*" means full access, "" means none
     const hasParentAdminAccess = useMemo(() => {
-        const hasParentEdit = 
-            parentPermissions?.canEdit === true || 
+        const hasParentEdit =
+            parentPermissions?.canEdit === true ||
             (parentPermissions?.canEditChildren && parentPermissions.canEditChildren !== '');
 
         return hasParentEdit || myTroopIds?.isScoutGlobalAdmin || myTroopIds?.isNationalAdmin;
@@ -101,10 +102,11 @@ const TroopPage: React.FC<TroopPageProps> = ({ credential, handleShare, boostUri
     }, [credentialWithEdits]);
 
     // Check credential status (valid, pending, revoked)
-    const credentialStatus = useTroopIDStatus(_credential, undefined, _boostUri);
+    const { status: credentialStatus } = useTroopIDStatus({ credential: _credential });
     // Parent admins should always see content regardless of credential status
     // (The old revocation logic is being deprecated and may incorrectly mark credentials)
-    const isRevokedOrPending = !hasParentAdminAccess && (credentialStatus === 'revoked' || credentialStatus === 'pending');
+    const isRevokedOrPending =
+        !hasParentAdminAccess && isCredentialActionRestricted(credentialStatus);
 
     const getScoutIdTypeFromBoost = (vc: VC) => {
         return vc?.credentialSubject?.achievement?.achievementType;

--- a/apps/scouts/src/pages/troop/TroopPage.tsx
+++ b/apps/scouts/src/pages/troop/TroopPage.tsx
@@ -27,6 +27,7 @@ import {
 import { VC, VerificationItem, Boost } from '@learncard/types';
 import { useTroopIDStatus } from './TroopIdStatusButton';
 import { isTroopIdContentRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
+import { selectHolderRecipient } from './troopPage.helpers';
 
 type TroopPageProps = {
     credential: VC;
@@ -87,8 +88,10 @@ const TroopPage: React.FC<TroopPageProps> = ({
     const currentUser = useGetCurrentLCNUser();
     const { data: recipients } = useGetBoostRecipients(_boostUri, true, true);
 
-    const currentUserRecipient = recipients?.find(
-        r => r.to.profileId === currentUser?.currentLCNUser?.profileId
+    const currentUserRecipient = selectHolderRecipient(
+        recipients,
+        currentUser?.currentLCNUser?.profileId,
+        credentialUri
     );
     const holderCredentialUri = credentialUri ?? currentUserRecipient?.uri;
     const ownsCurrentId =

--- a/apps/scouts/src/pages/troop/TroopPageFooter.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageFooter.tsx
@@ -32,7 +32,7 @@ type TroopPageFooterProps = {
     showIdDetails?: boolean;
     handleDetails?: () => void;
     ownsCurrentId?: boolean;
-    isRevoked?: boolean;
+    isRestricted?: boolean;
 };
 
 const TroopPageFooter: React.FC<TroopPageFooterProps> = ({
@@ -43,7 +43,7 @@ const TroopPageFooter: React.FC<TroopPageFooterProps> = ({
     showIdDetails,
     handleDetails,
     ownsCurrentId,
-    isRevoked,
+    isRestricted,
 }) => {
     const queryClient = useQueryClient();
     const { initWallet } = useWallet();
@@ -183,7 +183,7 @@ const TroopPageFooter: React.FC<TroopPageFooterProps> = ({
         );
     };
 
-    const showEditButton = role !== ScoutsRoleEnum.scout && canEdit;
+    const showEditButton = !isRestricted && role !== ScoutsRoleEnum.scout && canEdit;
 
     if (showEditButton) {
         return (
@@ -228,7 +228,7 @@ const TroopPageFooter: React.FC<TroopPageFooterProps> = ({
                             Back
                         </button>
 
-                        {!isRevoked && (
+                        {!isRestricted && (
                             <button
                                 onClick={handleOptions}
                                 className="bg-white rounded-full text-grayscale-80 py-[10px] px-[12px] shadow-button-bottom"
@@ -249,7 +249,7 @@ const TroopPageFooter: React.FC<TroopPageFooterProps> = ({
                             Back
                         </button>
 
-                        {!isRevoked && (
+                        {!isRestricted && (
                             <button
                                 onClick={handleOptions}
                                 className="bg-white rounded-full text-grayscale-80 py-[10px] px-[12px] shadow-button-bottom"

--- a/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
@@ -8,7 +8,7 @@ import TroopID from './TroopID';
 import ReplyIcon from 'learn-card-base/svgs/ReplyIcon';
 import QRCodeScanner from 'learn-card-base/svgs/QRCodeScanner';
 import TroopIdStatusButton, { useTroopIDStatus } from './TroopIdStatusButton';
-import { isCredentialActionRestricted } from './troopIdStatus.helpers';
+import { isCredentialActionRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
 import TroopIdBoxQRCodeFrame from '../../components/svgs/TroopIdBoxQRCodeFrame';
 import CredentialVerificationDisplay from 'learn-card-base/components/CredentialBadge/CredentialVerificationDisplay';
 import { VC } from '@learncard/types';
@@ -19,6 +19,8 @@ type TroopPageIdAndTroopBoxProps = {
     credential: VC;
     ownsCurrentId: boolean;
     boostUri: string;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
     handleShare: () => void;
     handleShowIdDetails: () => void;
 };
@@ -27,6 +29,8 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
     credential: credentialNoEdits,
     ownsCurrentId,
     boostUri,
+    credentialUri,
+    issuanceState,
     handleShare,
     handleShowIdDetails,
 }) => {
@@ -40,8 +44,12 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
     );
     const credential = credentialWithEdits ?? credentialNoEdits;
 
-    const { status: credentialStatus } = useTroopIDStatus({ credential: credentialNoEdits });
-    const isRevokedOrPending = isCredentialActionRestricted(credentialStatus);
+    const { status: credentialStatus, isLoading: lifecycleLoading } = useTroopIDStatus({
+        credential: credentialNoEdits,
+        credentialUri,
+        issuanceState,
+    });
+    const isRestricted = lifecycleLoading || isCredentialActionRestricted(credentialStatus);
 
     const { network: networkData } = useGetTroopNetwork({ credential });
 
@@ -74,11 +82,12 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
                     <div className="flex justify-center relative pb-[10px]">
                         <button
                             onClick={() => {
-                                if (isRevokedOrPending) return;
+                                if (isRestricted) return;
 
                                 handleShare();
                             }}
-                            className="bg-white rounded-full p-[10px] h-[50px] w-[50px] shadow-box-bottom"
+                            disabled={isRestricted}
+                            className="bg-white rounded-full p-[10px] h-[50px] w-[50px] shadow-box-bottom disabled:opacity-40 disabled:cursor-not-allowed"
                         >
                             <QRCodeScanner className="text-grayscale-900" />
                         </button>
@@ -95,6 +104,8 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
                 {ownsCurrentId && (
                     <TroopIdStatusButton
                         credential={credentialNoEdits}
+                        credentialUri={credentialUri}
+                        issuanceState={issuanceState}
                         onClick={handleShowIdDetails}
                         skeletonStyles={{
                             padding: '8px 14px 8px 14px',

--- a/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
@@ -106,6 +106,7 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
                         credential={credentialNoEdits}
                         credentialUri={credentialUri}
                         issuanceState={issuanceState}
+                        lifecycleEnabled={Boolean(credentialUri)}
                         onClick={handleShowIdDetails}
                         skeletonStyles={{
                             padding: '8px 14px 8px 14px',

--- a/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx
@@ -8,6 +8,7 @@ import TroopID from './TroopID';
 import ReplyIcon from 'learn-card-base/svgs/ReplyIcon';
 import QRCodeScanner from 'learn-card-base/svgs/QRCodeScanner';
 import TroopIdStatusButton, { useTroopIDStatus } from './TroopIdStatusButton';
+import { isCredentialActionRestricted } from './troopIdStatus.helpers';
 import TroopIdBoxQRCodeFrame from '../../components/svgs/TroopIdBoxQRCodeFrame';
 import CredentialVerificationDisplay from 'learn-card-base/components/CredentialBadge/CredentialVerificationDisplay';
 import { VC } from '@learncard/types';
@@ -39,8 +40,8 @@ const TroopPageIdAndTroopBox: React.FC<TroopPageIdAndTroopBoxProps> = ({
     );
     const credential = credentialWithEdits ?? credentialNoEdits;
 
-    const credentialStatus = useTroopIDStatus(credentialNoEdits, undefined, boostUri);
-    const isRevokedOrPending = credentialStatus === 'revoked' || credentialStatus === 'pending';
+    const { status: credentialStatus } = useTroopIDStatus({ credential: credentialNoEdits });
+    const isRevokedOrPending = isCredentialActionRestricted(credentialStatus);
 
     const { network: networkData } = useGetTroopNetwork({ credential });
 

--- a/apps/scouts/src/pages/troop/TroopPageMembersBox.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageMembersBox.tsx
@@ -20,6 +20,7 @@ import { ScoutsRoleEnum } from '../../stores/troopPageStore';
 import { useCanInviteTroop } from './useCanInviteTroop';
 import InviteSelectionModal from './InviteSelectionModal';
 import { VC } from '@learncard/types';
+import { hasReachableMembers } from './troopPage.helpers';
 
 export enum MemberTabsEnum {
     All = 'All',
@@ -192,7 +193,7 @@ const TroopPageMembersBox: React.FC<TroopPageMembersBoxProps> = ({
         [scoutCount, leaderCount, totalCount]
     );
 
-    const membersExist = Number(totalCount) > 0;
+    const membersExist = hasReachableMembers(totalCount, memberRows);
     const containerClasses = `bg-white rounded-[20px] shadow-box-bottom overflow-hidden flex flex-col px-5 pt-5 ${
         membersExist ? 'pb-2.5' : 'pb-5'
     }`;

--- a/apps/scouts/src/pages/troop/TroopPageMembersBox.tsx
+++ b/apps/scouts/src/pages/troop/TroopPageMembersBox.tsx
@@ -168,6 +168,8 @@ const TroopPageMembersBox: React.FC<TroopPageMembersBoxProps> = ({
                     ownerProfileId={member.profileId}
                     handleShare={handleShare}
                     boostUri={member.boostUri}
+                    credentialUri={member.credentialUri}
+                    issuanceState={member.issuanceState}
                     type={member?.type}
                 />,
                 { sectionClassName: '!max-w-[400px]' }

--- a/apps/scouts/src/pages/troop/ViewTroopIdModal.tsx
+++ b/apps/scouts/src/pages/troop/ViewTroopIdModal.tsx
@@ -19,10 +19,14 @@ import { LoadingSpinner } from 'learn-card-base/components/loaders/LoadingSpinne
 
 import { getWallpaperBackgroundStyles } from '../../helpers/troop.helpers';
 import { VC, VerificationItem } from '@learncard/types';
+import { useTroopIDStatus } from './TroopIdStatusButton';
+import { isCredentialActionRestricted, type TroopIdIssuanceState } from './troopIdStatus.helpers';
 
 type ViewTroopIdModalProps = {
     credential: VC;
     boostUri: string;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
     name?: string;
     image?: string;
     profileId?: string;
@@ -47,6 +51,8 @@ type ViewTroopIdModalProps = {
 const ViewTroopIdModal: React.FC<ViewTroopIdModalProps> = ({
     credential,
     boostUri,
+    credentialUri,
+    issuanceState,
     name,
     image,
     profileId,
@@ -75,8 +81,16 @@ const ViewTroopIdModal: React.FC<ViewTroopIdModalProps> = ({
 
     const [showDetails, setShowDetails] = useState(false);
 
-    const { data: resolvedCredential } = useResolveBoost(boostUri);
-    credential = resolvedCredential ?? credential;
+    const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
+    credential = resolvedCredential?.boostCredential ?? resolvedCredential ?? credential;
+
+    const { status, isLoading: statusLoading } = useTroopIDStatus({
+        credential,
+        credentialUri,
+        issuanceState,
+        enabled: Boolean(credentialUri),
+    });
+    const canShare = !statusLoading && !isCredentialActionRestricted(status);
 
     const [verificationItems, setVerificationItems] = useState<VerificationItem[]>([]);
     const { verifyCredential } = useVerifyCredential(!isClaimMode && !skipProofCheck);
@@ -111,9 +125,12 @@ const ViewTroopIdModal: React.FC<ViewTroopIdModalProps> = ({
                     <ViewTroopIdTemplate
                         idMainText={name}
                         idThumb={image}
-                        credential={{ ...credential, boostId: boostUri }}
+                        credential={credential}
+                        boostUri={boostUri}
+                        credentialUri={credentialUri}
+                        issuanceState={issuanceState}
                         divetButton={
-                            handleShare ? (
+                            handleShare && canShare ? (
                                 <button
                                     onClick={handleShare}
                                     className="bg-white rounded-full p-[10px] h-[50px] w-[50px] shadow-box-bottom"
@@ -128,7 +145,6 @@ const ViewTroopIdModal: React.FC<ViewTroopIdModalProps> = ({
                         handleClaim={handleClaimCredential}
                         skipProofCheck={skipProofCheck}
                         showCounts={showCounts}
-                        otherUserProfileID={profileId}
                     />
                 )}
 
@@ -160,7 +176,7 @@ const ViewTroopIdModal: React.FC<ViewTroopIdModalProps> = ({
                             >
                                 {showDetails ? 'Back' : 'Details'}
                             </button>
-                            {handleShare && (
+                            {handleShare && canShare && (
                                 <button
                                     onClick={handleShare}
                                     className="bg-grayscale-800 py-[9px] pl-[20px] pr-[15px] rounded-[30px] font-notoSans text-[17px] font-[600] leading-[24px] tracking-[0.25px] text-white w-full shadow-button-bottom flex gap-[5px] justify-center"

--- a/apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx
+++ b/apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx
@@ -140,7 +140,6 @@ const ViewTroopIdTemplate: React.FC<ViewTroopIdTemplateProps> = ({
                             right: '-10px',
                         }}
                         isHidden={!isAlreadyClaimed}
-                        otherUserProfileID={otherUserProfileID}
                     />
 
                     <div className="flex flex-col items-center gap-[7px]">

--- a/apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx
+++ b/apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx
@@ -20,10 +20,13 @@ import {
 import { VC } from '@learncard/types';
 import { ScoutsRoleEnum } from '../../stores/troopPageStore';
 import { AchievementTypes } from 'learn-card-base/components/IssueVC/constants';
+import { type TroopIdIssuanceState } from './troopIdStatus.helpers';
 
 type ViewTroopIdTemplateProps = {
     credential: VC; // for the ID footer
     boostUri?: string;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
 
     idMainText: string; // line 1
     idSubText?: string; // line 2 override
@@ -41,13 +44,13 @@ type ViewTroopIdTemplateProps = {
     skipProofCheck?: boolean;
 
     showCounts?: boolean;
-
-    otherUserProfileID?: string;
 };
 
 const ViewTroopIdTemplate: React.FC<ViewTroopIdTemplateProps> = ({
     credential,
     boostUri,
+    credentialUri,
+    issuanceState,
 
     idMainText,
     idSubText,
@@ -64,7 +67,6 @@ const ViewTroopIdTemplate: React.FC<ViewTroopIdTemplateProps> = ({
     skipProofCheck,
 
     showCounts = true,
-    otherUserProfileID,
 }) => {
     boostUri = boostUri ?? credential?.boostId;
 
@@ -131,6 +133,9 @@ const ViewTroopIdTemplate: React.FC<ViewTroopIdTemplateProps> = ({
                 <div className="bg-white relative px-[20px] flex flex-col gap-[10px] pb-[10px] pt-[10px]">
                     <TroopIdStatusButton
                         credential={credential}
+                        credentialUri={credentialUri}
+                        issuanceState={issuanceState}
+                        lifecycleEnabled={Boolean(credentialUri)}
                         checkProof={!isGeneralView && !isClaimMode && !skipProofCheck}
                         skeletonStyles={{
                             padding: '8px 14px 8px 14px',
@@ -139,7 +144,7 @@ const ViewTroopIdTemplate: React.FC<ViewTroopIdTemplateProps> = ({
                             top: '-40px',
                             right: '-10px',
                         }}
-                        isHidden={!isAlreadyClaimed}
+                        isHidden={isClaimMode && !isAlreadyClaimed}
                     />
 
                     <div className="flex flex-col items-center gap-[7px]">

--- a/apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { getGroupRemovalOutcome } from '../groupRemoval.helpers';
+
+describe('getGroupRemovalOutcome', () => {
+    it('accepts new and already-revoked complete outcomes', () => {
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: ['credential:1'],
+                alreadyRevokedCredentialUris: [],
+                failedCredentialUris: [],
+            })
+        ).toBe('complete');
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: [],
+                alreadyRevokedCredentialUris: ['credential:1'],
+                failedCredentialUris: [],
+            })
+        ).toBe('complete');
+    });
+
+    it('reports a retryable partial outcome when any URI failed', () => {
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: ['credential:1'],
+                alreadyRevokedCredentialUris: [],
+                failedCredentialUris: ['credential:2'],
+            })
+        ).toBe('partial');
+    });
+});

--- a/apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { getGroupRemovalOutcome } from '../groupRemoval.helpers';
+import { getGroupRemovalOutcome, isRemovableGroupMemberRole } from '../groupRemoval.helpers';
 
 describe('getGroupRemovalOutcome', () => {
     it('accepts new and already-revoked complete outcomes', () => {
@@ -27,5 +27,11 @@ describe('getGroupRemovalOutcome', () => {
                 failedCredentialUris: ['credential:2'],
             })
         ).toBe('partial');
+    });
+});
+
+describe('isRemovableGroupMemberRole', () => {
+    it('allows Leader rows through the unified group removal path', () => {
+        expect(isRemovableGroupMemberRole('Leader')).toBe(true);
     });
 });

--- a/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+    canSharePersonalTroopId,
     deriveTroopIdStatus,
     isCredentialActionRestricted,
     isTroopIdContentRestricted,
@@ -80,4 +81,25 @@ describe('deriveTroopIdStatus', () => {
             })
         ).toBe(false);
     });
+
+    it.each([
+        ['missing', undefined, false, false],
+        ['loading', undefined, true, false],
+        ['error', undefined, false, false],
+        ['pending', 'pending', false, false],
+        ['suspended', 'suspended', false, false],
+        ['revoked', 'revoked', false, false],
+        ['valid', 'valid', false, true],
+    ] as const)(
+        'allows personal Share only for a resolved valid credential (%s)',
+        (_case, status, lifecycleLoading, expected) => {
+            expect(
+                canSharePersonalTroopId({
+                    isPersonalId: true,
+                    lifecycleLoading,
+                    status,
+                })
+            ).toBe(expected);
+        }
+    );
 });

--- a/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+
+import { deriveTroopIdStatus, isCredentialActionRestricted } from '../troopIdStatus.helpers';
+
+describe('deriveTroopIdStatus', () => {
+    it('uses revoked and suspended lifecycle states before issuance state', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'revoked', issuanceState: 'pending' })).toBe(
+            'revoked'
+        );
+        expect(
+            deriveTroopIdStatus({ lifecycleStatus: 'suspended', issuanceState: 'accepted' })
+        ).toBe('suspended');
+    });
+
+    it('uses explicit pending metadata and otherwise reports valid', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', issuanceState: 'pending' })).toBe(
+            'pending'
+        );
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', issuanceState: 'accepted' })).toBe(
+            'valid'
+        );
+    });
+
+    it('keeps loading neutral and restricts actions until resolved', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', isLoading: true })).toBeUndefined();
+        expect(isCredentialActionRestricted(undefined)).toBe(true);
+        expect(isCredentialActionRestricted('valid')).toBe(false);
+        expect(isCredentialActionRestricted('pending')).toBe(true);
+        expect(isCredentialActionRestricted('suspended')).toBe(true);
+        expect(isCredentialActionRestricted('revoked')).toBe(true);
+    });
+});

--- a/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
@@ -29,4 +29,14 @@ describe('deriveTroopIdStatus', () => {
         expect(isCredentialActionRestricted('suspended')).toBe(true);
         expect(isCredentialActionRestricted('revoked')).toBe(true);
     });
+
+    it.each([
+        [undefined, true],
+        ['pending', true],
+        ['suspended', true],
+        ['revoked', true],
+        ['valid', false],
+    ] as const)('maps %s to restricted=%s', (status, expected) => {
+        expect(isCredentialActionRestricted(status)).toBe(expected);
+    });
 });

--- a/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
-import { deriveTroopIdStatus, isCredentialActionRestricted } from '../troopIdStatus.helpers';
+import {
+    deriveTroopIdStatus,
+    isCredentialActionRestricted,
+    isTroopIdContentRestricted,
+    shouldShowTroopIdStatus,
+} from '../troopIdStatus.helpers';
 
 describe('deriveTroopIdStatus', () => {
     it('uses revoked and suspended lifecycle states before issuance state', () => {
@@ -38,5 +43,41 @@ describe('deriveTroopIdStatus', () => {
         ['valid', false],
     ] as const)('maps %s to restricted=%s', (status, expected) => {
         expect(isCredentialActionRestricted(status)).toBe(expected);
+    });
+
+    it('keeps lifecycle errors and missing holder URIs unavailable and restricted', () => {
+        const lifecycleErrorStatus = deriveTroopIdStatus({
+            lifecycleStatus: 'active',
+            isError: true,
+        });
+        const missingHolderUriStatus = deriveTroopIdStatus({
+            lifecycleStatus: 'active',
+            lifecycleEnabled: false,
+        });
+
+        expect(lifecycleErrorStatus).toBeUndefined();
+        expect(isCredentialActionRestricted(lifecycleErrorStatus)).toBe(true);
+        expect(missingHolderUriStatus).toBeUndefined();
+        expect(isCredentialActionRestricted(missingHolderUriStatus)).toBe(true);
+    });
+
+    it('hides URI-less managed status instead of showing a valid holder ID', () => {
+        expect(shouldShowTroopIdStatus({ lifecycleEnabled: false })).toBe(false);
+    });
+
+    it('preserves the explicit parent-admin content bypass without a holder status', () => {
+        const holderStatus = deriveTroopIdStatus({
+            lifecycleStatus: 'active',
+            lifecycleEnabled: false,
+        });
+
+        expect(holderStatus).toBeUndefined();
+        expect(
+            isTroopIdContentRestricted({
+                hasParentAdminAccess: true,
+                lifecycleLoading: false,
+                status: holderStatus,
+            })
+        ).toBe(false);
     });
 });

--- a/apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts
+++ b/apps/scouts/src/pages/troop/__tests__/troopPage.helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+
+import { hasReachableMembers, selectHolderRecipient } from '../troopPage.helpers';
+
+describe('selectHolderRecipient', () => {
+    it('uses the exact credential URI when one profile has multiple issuances', () => {
+        const recipients = [
+            {
+                uri: 'lc:credential:pending-sibling',
+                received: undefined,
+                to: { profileId: 'scout-1' },
+            },
+            {
+                uri: 'lc:credential:accepted-holder',
+                received: { date: '2026-08-10T12:00:00.000Z' },
+                to: { profileId: 'scout-1' },
+            },
+        ];
+
+        expect(
+            selectHolderRecipient(recipients, 'scout-1', 'lc:credential:accepted-holder')?.uri
+        ).toBe('lc:credential:accepted-holder');
+    });
+
+    it('falls back to the profile only when there is no exact holder URI', () => {
+        const recipients = [
+            {
+                uri: 'lc:credential:profile-fallback',
+                received: undefined,
+                to: { profileId: 'scout-1' },
+            },
+        ];
+
+        expect(selectHolderRecipient(recipients, 'scout-1')?.uri).toBe(
+            'lc:credential:profile-fallback'
+        );
+        expect(
+            selectHolderRecipient(recipients, 'scout-1', 'lc:credential:missing-exact')
+        ).toBeUndefined();
+    });
+});
+
+describe('hasReachableMembers', () => {
+    it('keeps pending-only member controls reachable without inflating accepted counts', () => {
+        const pendingRows = [{ issuanceState: 'pending' }];
+
+        expect(hasReachableMembers(0, pendingRows)).toBe(true);
+    });
+
+    it('hides member controls when both accepted counts and visible rows are empty', () => {
+        expect(hasReachableMembers(0, [])).toBe(false);
+    });
+});

--- a/apps/scouts/src/pages/troop/groupRemoval.helpers.ts
+++ b/apps/scouts/src/pages/troop/groupRemoval.helpers.ts
@@ -5,3 +5,6 @@ export type GroupRemovalOutcome = 'complete' | 'partial';
 export const getGroupRemovalOutcome = (
     result: RevokeBoostRecipientGroupResult
 ): GroupRemovalOutcome => (result.failedCredentialUris.length === 0 ? 'complete' : 'partial');
+
+export const isRemovableGroupMemberRole = (role?: string): boolean =>
+    role === 'Scout' || role === 'Leader';

--- a/apps/scouts/src/pages/troop/groupRemoval.helpers.ts
+++ b/apps/scouts/src/pages/troop/groupRemoval.helpers.ts
@@ -1,0 +1,7 @@
+import type { RevokeBoostRecipientGroupResult } from '@learncard/types';
+
+export type GroupRemovalOutcome = 'complete' | 'partial';
+
+export const getGroupRemovalOutcome = (
+    result: RevokeBoostRecipientGroupResult
+): GroupRemovalOutcome => (result.failedCredentialUris.length === 0 ? 'complete' : 'partial');

--- a/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
+++ b/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
@@ -1,0 +1,26 @@
+import type { CredentialLifecycleStatus } from 'learn-card-base';
+
+export type TroopIdCredentialStatus = 'valid' | 'pending' | 'suspended' | 'revoked';
+export type TroopIdIssuanceState = 'accepted' | 'pending';
+
+export interface DeriveTroopIdStatusOptions {
+    lifecycleStatus: CredentialLifecycleStatus;
+    issuanceState?: TroopIdIssuanceState;
+    isLoading?: boolean;
+}
+
+export const deriveTroopIdStatus = ({
+    lifecycleStatus,
+    issuanceState = 'accepted',
+    isLoading = false,
+}: DeriveTroopIdStatusOptions): TroopIdCredentialStatus | undefined => {
+    if (isLoading) return undefined;
+    if (lifecycleStatus === 'revoked') return 'revoked';
+    if (lifecycleStatus === 'suspended') return 'suspended';
+    if (issuanceState === 'pending') return 'pending';
+    return 'valid';
+};
+
+export const isCredentialActionRestricted = (
+    status: TroopIdCredentialStatus | undefined
+): boolean => status !== 'valid';

--- a/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
+++ b/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
@@ -7,14 +7,18 @@ export interface DeriveTroopIdStatusOptions {
     lifecycleStatus: CredentialLifecycleStatus;
     issuanceState?: TroopIdIssuanceState;
     isLoading?: boolean;
+    isError?: boolean;
+    lifecycleEnabled?: boolean;
 }
 
 export const deriveTroopIdStatus = ({
     lifecycleStatus,
     issuanceState = 'accepted',
     isLoading = false,
+    isError = false,
+    lifecycleEnabled = true,
 }: DeriveTroopIdStatusOptions): TroopIdCredentialStatus | undefined => {
-    if (isLoading) return undefined;
+    if (!lifecycleEnabled || isLoading || isError) return undefined;
     if (lifecycleStatus === 'revoked') return 'revoked';
     if (lifecycleStatus === 'suspended') return 'suspended';
     if (issuanceState === 'pending') return 'pending';
@@ -24,3 +28,24 @@ export const deriveTroopIdStatus = ({
 export const isCredentialActionRestricted = (
     status: TroopIdCredentialStatus | undefined
 ): boolean => status !== 'valid';
+
+export interface TroopIdContentRestrictionOptions {
+    hasParentAdminAccess: boolean;
+    lifecycleLoading: boolean;
+    status: TroopIdCredentialStatus | undefined;
+}
+
+export const isTroopIdContentRestricted = ({
+    hasParentAdminAccess,
+    lifecycleLoading,
+    status,
+}: TroopIdContentRestrictionOptions): boolean =>
+    !hasParentAdminAccess && (lifecycleLoading || isCredentialActionRestricted(status));
+
+export const shouldShowTroopIdStatus = ({
+    lifecycleEnabled = true,
+    credentialUri,
+}: {
+    lifecycleEnabled?: boolean;
+    credentialUri?: string;
+}): boolean => lifecycleEnabled && Boolean(credentialUri);

--- a/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
+++ b/apps/scouts/src/pages/troop/troopIdStatus.helpers.ts
@@ -1,7 +1,8 @@
 import type { CredentialLifecycleStatus } from 'learn-card-base';
 
-export type TroopIdCredentialStatus = 'valid' | 'pending' | 'suspended' | 'revoked';
-export type TroopIdIssuanceState = 'accepted' | 'pending';
+import type { TroopIdCredentialStatus, TroopIdIssuanceState } from './troopIdStatus.types';
+
+export type { TroopIdCredentialStatus, TroopIdIssuanceState } from './troopIdStatus.types';
 
 export interface DeriveTroopIdStatusOptions {
     lifecycleStatus: CredentialLifecycleStatus;
@@ -28,6 +29,19 @@ export const deriveTroopIdStatus = ({
 export const isCredentialActionRestricted = (
     status: TroopIdCredentialStatus | undefined
 ): boolean => status !== 'valid';
+
+export interface CanSharePersonalTroopIdOptions {
+    isPersonalId: boolean;
+    lifecycleLoading: boolean;
+    status: TroopIdCredentialStatus | undefined;
+}
+
+export const canSharePersonalTroopId = ({
+    isPersonalId,
+    lifecycleLoading,
+    status,
+}: CanSharePersonalTroopIdOptions): boolean =>
+    isPersonalId && !lifecycleLoading && !isCredentialActionRestricted(status);
 
 export interface TroopIdContentRestrictionOptions {
     hasParentAdminAccess: boolean;

--- a/apps/scouts/src/pages/troop/troopIdStatus.types.ts
+++ b/apps/scouts/src/pages/troop/troopIdStatus.types.ts
@@ -1,0 +1,13 @@
+import type { CredentialStatusResult } from 'learn-card-base/hooks/credentialStatus.types';
+
+export type TroopIdCredentialStatus = 'valid' | 'pending' | 'suspended' | 'revoked';
+export type TroopIdIssuanceState = 'accepted' | 'pending';
+
+export interface TroopIdStatusResult extends Omit<CredentialStatusResult, 'status'> {
+    status: TroopIdCredentialStatus | undefined;
+}
+
+type AssertFalse<T extends false> = T;
+export type TroopIdStatusResultIsIndependent = AssertFalse<
+    TroopIdStatusResult extends CredentialStatusResult ? true : false
+>;

--- a/apps/scouts/src/pages/troop/troopPage.helpers.ts
+++ b/apps/scouts/src/pages/troop/troopPage.helpers.ts
@@ -1,0 +1,19 @@
+export interface TroopRecipientIssuance {
+    uri: string;
+    received?: unknown;
+    to: { profileId: string };
+}
+
+export const selectHolderRecipient = <T extends TroopRecipientIssuance>(
+    recipients: T[] | undefined,
+    profileId: string | undefined,
+    credentialUri?: string
+): T | undefined =>
+    credentialUri
+        ? recipients?.find(recipient => recipient.uri === credentialUri)
+        : recipients?.find(recipient => recipient.to.profileId === profileId);
+
+export const hasReachableMembers = (
+    acceptedMemberCount: number | string,
+    memberRows: readonly unknown[]
+): boolean => Number(acceptedMemberCount) > 0 || memberRows.length > 0;

--- a/apps/scouts/tsconfig.troop-status.json
+++ b/apps/scouts/tsconfig.troop-status.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [],
+    "files": ["src/pages/troop/troopIdStatus.types.ts"]
+}

--- a/docs/apps/scouts/credential-revocation.md
+++ b/docs/apps/scouts/credential-revocation.md
@@ -1,115 +1,17 @@
-# Credential Revocation
+# ScoutPass credential revocation
 
-When a scout leaves a troop or their credential needs to be invalidated, ScoutPass uses LearnCard's revocation system to cleanly remove access while preserving audit history.
+## Lifecycle source of truth
 
----
+ScoutPass reads the issuer-controlled lifecycle recorded by LearnCard Network for the specific credential URI. If that record is unavailable, it verifies the credential's Bitstring Status List entry. A loading state, missing list entry, or request failure is never treated as proof of revocation.
 
-## How Revocation Works
+## Removing a member
 
-Revocation is tracked via a `status` property on the Neo4j `CREDENTIAL_RECEIVED` relationship:
+Removing a member revokes every active, pending, or suspended credential issued from that group ID to the profile. LearnCard also removes permissions, administrator grants, and connections created by those credentials. Repeating the operation is safe; a partial result remains visible so the administrator can retry.
 
-| Status Value | Meaning |
-|--------------|---------|
-| `null` | Active/claimed credential |
-| `'pending'` | Sent but not yet accepted |
-| `'revoked'` | Credential has been revoked |
+## Holder experience
 
-When a credential is revoked:
-1. The credential is **marked as revoked** (not deleted) for audit purposes
-2. The scout is **filtered out** of member/recipient lists
-3. Any **permissions granted via claim hooks** are reversed
-4. Any **auto-connect relationships** are cleaned up
-5. The scout's **wallet syncs** to remove the credential from view
+Revoked IDs remain in the holder's credential list and display **ID Revoked**. Suspended and unaccepted IDs display **ID Suspended** and **Pending Acceptance**. Sharing and membership-protected actions are unavailable in all three states.
 
----
+## Legacy credentials
 
-## Revocation Flow
-
-```mermaid
-sequenceDiagram
-    participant TL as Troop Leader
-    participant BS as Brain Service
-    participant Neo4j
-    participant Scout as Scout's Wallet
-
-    TL->>BS: Revoke credential
-    BS->>Neo4j: Set CREDENTIAL_RECEIVED.status = 'revoked'
-    BS->>Neo4j: Run revoke hooks (cleanup permissions)
-    
-    Note over Scout: Later, when scout opens app...
-    
-    Scout->>BS: getRevokedCredentials()
-    BS-->>Scout: [revokedUri1, ...]
-    Scout->>Scout: Remove from local wallet index
-    Scout->>Scout: Refresh UI
-```
-
----
-
-## Cleanup Hooks
-
-When revocation occurs, these cleanup operations run automatically:
-
-| Hook | Purpose |
-|------|---------|
-| `processPermissionsRevokeHooks` | Removes roles granted via GRANT_PERMISSIONS claim hooks |
-| `processAutoConnectRevokeHooks` | Removes AUTO_CONNECT_RECIPIENT relationships |
-| `processAdminRevokeHooks` | Removes admin roles granted via ADD_ADMIN claim hooks |
-| `processConnectionRevoke` | Removes CONNECTED_WITH relationships sourced from the boost |
-
----
-
-## Query Filtering
-
-All recipient queries automatically exclude revoked credentials:
-
-```cypher
-MATCH (c:Credential)-[r:CREDENTIAL_RECEIVED]->(p:Profile)
-WHERE (r.status IS NULL OR r.status <> 'revoked')
-RETURN p
-```
-
-| Query | Default Behavior |
-|-------|------------------|
-| `getBoostRecipients` | Returns only claimed credentials |
-| `countBoostRecipients` | Counts only claimed credentials |
-
-> **Note:** Revoked credentials are always filtered out, regardless of query options.
-
----
-
-## Wallet Sync
-
-The scout's wallet syncs with the network to remove revoked credentials using the `useSyncRevokedCredentials` hook:
-
-```typescript
-import { useSyncRevokedCredentials } from 'learn-card-base';
-
-// In AppRouter.tsx or top-level component
-useSyncRevokedCredentials(enabled);
-```
-
-This hook:
-1. Fetches revoked URIs from `wallet.invoke.getRevokedCredentials()`
-2. Removes matching records from the LearnCloud personal index
-3. Invalidates UI queries to refresh the display
-
----
-
-## Why Two Storage Layers?
-
-Credentials exist in two places:
-
-| Layer | Purpose |
-|-------|---------|
-| **Brain Service (Neo4j)** | Network-level tracking, source of truth for status |
-| **LearnCloud (MongoDB)** | User's personal wallet, what shows in the app |
-
-The brain service cannot directly modify the user's LearnCloud index (it's user-authenticated). The frontend sync hook bridges this gap.
-
----
-
-## Related Documentation
-
-- [Boost Credentials](../../core-concepts/credentials-and-data/boost-credentials.md) — Boost hierarchy and permissions
-- [Credential Lifecycle](../../core-concepts/credentials-and-data/credential-lifecycle.md) — Full credential lifecycle
+Credentials issued before Bitstring Status List support still receive authoritative LearnCard Network revocation, but their old signed copies cannot be changed. External cryptographic revocation for those IDs requires controlled reissuance, retirement or blocklisting of old identifiers, and verifier cutover in a separate migration cycle.

--- a/docs/superpowers/plans/2026-08-10-lc-1950-scoutpass-real-revocation.md
+++ b/docs/superpowers/plans/2026-08-10-lc-1950-scoutpass-real-revocation.md
@@ -1,0 +1,1943 @@
+# LC-1950 ScoutPass Real Revocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ScoutPass recipient-list revocation inference with LearnCard's authoritative lifecycle system and make administrator removal revoke every credential instance for the selected Boost/profile pair.
+
+**Architecture:** Move the existing LearnCard App lifecycle hook into `learn-card-base`, then give ScoutPass concrete credential-record URIs and a pure presentation adapter. Add a dedicated, idempotent `revokeBoostRecipientGroup` path from brain service through the network plugin and React Query, leaving the existing per-instance API unchanged. The server owns enumeration, Bitstring updates, cleanup hooks, partial-failure reporting, and consolidated notification delivery.
+
+**Tech Stack:** TypeScript, React 18, TanStack React Query 5, tRPC 11, Zod 4, Neo4j/Neogma, Vitest, Bun test, Nx, Bitstring Status List.
+
+## Global Constraints
+
+-   Implement only the runtime cycle defined in `docs/superpowers/specs/2026-08-09-lc-1950-scoutpass-real-revocation-design.md`; pre-Bitstring reissuance, retirement/blocklist, and verifier cutover remain a separate follow-up.
+-   Group removal must cover every active, pending, and suspended credential instance for the Boost/profile pair.
+-   Keep revoked credentials visible; do not delete them from LearnCloud or the network index.
+-   Never derive `revoked` from list absence, loading state, request failure, or verification failure.
+-   Keep `revokeBoostRecipient(boostUri, recipientProfileId, credentialUri?)` and its latest-instance fallback behavior backward compatible.
+-   A credential with a revocation entry is successful only after its Bitstring update and cleanup hooks succeed; a missing entry is logged as a migration gap and remains authoritatively revoked.
+-   Retrying group removal must re-run idempotent Bitstring and cleanup work for already-revoked instances so partial failures can heal.
+-   Do not modify the self-service `Leave` branch; it is outside this implementation.
+-   Use four-space TypeScript/JSX indentation, named exports for new public APIs, explicit return types, friendly error copy, and existing ScoutPass design tokens.
+-   Do not add dependencies.
+
+## File Structure
+
+### Shared lifecycle source
+
+-   Create `packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts` — pure mapping from verification output to `active`, `revoked`, or `suspended`.
+-   Create `packages/learn-card-base/src/hooks/useCredentialStatus.ts` — authoritative holder query with Bitstring verification fallback and loading/error metadata.
+-   Create `packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts` — pure lifecycle precedence tests.
+-   Create `packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx` — hook source/fallback/fail-open tests.
+-   Modify `packages/learn-card-base/src/index.ts` — export the shared lifecycle API.
+-   Modify `apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts` — compatibility re-export from `learn-card-base`.
+-   Modify `apps/learn-card-app/src/hooks/useCredentialStatus.ts` — preserve the existing positional API while delegating to the shared hook.
+
+### Group revocation backend and public API
+
+-   Modify `packages/learn-card-types/src/lcn.ts` — shared Zod validator and result type.
+-   Modify `services/learn-card-network/brain-service/src/helpers/status-list.helpers.ts` — distinguish updated, missing-entry, and failed Bitstring outcomes.
+-   Modify `services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts` — return idempotent revocation details while preserving the boolean wrapper.
+-   Modify `services/learn-card-network/brain-service/src/accesslayer/credential/read.ts` — return all Boost/profile credential instances in deterministic order.
+-   Modify `services/learn-card-network/brain-service/src/routes/boosts.ts` — add the authorized best-effort group route and consolidated notification.
+-   Create `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts` — active/pending/suspended, Bitstring, retry, authorization, partial failure, cleanup, and notification coverage.
+-   Modify `packages/plugins/learn-card-network/src/types.ts` — expose the group method.
+-   Modify `packages/plugins/learn-card-network/src/plugin.ts` — call the generated brain-client mutation.
+-   Create `packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts` — typed group mutation with settled invalidation.
+-   Create `packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx` — invocation and invalidation coverage.
+-   Modify `packages/learn-card-base/src/index.ts` — export the group mutation.
+
+### ScoutPass lifecycle and removal UI
+
+-   Create `apps/scouts/src/pages/troop/troopIdStatus.helpers.ts` — pure ScoutPass lifecycle presentation and action-gating rules.
+-   Create `apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts` — state precedence and restriction tests.
+-   Modify `apps/scouts/src/pages/troop/TroopIdStatusButton.tsx` — consume the shared lifecycle hook and display suspended/unavailable states.
+-   Modify `apps/scouts/src/components/boost/hooks/useBoostMenu.tsx` — use credential-record status and suppress sharing when restricted.
+-   Modify `apps/scouts/src/components/boost/boost-options-menu/BoostOptionsMenu.tsx` — accept an explicit share-visibility flag.
+-   Modify `apps/scouts/src/components/boost/boost-earned-card/BoostEarnedIDCard.tsx` — pass the earned record URI and guard every share entry point.
+-   Modify `apps/scouts/src/pages/ids/IdDisplayContainer.tsx` — pass record URIs through status and detail views; hide the QR action when restricted.
+-   Modify `apps/scouts/src/pages/troop/TroopPage.tsx` — distinguish held credential URI from managed Boost URI and gate protected content.
+-   Modify `apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx` — use credential-record lifecycle status for the badge and share button.
+-   Modify `apps/scouts/src/pages/troop/TroopPageFooter.tsx` — treat pending, suspended, and revoked as restricted.
+-   Modify `apps/scouts/src/pages/troop/ViewTroopIdModal.tsx` — gate sharing for the exact issuance being viewed.
+-   Modify `apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx` — pass the exact issuance into the status badge.
+-   Modify `apps/scouts/src/hooks/useTroopMembers.tsx` — retain recipient credential URI and explicit acceptance metadata.
+-   Modify `apps/scouts/src/pages/troop/TroopPageMembersBox.tsx` — pass the member issuance metadata to the options modal.
+-   Create `apps/scouts/src/pages/troop/groupRemoval.helpers.ts` — pure success/partial response interpretation.
+-   Create `apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts` — full, already-revoked, and partial outcomes.
+-   Modify `apps/scouts/src/pages/troop/IdOptionsModal.tsx` — use one group-removal path for Scout, Member, and Administrator roles.
+-   Modify `apps/scouts/src/AppRouter.tsx` — remove deletion-based revoked-credential synchronization.
+
+### Documentation
+
+-   Modify `docs/apps/scouts/credential-revocation.md` — document authoritative status, retained records, group semantics, and the legacy limitation.
+-   Modify `apps/scouts/AGENTS.md` — replace recipient-list inference guidance with the new lifecycle landmarks.
+
+---
+
+### Task 1: Share the LearnCard credential lifecycle hook
+
+**Files:**
+
+-   Create: `packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts`
+-   Create: `packages/learn-card-base/src/hooks/useCredentialStatus.ts`
+-   Create: `packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts`
+-   Create: `packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx`
+-   Modify: `packages/learn-card-base/src/index.ts`
+-   Modify: `apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts`
+-   Modify: `apps/learn-card-app/src/hooks/useCredentialStatus.ts`
+-   Test: `apps/learn-card-app/src/hooks/__tests__/useCredentialStatus.test.ts`
+
+**Interfaces:**
+
+-   Consumes: `wallet.invoke.getMyCredentialLifecycleStatuses({ uris })`, `wallet.read.get(uri)`, and `wallet.invoke.verifyCredential(vc, {}, false)`.
+-   Produces: `CredentialLifecycleStatus`, `deriveLifecycleStatus(check)`, `UseCredentialStatusOptions`, `CredentialStatusResult`, and `useCredentialStatus(options)` from `learn-card-base`.
+
+-   [ ] **Step 1: Write the pure derivation tests in the shared package**
+
+Create `packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts` with the five existing LearnCard App cases plus precedence when both bits are set:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { deriveLifecycleStatus } from '../deriveLifecycleStatus';
+
+describe('deriveLifecycleStatus', () => {
+    it('gives a set revocation bit precedence over suspension', () => {
+        expect(
+            deriveLifecycleStatus({
+                status: [
+                    {
+                        entryType: 'BitstringStatusListEntry',
+                        statusPurpose: 'suspension',
+                        isSet: true,
+                    },
+                    {
+                        entryType: 'BitstringStatusListEntry',
+                        statusPurpose: 'revocation',
+                        isSet: true,
+                    },
+                ],
+            })
+        ).toBe('revoked');
+    });
+
+    it.each([
+        ['revoked', 'revocation'],
+        ['suspended', 'suspension'],
+    ] as const)('returns %s for a set %s entry', (expected, purpose) => {
+        expect(
+            deriveLifecycleStatus({
+                status: [
+                    { entryType: 'BitstringStatusListEntry', statusPurpose: purpose, isSet: true },
+                ],
+            })
+        ).toBe(expected);
+    });
+
+    it('fails open for empty checks and unrelated verification errors', () => {
+        expect(deriveLifecycleStatus(undefined)).toBe('active');
+        expect(deriveLifecycleStatus({ errors: ['proof could not be loaded'] })).toBe('active');
+    });
+});
+```
+
+-   [ ] **Step 2: Run the shared derivation test and verify it fails**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- src/hooks/__tests__/deriveLifecycleStatus.test.ts
+```
+
+Expected: FAIL because `deriveLifecycleStatus.ts` does not exist in `learn-card-base`.
+
+-   [ ] **Step 3: Move the pure lifecycle contract into `learn-card-base`**
+
+Create `packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts`:
+
+```ts
+import type { VerificationCheck } from '@learncard/types';
+
+export type CredentialLifecycleStatus = 'active' | 'revoked' | 'suspended';
+
+export const deriveLifecycleStatus = (
+    check: Partial<VerificationCheck> | undefined | null
+): CredentialLifecycleStatus => {
+    const entries = check?.status ?? [];
+    if (entries.some(entry => entry.statusPurpose === 'revocation' && entry.isSet)) {
+        return 'revoked';
+    }
+    if (entries.some(entry => entry.statusPurpose === 'suspension' && entry.isSet)) {
+        return 'suspended';
+    }
+
+    const errors = check?.errors ?? [];
+    if (errors.some(error => /revok/i.test(error))) return 'revoked';
+    if (errors.some(error => /suspend/i.test(error))) return 'suspended';
+
+    return 'active';
+};
+```
+
+-   [ ] **Step 4: Run the pure derivation tests and verify they pass**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+-   [ ] **Step 5: Write hook tests for authoritative state, fallback, loading, and failure**
+
+Create `packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx` using `@vitest-environment jsdom`, a fresh `QueryClient`, and mocked `useWallet`. Cover these exact expectations:
+
+```ts
+expect(result.current.status).toBe('revoked');
+expect(mocks.verifyCredential).not.toHaveBeenCalled();
+
+// Backend throws, verification reports suspension.
+expect(result.current.status).toBe('suspended');
+expect(result.current.isError).toBe(false);
+
+// Both sources fail: active fail-open, but error metadata is retained.
+expect(result.current.status).toBe('active');
+expect(result.current.isError).toBe(true);
+
+// Disabled/no URI: no wallet initialization and no loading state.
+expect(result.current).toEqual({ status: 'active', isLoading: false, isError: false });
+expect(mocks.initWallet).not.toHaveBeenCalled();
+```
+
+Use this wrapper in the test:
+
+```tsx
+const renderStatusHook = (options: UseCredentialStatusOptions) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return renderHook(() => useCredentialStatus(options), { wrapper });
+};
+```
+
+-   [ ] **Step 6: Run the hook test and verify it fails**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- src/hooks/__tests__/useCredentialStatus.test.tsx
+```
+
+Expected: FAIL because the shared hook and types do not exist.
+
+-   [ ] **Step 7: Implement the shared hook with explicit source outcomes**
+
+Create `packages/learn-card-base/src/hooks/useCredentialStatus.ts` with this public contract:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import type { VC, VerificationCheck } from '@learncard/types';
+import { useWallet } from './useWallet';
+import { deriveLifecycleStatus, type CredentialLifecycleStatus } from './deriveLifecycleStatus';
+
+export interface UseCredentialStatusOptions {
+    uri?: string;
+    credential?: VC;
+    enabled?: boolean;
+}
+
+export interface CredentialStatusResult {
+    status: CredentialLifecycleStatus;
+    isLoading: boolean;
+    isError: boolean;
+}
+
+interface CredentialStatusQueryResult {
+    status: CredentialLifecycleStatus;
+    isError: boolean;
+}
+
+export const useCredentialStatus = ({
+    uri,
+    credential,
+    enabled = true,
+}: UseCredentialStatusOptions): CredentialStatusResult => {
+    const { initWallet } = useWallet();
+    const shouldQuery = enabled && Boolean(uri);
+
+    const query = useQuery({
+        queryKey: ['credentialStatus', uri],
+        enabled: shouldQuery,
+        staleTime: 5 * 60 * 1000,
+        refetchOnMount: 'always',
+        queryFn: async (): Promise<CredentialStatusQueryResult> => {
+            const wallet = await initWallet();
+
+            try {
+                const statuses = await wallet?.invoke?.getMyCredentialLifecycleStatuses?.({
+                    uris: [uri as string],
+                });
+                const status = statuses?.[uri as string];
+                if (status === 'active' || status === 'revoked' || status === 'suspended') {
+                    return { status, isError: false };
+                }
+            } catch {
+                // The verification fallback below remains authoritative for Bitstring entries.
+            }
+
+            try {
+                const resolved = credential ?? ((await wallet?.read?.get?.(uri as string)) as VC);
+                if (!resolved || !wallet?.invoke?.verifyCredential) {
+                    return { status: 'active', isError: true };
+                }
+                const verify = wallet.invoke.verifyCredential as unknown as (
+                    candidate: VC,
+                    options: Record<string, unknown>,
+                    prettify: boolean
+                ) => Promise<VerificationCheck>;
+                const check = await verify(resolved, {}, false);
+                return { status: deriveLifecycleStatus(check), isError: false };
+            } catch {
+                return { status: 'active', isError: true };
+            }
+        },
+    });
+
+    if (!shouldQuery) return { status: 'active', isLoading: false, isError: false };
+
+    return {
+        status: query.data?.status ?? 'active',
+        isLoading: query.isLoading,
+        isError: query.data?.isError ?? query.isError,
+    };
+};
+```
+
+If the exact generated `verifyCredential` overload accepts `boolean`, use it directly; otherwise retain the narrow cast used by the current LearnCard App hook.
+
+-   [ ] **Step 8: Export the shared API and preserve LearnCard App imports**
+
+Add to `packages/learn-card-base/src/index.ts`:
+
+```ts
+export * from './hooks/deriveLifecycleStatus';
+export * from './hooks/useCredentialStatus';
+```
+
+Replace `apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts` with:
+
+```ts
+export { deriveLifecycleStatus } from 'learn-card-base';
+export type { CredentialLifecycleStatus } from 'learn-card-base';
+```
+
+Keep LearnCard App's positional hook contract in `apps/learn-card-app/src/hooks/useCredentialStatus.ts`:
+
+```ts
+import type { VC } from '@learncard/types';
+import {
+    useCredentialStatus as useSharedCredentialStatus,
+    type CredentialLifecycleStatus,
+} from 'learn-card-base';
+
+export type { CredentialLifecycleStatus } from 'learn-card-base';
+export { deriveLifecycleStatus } from 'learn-card-base';
+
+export const useCredentialStatus = (
+    credential: VC | undefined,
+    uri: string | undefined,
+    enabled = true
+): CredentialLifecycleStatus => useSharedCredentialStatus({ credential, uri, enabled }).status;
+```
+
+-   [ ] **Step 9: Run shared and LearnCard App lifecycle tests**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- \
+  src/hooks/__tests__/deriveLifecycleStatus.test.ts \
+  src/hooks/__tests__/useCredentialStatus.test.tsx
+bun run --cwd apps/learn-card-app test:unit -- \
+  src/hooks/__tests__/useCredentialStatus.test.ts
+```
+
+Expected: all shared cases pass and the existing five LearnCard App cases remain green.
+
+-   [ ] **Step 10: Commit the shared lifecycle source**
+
+```bash
+git add packages/learn-card-base/src/hooks packages/learn-card-base/src/index.ts \
+  apps/learn-card-app/src/hooks/deriveLifecycleStatus.ts \
+  apps/learn-card-app/src/hooks/useCredentialStatus.ts
+git commit -m "refactor: share credential lifecycle status hook"
+```
+
+### Task 2: Add idempotent group revocation to the brain service
+
+**Files:**
+
+-   Modify: `packages/learn-card-types/src/lcn.ts`
+-   Modify: `services/learn-card-network/brain-service/src/helpers/status-list.helpers.ts`
+-   Modify: `services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts`
+-   Modify: `services/learn-card-network/brain-service/src/accesslayer/credential/read.ts`
+-   Modify: `services/learn-card-network/brain-service/src/routes/boosts.ts`
+-   Create: `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts`
+-   Test: `services/learn-card-network/brain-service/test/revoke-suspend-per-instance.spec.ts`
+-   Test: `services/learn-card-network/brain-service/test/revoke-credential.spec.ts`
+
+**Interfaces:**
+
+-   Consumes: `getBoostPermissions`, `processRevokeHooks`, `setCredentialBitstringStatus`, `addNotificationToQueue`, and the existing Boost/credential graph.
+-   Produces: `RevokeBoostRecipientGroupResultValidator`, `RevokeBoostRecipientGroupResult`, `getCredentialStatusesForBoostAndProfile`, `revokeCredentialForProfile`, and tRPC route `boost.revokeBoostRecipientGroup`.
+
+-   [ ] **Step 1: Write the group-route integration fixture and all-instance failure test**
+
+Create `services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts` using the setup pattern from `revoke-suspend-per-instance.spec.ts`. Issue two accepted instances and one pending instance, suspend one accepted instance, call the not-yet-existing route, and assert all three URIs are returned:
+
+```ts
+const userARef = { profileId: 'usera', user: userA };
+const userBRef = { profileId: 'userb', user: userB };
+const input = { boostUri, recipientProfileId: 'userb' };
+
+const activeUri = await sendBoost(userARef, userBRef, boostUri, true);
+const suspendedUri = await sendBoost(userARef, userBRef, boostUri, true);
+const pendingUri = await sendBoost(userARef, userBRef, boostUri, false);
+
+await userA.clients.fullAuth.boost.suspendBoostRecipient({
+    boostUri,
+    recipientProfileId: 'userb',
+    credentialUri: suspendedUri,
+});
+
+const result = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+    boostUri,
+    recipientProfileId: 'userb',
+});
+
+expect(new Set(result.revokedCredentialUris)).toEqual(
+    new Set([activeUri, suspendedUri, pendingUri])
+);
+expect(result.alreadyRevokedCredentialUris).toEqual([]);
+expect(result.failedCredentialUris).toEqual([]);
+
+const statuses = await userB.clients.fullAuth.activity.getMyCredentialLifecycleStatuses({
+    uris: [activeUri, suspendedUri, pendingUri],
+});
+expect(statuses).toEqual({
+    [activeUri]: 'revoked',
+    [suspendedUri]: 'revoked',
+    [pendingUri]: 'revoked',
+});
+
+await userA.clients.fullAuth.boost.unsuspendBoostRecipient({
+    boostUri,
+    recipientProfileId: 'userb',
+    credentialUri: suspendedUri,
+});
+expect(
+    await userB.clients.fullAuth.activity.getMyCredentialLifecycleStatuses({
+        uris: [suspendedUri],
+    })
+).toEqual({ [suspendedUri]: 'revoked' });
+```
+
+-   [ ] **Step 2: Add failing tests for authorization, idempotency, and consolidated notification**
+
+Add these assertions before implementation:
+
+```ts
+const input = { boostUri, recipientProfileId: 'userb' };
+
+await expect(
+    userC.clients.fullAuth.boost.revokeBoostRecipientGroup({
+        boostUri,
+        recipientProfileId: 'userb',
+    })
+).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+const first = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+const second = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+expect(first.revokedCredentialUris).toHaveLength(2);
+expect(second.revokedCredentialUris).toEqual([]);
+expect(new Set(second.alreadyRevokedCredentialUris)).toEqual(new Set(first.revokedCredentialUris));
+expect(second.failedCredentialUris).toEqual([]);
+
+// In a fresh test, install the spy after issuance and before the first group removal.
+const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+notificationSpy.mockClear();
+const notifiedResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+expect(notificationSpy).toHaveBeenCalledTimes(1);
+expect(notificationSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+        data: { vcUris: expect.arrayContaining(notifiedResult.revokedCredentialUris) },
+    })
+);
+```
+
+Reset the notification spy before the idempotency assertion so the existing issuance notifications do not affect the count.
+
+-   [ ] **Step 3: Add failing Bitstring and legacy-gap tests**
+
+Use the `statusBoostTemplate`, `getEntryForPurpose`, and `isStatusBitSet` helpers from the per-instance suite to issue two status-enabled credentials, then assert both revocation bits are set after the group call. Separately issue `testUnsignedBoost`, spy on `console.warn`, and assert the group still returns the URI as revoked while emitting a machine-searchable migration-gap event:
+
+```ts
+expect(await isStatusBitSet(firstEntry)).toBe(true);
+expect(await isStatusBitSet(secondEntry)).toBe(true);
+
+expect(warnSpy).toHaveBeenCalledWith(
+    '[revokeBoostRecipientGroup] migration-gap',
+    expect.objectContaining({ credentialId: expect.any(String), reason: 'missing-entry' })
+);
+```
+
+-   [ ] **Step 4: Add a failing partial-cleanup retry test**
+
+Spy on `processRevokeHooks`, fail only one credential on the first request, restore the implementation, and call the route again:
+
+```ts
+expect(firstResult.failedCredentialUris).toEqual([failingUri]);
+expect(firstResult.revokedCredentialUris).toContain(successfulUri);
+
+expect(secondResult.failedCredentialUris).toEqual([]);
+expect(secondResult.alreadyRevokedCredentialUris).toContain(failingUri);
+expect(processRevokeHooksSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ profileId: 'userb' }),
+    expect.objectContaining({ id: failingCredentialId })
+);
+```
+
+This test is the guard against skipping cleanup simply because the first request already changed `CREDENTIAL_SENT.status`.
+
+Repeat the retry shape with a one-call mock of `setCredentialBitstringStatusWithResult` that returns `failed` for one status-enabled credential. Assert that URI is failed on the first call and is classified as already revoked after the real helper succeeds on retry. This distinguishes a missing legacy entry from a broken update for a credential that does have an entry.
+
+```ts
+await issueStatusInstanceToUserB(statusBoostUri);
+const { credentialUri: newestCredentialUri } = await issueStatusInstanceToUserB(statusBoostUri);
+const input = { boostUri: statusBoostUri, recipientProfileId: 'userb' };
+const realStatusUpdate = statusListHelpers.setCredentialBitstringStatusWithResult;
+const statusUpdateSpy = vi
+    .spyOn(statusListHelpers, 'setCredentialBitstringStatusWithResult')
+    .mockResolvedValueOnce('failed')
+    .mockImplementation(realStatusUpdate);
+
+const firstResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+expect(firstResult.failedCredentialUris).toContain(newestCredentialUri);
+
+statusUpdateSpy.mockRestore();
+const retryResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+expect(retryResult.failedCredentialUris).toEqual([]);
+expect(retryResult.alreadyRevokedCredentialUris).toContain(newestCredentialUri);
+```
+
+-   [ ] **Step 5: Add failing group-path permission and connection cleanup tests**
+
+For permissions, create a claim Boost and target Boost, attach a `GRANT_PERMISSIONS` claim hook, issue the claim Boost twice, and remove the profile through the group route:
+
+```ts
+await userA.clients.fullAuth.claimHook.createClaimHook({
+    hook: {
+        type: 'GRANT_PERMISSIONS',
+        data: {
+            claimUri,
+            targetUri,
+            permissions: { canIssue: true },
+        },
+    },
+});
+await sendBoost(userARef, userBRef, claimUri, true);
+await sendBoost(userARef, userBRef, claimUri, true);
+expect((await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })).canIssue).toBe(
+    true
+);
+
+await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+    boostUri: claimUri,
+    recipientProfileId: 'userb',
+});
+expect(
+    (await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })).canIssue
+).toBeFalsy();
+```
+
+Add an `ADD_ADMIN` variant using the same `claimUri`/`targetUri` pair:
+
+```ts
+await userA.clients.fullAuth.claimHook.createClaimHook({
+    hook: { type: 'ADD_ADMIN', data: { claimUri, targetUri } },
+});
+await sendBoost(userARef, userBRef, claimUri, true);
+expect((await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })).role).toBe(
+    'admin'
+);
+
+await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+    boostUri: claimUri,
+    recipientProfileId: 'userb',
+});
+expect((await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })).role).not.toBe(
+    'admin'
+);
+```
+
+For connection cleanup, create a Boost with `autoConnectRecipients: true`, issue it, assert the `CONNECTED_WITH` query returns a positive count, call the group route, and assert the count is zero. Use the exact Cypher helper:
+
+```ts
+const getConnectionCount = async (fromId: string, toId: string): Promise<number> => {
+    const { neogma } = await import('@instance');
+    const query = await neogma.queryRunner.run(
+        `MATCH (:Profile {profileId: $fromId})-[r:CONNECTED_WITH]-(:Profile {profileId: $toId})
+         RETURN count(r) AS count`,
+        { fromId, toId }
+    );
+    return query.records[0]?.get('count').toNumber() ?? 0;
+};
+```
+
+-   [ ] **Step 6: Run the new suite and verify the route is missing**
+
+Run:
+
+```bash
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  test/revoke-boost-recipient-group.spec.ts
+```
+
+Expected: FAIL at compile/runtime because `revokeBoostRecipientGroup` is not defined.
+
+-   [ ] **Step 7: Define the shared result validator**
+
+Add near the Boost recipient validators in `packages/learn-card-types/src/lcn.ts`:
+
+```ts
+export const RevokeBoostRecipientGroupResultValidator = z.object({
+    revokedCredentialUris: z.array(z.string()),
+    alreadyRevokedCredentialUris: z.array(z.string()),
+    failedCredentialUris: z.array(z.string()),
+});
+
+export type RevokeBoostRecipientGroupResult = z.infer<
+    typeof RevokeBoostRecipientGroupResultValidator
+>;
+```
+
+-   [ ] **Step 8: Make status-list mutation outcomes explicit**
+
+In `status-list.helpers.ts`, add a detailed helper and keep the boolean API as a compatibility wrapper:
+
+```ts
+export type CredentialBitstringStatusUpdateResult = 'updated' | 'missing-entry' | 'failed';
+
+export const setCredentialBitstringStatusWithResult = async (
+    credentialId: string,
+    statusPurpose: BitstringStatusPurpose,
+    value: boolean
+): Promise<CredentialBitstringStatusUpdateResult> => {
+    const credential = await Credential.findOne({ where: { id: credentialId } });
+    if (!credential) return 'failed';
+
+    const entries = getBitstringStatusListEntries(JSON.parse(credential.credential)).filter(
+        entry => entry.statusPurpose === statusPurpose
+    );
+    if (entries.length === 0) return 'missing-entry';
+
+    const results = await Promise.all(entries.map(entry => setStatusListEntryBit(entry, value)));
+    return results.every(Boolean) ? 'updated' : 'failed';
+};
+
+export const setCredentialBitstringStatus = async (
+    credentialId: string,
+    statusPurpose: BitstringStatusPurpose,
+    value: boolean
+): Promise<boolean> =>
+    (await setCredentialBitstringStatusWithResult(credentialId, statusPurpose, value)) ===
+    'updated';
+```
+
+-   [ ] **Step 9: Add an idempotent relationship/status primitive**
+
+In `credential/relationships/update.ts`, add:
+
+```ts
+import { neogma } from '@instance';
+import {
+    setCredentialBitstringStatusWithResult,
+    type CredentialBitstringStatusUpdateResult,
+} from '@helpers/status-list.helpers';
+
+export interface RevokeCredentialForProfileResult {
+    found: boolean;
+    wasAlreadyRevoked: boolean;
+    statusList: CredentialBitstringStatusUpdateResult;
+}
+
+export const revokeCredentialForProfile = async (
+    credentialId: string,
+    profileId: string
+): Promise<RevokeCredentialForProfileResult> => {
+    const revokedAt = new Date().toISOString();
+    const result = await neogma.queryRunner.run(
+        `MATCH (credential:Credential {id: $credentialId})
+         MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
+         WHERE sender:Profile OR sender:AppStoreListing
+         WITH sent, sent.status AS previousStatus
+         SET sent.status = "revoked", sent.revokedAt = $revokedAt
+         RETURN previousStatus`,
+        { credentialId, profileId, revokedAt }
+    );
+
+    if (result.records.length === 0) {
+        return { found: false, wasAlreadyRevoked: false, statusList: 'failed' };
+    }
+
+    let statusList: CredentialBitstringStatusUpdateResult = 'failed';
+    try {
+        statusList = await setCredentialBitstringStatusWithResult(credentialId, 'revocation', true);
+    } catch (error) {
+        console.error('[revokeCredentialForProfile] status-list update failed', {
+            credentialId,
+            error,
+        });
+    }
+
+    return {
+        found: true,
+        wasAlreadyRevoked: result.records[0]?.get('previousStatus') === 'revoked',
+        statusList,
+    };
+};
+```
+
+Rewrite `revokeCredentialReceived` as a wrapper over this result. It returns `result.found`, logs `missing-entry` with its existing warning behavior, and does not change the external route's boolean response.
+
+```ts
+export const revokeCredentialReceived = async (
+    credentialId: string,
+    profileId: string
+): Promise<boolean> => {
+    const result = await revokeCredentialForProfile(credentialId, profileId);
+    if (result.found && result.statusList !== 'updated') {
+        console.warn('[revokeCredentialReceived] verifiable revocation unavailable', {
+            credentialId,
+            reason: result.statusList,
+        });
+    }
+    return result.found;
+};
+```
+
+-   [ ] **Step 10: Add the plural Boost/profile accessor and preserve latest-only behavior**
+
+In `credential/read.ts`, implement:
+
+```ts
+export const getCredentialStatusesForBoostAndProfile = async (
+    boostId: string,
+    profileId: string
+): Promise<CredentialStatusForBoostAndProfile[]> => {
+    const result = await neogma.queryRunner.run(
+        `MATCH (boost:Boost {id: $boostId})<-[:INSTANCE_OF]-(credential:Credential)
+         MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
+         WHERE sender:Profile OR sender:AppStoreListing
+         OPTIONAL MATCH (credential)-[received:CREDENTIAL_RECEIVED]->(:Profile {profileId: $profileId})
+         RETURN credential, sent, received
+         ORDER BY coalesce(received.date, sent.date) DESC, credential.id DESC`,
+        { boostId, profileId }
+    );
+
+    const statuses = await Promise.all(
+        result.records.map(async record => {
+            const credentialNode = record.get('credential') as {
+                properties?: Record<string, unknown>;
+            };
+            const credentialProps = inflateObject<CredentialType>(
+                (credentialNode?.properties ?? {}) as CredentialType
+            );
+            const credential = await Credential.findOne({ where: { id: credentialProps.id } });
+            if (!credential) return null;
+
+            const sentNode = record.get('sent') as {
+                properties?: Record<string, unknown>;
+            };
+            const receivedNode = record.get('received') as {
+                properties?: Record<string, unknown>;
+            } | null;
+            const sentProps = inflateRelationshipProperties(sentNode?.properties ?? {});
+            const receivedProps = receivedNode?.properties
+                ? inflateRelationshipProperties(receivedNode.properties)
+                : undefined;
+            const rawStatus = sentProps.status ?? receivedProps?.status;
+
+            return {
+                credential,
+                sentDate: sentProps.date as string | undefined,
+                receivedDate: receivedProps?.date as string | undefined,
+                status:
+                    rawStatus === 'revoked'
+                        ? ('revoked' as const)
+                        : rawStatus === 'suspended'
+                        ? ('suspended' as const)
+                        : receivedProps
+                        ? ('claimed' as const)
+                        : ('pending' as const),
+            };
+        })
+    );
+
+    return statuses.filter(
+        (status): status is CredentialStatusForBoostAndProfile => status !== null
+    );
+};
+
+export const getCredentialStatusForBoostAndProfile = async (
+    boostId: string,
+    profileId: string
+): Promise<CredentialStatusForBoostAndProfile | null> =>
+    (await getCredentialStatusesForBoostAndProfile(boostId, profileId))[0] ?? null;
+```
+
+The plural query must return `pending` when there is no received relationship, `claimed` when received, and let `revoked`/`suspended` from `sent.status ?? received.status` take precedence.
+
+-   [ ] **Step 11: Implement the authorized best-effort group route**
+
+Add `revokeBoostRecipientGroup` beside `revokeBoostRecipient` in `boosts.ts`, importing both `RevokeBoostRecipientGroupResultValidator` and `RevokeBoostRecipientGroupResult`. Start the route with the same resource resolution and authorization order as the singular route:
+
+```ts
+revokeBoostRecipientGroup: profileRoute
+    .meta({
+        openapi: {
+            protect: true,
+            method: 'POST',
+            path: '/boost/recipients/revoke-group',
+            tags: ['Boosts'],
+            summary: 'Revoke every credential for a Boost recipient',
+        },
+        requiredScope: 'boosts:write',
+    })
+    .input(z.object({ boostUri: z.string(), recipientProfileId: z.string() }))
+    .output(RevokeBoostRecipientGroupResultValidator)
+    .mutation(async ({ ctx, input }) => {
+        const resolvedRecipientProfileId = await getProfileIdFromString(
+            input.recipientProfileId,
+            ctx.domain
+        );
+        if (!resolvedRecipientProfileId) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'Profile not found' });
+        }
+
+        const boost = await getBoostByUri(decodeURIComponent(input.boostUri));
+        if (!boost) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
+        }
+
+        const permissions = await getBoostPermissions(boost, ctx.user.profile);
+        if (!permissions.canRevoke) {
+            throw new TRPCError({
+                code: 'UNAUTHORIZED',
+                message: 'Profile does not have permission to revoke credentials for this boost',
+            });
+        }
+
+        const recipientProfile = await getProfileByProfileId(resolvedRecipientProfileId);
+        if (!recipientProfile) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'Recipient profile not found' });
+        }
+```
+
+Immediately after that recipient-profile check, use this processing block as the remainder of the mutation body and finish with `return result;`:
+
+```ts
+const instances = await getCredentialStatusesForBoostAndProfile(
+    boost.id,
+    resolvedRecipientProfileId
+);
+const result: RevokeBoostRecipientGroupResult = {
+    revokedCredentialUris: [],
+    alreadyRevokedCredentialUris: [],
+    failedCredentialUris: [],
+};
+
+for (const instance of instances) {
+    const uri = constructUri('credential', instance.credential.id, ctx.domain);
+    try {
+        const revocation = await revokeCredentialForProfile(
+            instance.credential.id,
+            resolvedRecipientProfileId
+        );
+        const hookResult = await Promise.allSettled([
+            processRevokeHooks(recipientProfile, instance.credential),
+        ]);
+        const hooksFailed = hookResult.some(item => item.status === 'rejected');
+
+        if (revocation.statusList === 'missing-entry') {
+            console.warn('[revokeBoostRecipientGroup] migration-gap', {
+                credentialId: instance.credential.id,
+                reason: 'missing-entry',
+            });
+        }
+
+        if (!revocation.found || revocation.statusList === 'failed' || hooksFailed) {
+            result.failedCredentialUris.push(uri);
+        } else if (revocation.wasAlreadyRevoked) {
+            result.alreadyRevokedCredentialUris.push(uri);
+        } else {
+            result.revokedCredentialUris.push(uri);
+        }
+    } catch (error) {
+        console.error('[revokeBoostRecipientGroup] credential failed', {
+            credentialId: instance.credential.id,
+            error,
+        });
+        result.failedCredentialUris.push(uri);
+    }
+}
+
+if (result.revokedCredentialUris.length > 0) {
+    try {
+        await addNotificationToQueue({
+            type: LCNNotificationTypeEnumValidator.enum.CREDENTIAL_REVOKED,
+            to: {
+                did: getDidWeb(ctx.domain, resolvedRecipientProfileId),
+                profileId: resolvedRecipientProfileId,
+                ...(recipientProfile.notificationsWebhook && {
+                    notificationsWebhook: recipientProfile.notificationsWebhook,
+                }),
+            },
+            from: {
+                did: getDidWeb(ctx.domain, ctx.user.profile.profileId),
+                profileId: ctx.user.profile.profileId,
+                displayName: ctx.user.profile.displayName,
+            },
+            message: getNotificationMessage(
+                boost.name ? 'credentialRevokedNamed' : 'credentialRevokedUnnamed',
+                resolveRecipientLocale(recipientProfile),
+                {
+                    credentialName: boost.name ?? undefined,
+                    issuer: ctx.user.profile.displayName ?? ctx.user.profile.profileId,
+                }
+            ),
+            data: { vcUris: result.revokedCredentialUris },
+        });
+    } catch (error) {
+        console.error('Failed to queue group CREDENTIAL_REVOKED notification', error);
+    }
+}
+
+return result;
+```
+
+Close the mutation and route object after `return result;`. The notification block deliberately excludes `alreadyRevokedCredentialUris` so an idempotent repeat does not notify the holder again.
+
+-   [ ] **Step 12: Run the new backend suite and fix only failures in its contract**
+
+Run the command from Step 6.
+
+Expected: all group route cases pass. If the partial-failure spy identifies credentials by URI, use `getIdFromUri` so the assertion is independent of URI formatting.
+
+-   [ ] **Step 13: Run the existing per-instance and cleanup regressions**
+
+Run:
+
+```bash
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  test/revoke-suspend-per-instance.spec.ts \
+  test/revoke-credential.spec.ts
+```
+
+Expected: existing per-instance targeting, latest fallback, suspension, Bitstring, permissions, and connection cleanup tests pass unchanged.
+
+-   [ ] **Step 14: Build the shared types package**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-types build
+```
+
+Expected: build succeeds with the new validator exported through `src/index.ts`'s existing `export * from './lcn'`.
+
+-   [ ] **Step 15: Commit the backend group operation**
+
+```bash
+git add packages/learn-card-types/src/lcn.ts \
+  services/learn-card-network/brain-service/src/helpers/status-list.helpers.ts \
+  services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts \
+  services/learn-card-network/brain-service/src/accesslayer/credential/read.ts \
+  services/learn-card-network/brain-service/src/routes/boosts.ts \
+  services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
+git commit -m "feat: revoke all ScoutPass group credentials"
+```
+
+### Task 3: Expose the group mutation through the plugin and React Query
+
+**Files:**
+
+-   Modify: `packages/plugins/learn-card-network/src/types.ts`
+-   Modify: `packages/plugins/learn-card-network/src/plugin.ts`
+-   Create: `packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts`
+-   Create: `packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx`
+-   Modify: `packages/learn-card-base/src/index.ts`
+
+**Interfaces:**
+
+-   Consumes: brain-client mutation `client.boost.revokeBoostRecipientGroup.mutate({ boostUri, recipientProfileId })` and `RevokeBoostRecipientGroupResult` from `@learncard/types`.
+-   Produces: plugin method `revokeBoostRecipientGroup(boostUri, recipientProfileId)` and hook `useRevokeBoostRecipientGroup()`.
+
+-   [ ] **Step 1: Write a failing React Query mutation test**
+
+Create `revokeBoostRecipientGroup.test.tsx` with a mocked wallet method and a real `QueryClient`. Assert positional plugin invocation and settled invalidation:
+
+```ts
+await result.current.mutateAsync({
+    boostUri: 'lc:network:test:boost:troop',
+    recipientProfileId: 'scout-1',
+});
+
+expect(mocks.revokeBoostRecipientGroup).toHaveBeenCalledWith(
+    'lc:network:test:boost:troop',
+    'scout-1'
+);
+expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: ['credentialStatus'],
+});
+```
+
+Repeat with `mocks.revokeBoostRecipientGroup.mockRejectedValueOnce(new Error('offline'))` and assert the same invalidation prefixes are called from `onSettled`.
+
+-   [ ] **Step 2: Run the mutation test and verify it fails**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- \
+  src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+```
+
+Expected: FAIL because the hook does not exist.
+
+-   [ ] **Step 3: Add the typed network plugin method**
+
+Import `RevokeBoostRecipientGroupResult` in `packages/plugins/learn-card-network/src/types.ts` and add:
+
+```ts
+revokeBoostRecipientGroup: (boostUri: string, recipientProfileId: string) =>
+    Promise<RevokeBoostRecipientGroupResult>;
+```
+
+Add the implementation beside `revokeBoostRecipient` in `plugin.ts`:
+
+```ts
+revokeBoostRecipientGroup: async (_learnCard, boostUri, recipientProfileId) => {
+    await ensureUser();
+    return client.boost.revokeBoostRecipientGroup.mutate({
+        boostUri,
+        recipientProfileId,
+    });
+},
+```
+
+-   [ ] **Step 4: Implement the focused React Query mutation**
+
+Create `revokeBoostRecipientGroup.ts`:
+
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { RevokeBoostRecipientGroupResult } from '@learncard/types';
+import { useWallet } from '../../hooks/useWallet';
+
+export interface RevokeBoostRecipientGroupParams {
+    boostUri: string;
+    recipientProfileId: string;
+}
+
+const INVALIDATION_PREFIXES = [
+    ['boostRecipients'],
+    ['getPaginatedBoostRecipients'],
+    ['getBoostRecipientCount'],
+    ['boosts'],
+    ['useNetworkMembers'],
+    ['getMyActivities'],
+    ['getActivityStats'],
+    ['credentialStatus'],
+] as const;
+
+export const useRevokeBoostRecipientGroup = () => {
+    const { initWallet } = useWallet();
+    const queryClient = useQueryClient();
+
+    return useMutation<RevokeBoostRecipientGroupResult, Error, RevokeBoostRecipientGroupParams>({
+        mutationFn: async ({ boostUri, recipientProfileId }) => {
+            const wallet = await initWallet();
+            const method = wallet?.invoke?.revokeBoostRecipientGroup;
+            if (!method) throw new Error('Group removal is unavailable');
+            return method(boostUri, recipientProfileId);
+        },
+        onSettled: async () => {
+            await Promise.all(
+                INVALIDATION_PREFIXES.map(queryKey =>
+                    queryClient.invalidateQueries({ queryKey: [...queryKey] })
+                )
+            );
+        },
+    });
+};
+```
+
+Export it from `packages/learn-card-base/src/index.ts`.
+
+-   [ ] **Step 5: Run the mutation test and package builds**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- \
+  src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+bun run --cwd packages/plugins/learn-card-network build
+```
+
+Expected: mutation tests and the typed network plugin build pass.
+
+-   [ ] **Step 6: Commit the client API path**
+
+```bash
+git add packages/plugins/learn-card-network/src/types.ts \
+  packages/plugins/learn-card-network/src/plugin.ts \
+  packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts \
+  packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx \
+  packages/learn-card-base/src/index.ts
+git commit -m "feat: expose ScoutPass group revocation mutation"
+```
+
+### Task 4: Replace ScoutPass list inference with lifecycle presentation
+
+**Files:**
+
+-   Create: `apps/scouts/src/pages/troop/troopIdStatus.helpers.ts`
+-   Create: `apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts`
+-   Modify: `apps/scouts/src/pages/troop/TroopIdStatusButton.tsx`
+
+**Interfaces:**
+
+-   Consumes: shared `useCredentialStatus({ credential, uri, enabled })`.
+-   Produces: `TroopIdCredentialStatus`, `TroopIdIssuanceState`, `deriveTroopIdStatus`, `isCredentialActionRestricted`, and object-returning `useTroopIDStatus`.
+
+-   [ ] **Step 1: Write the pure ScoutPass status tests**
+
+Create `troopIdStatus.helpers.test.ts` with Bun's test API:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import { deriveTroopIdStatus, isCredentialActionRestricted } from '../troopIdStatus.helpers';
+
+describe('deriveTroopIdStatus', () => {
+    it('uses revoked and suspended lifecycle states before issuance state', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'revoked', issuanceState: 'pending' })).toBe(
+            'revoked'
+        );
+        expect(
+            deriveTroopIdStatus({ lifecycleStatus: 'suspended', issuanceState: 'accepted' })
+        ).toBe('suspended');
+    });
+
+    it('uses explicit pending metadata and otherwise reports valid', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', issuanceState: 'pending' })).toBe(
+            'pending'
+        );
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', issuanceState: 'accepted' })).toBe(
+            'valid'
+        );
+    });
+
+    it('keeps loading neutral and restricts actions until resolved', () => {
+        expect(deriveTroopIdStatus({ lifecycleStatus: 'active', isLoading: true })).toBeUndefined();
+        expect(isCredentialActionRestricted(undefined)).toBe(true);
+        expect(isCredentialActionRestricted('valid')).toBe(false);
+        expect(isCredentialActionRestricted('pending')).toBe(true);
+        expect(isCredentialActionRestricted('suspended')).toBe(true);
+        expect(isCredentialActionRestricted('revoked')).toBe(true);
+    });
+});
+```
+
+-   [ ] **Step 2: Run the helper test and verify it fails**
+
+Run:
+
+```bash
+bun test apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+```
+
+Expected: FAIL because the helper file does not exist.
+
+-   [ ] **Step 3: Implement the pure presentation adapter**
+
+Create `troopIdStatus.helpers.ts`:
+
+```ts
+import type { CredentialLifecycleStatus } from 'learn-card-base';
+
+export type TroopIdCredentialStatus = 'valid' | 'pending' | 'suspended' | 'revoked';
+export type TroopIdIssuanceState = 'accepted' | 'pending';
+
+export interface DeriveTroopIdStatusOptions {
+    lifecycleStatus: CredentialLifecycleStatus;
+    issuanceState?: TroopIdIssuanceState;
+    isLoading?: boolean;
+}
+
+export const deriveTroopIdStatus = ({
+    lifecycleStatus,
+    issuanceState = 'accepted',
+    isLoading = false,
+}: DeriveTroopIdStatusOptions): TroopIdCredentialStatus | undefined => {
+    if (isLoading) return undefined;
+    if (lifecycleStatus === 'revoked') return 'revoked';
+    if (lifecycleStatus === 'suspended') return 'suspended';
+    if (issuanceState === 'pending') return 'pending';
+    return 'valid';
+};
+
+export const isCredentialActionRestricted = (
+    status: TroopIdCredentialStatus | undefined
+): boolean => status !== 'valid';
+```
+
+-   [ ] **Step 4: Replace `useTroopIDStatus` recipient queries**
+
+In `TroopIdStatusButton.tsx`, remove `useGetBoostRecipients`, `useGetCurrentLCNUser`, and `useGetIDs`. Define:
+
+```ts
+export interface UseTroopIdStatusOptions {
+    credential?: VC;
+    credentialUri?: string;
+    issuanceState?: TroopIdIssuanceState;
+    enabled?: boolean;
+}
+
+export const useTroopIDStatus = ({
+    credential,
+    credentialUri,
+    issuanceState = 'accepted',
+    enabled = true,
+}: UseTroopIdStatusOptions) => {
+    const lifecycle = useCredentialStatus({
+        credential,
+        uri: credentialUri,
+        enabled: enabled && Boolean(credentialUri),
+    });
+    return {
+        ...lifecycle,
+        status: deriveTroopIdStatus({
+            lifecycleStatus: lifecycle.status,
+            issuanceState,
+            isLoading: lifecycle.isLoading,
+        }),
+    };
+};
+```
+
+Update `TroopIdStatusButtonProps` to accept `credentialUri`, `issuanceState`, and `lifecycleEnabled`. Add `Suspended` and `Unavailable` enum values. Preserve expired/invalid proof precedence, then map lifecycle presentation to:
+
+```ts
+case TroopIdStatusEnum.Suspended:
+    text = 'ID Suspended';
+    buttonColor = 'bg-amber-500';
+    break;
+case TroopIdStatusEnum.Unavailable:
+    text = 'Status Unavailable';
+    buttonColor = 'bg-amber-500';
+    break;
+```
+
+Render the skeleton while either proof data or lifecycle data is loading. An `isError` lifecycle result may show `Status Unavailable`, but it must never choose `Revoked`.
+
+-   [ ] **Step 5: Run the pure tests and build ScoutPass**
+
+Run:
+
+```bash
+bun test apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+bunx nx build scouts
+```
+
+Expected: helper tests and ScoutPass TypeScript/Vite build pass after updating any direct callers to the new object-returning hook signature with destructuring only; URI wiring is completed in Task 5.
+
+-   [ ] **Step 6: Prove list absence no longer drives lifecycle**
+
+Run:
+
+```bash
+rg -n "useGetBoostRecipients|isClaimedError|isAllError|useIsTroopIDRevokedFake" \
+  apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
+```
+
+Expected: no matches.
+
+-   [ ] **Step 7: Commit the ScoutPass lifecycle adapter**
+
+```bash
+git add apps/scouts/src/pages/troop/troopIdStatus.helpers.ts \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts \
+  apps/scouts/src/pages/troop/TroopIdStatusButton.tsx
+git commit -m "fix: use authoritative ScoutPass ID status"
+```
+
+### Task 5: Propagate credential URIs and gate sharing/protected actions
+
+**Files:**
+
+-   Modify: `apps/scouts/src/components/boost/hooks/useBoostMenu.tsx`
+-   Modify: `apps/scouts/src/components/boost/boost-options-menu/BoostOptionsMenu.tsx`
+-   Modify: `apps/scouts/src/components/boost/boost-earned-card/BoostEarnedIDCard.tsx`
+-   Modify: `apps/scouts/src/pages/ids/IdDisplayContainer.tsx`
+-   Modify: `apps/scouts/src/pages/troop/TroopPage.tsx`
+-   Modify: `apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx`
+-   Modify: `apps/scouts/src/pages/troop/TroopPageFooter.tsx`
+-   Modify: `apps/scouts/src/pages/troop/ViewTroopIdModal.tsx`
+-   Modify: `apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx`
+-   Test: `apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts`
+
+**Interfaces:**
+
+-   Consumes: `useTroopIDStatus({ credential, credentialUri, issuanceState, enabled })` and `isCredentialActionRestricted(status)`.
+-   Produces: `credentialUri?: string` across earned-ID display/detail props, `canShare` from `useBoostMenu`, and explicit `showShareButton` in `BoostOptionsMenu`.
+
+-   [ ] **Step 1: Extend the status helper test with share/protected-action assertions**
+
+Add a table test that treats unresolved, pending, suspended, and revoked states as restricted, and only valid as unrestricted:
+
+```ts
+it.each([
+    [undefined, true],
+    ['pending', true],
+    ['suspended', true],
+    ['revoked', true],
+    ['valid', false],
+] as const)('maps %s to restricted=%s', (status, expected) => {
+    expect(isCredentialActionRestricted(status)).toBe(expected);
+});
+```
+
+-   [ ] **Step 2: Run the helper test and confirm the gating contract**
+
+Run:
+
+```bash
+bun test apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+```
+
+Expected: PASS; this is the pure rule every UI entry point must consume.
+
+-   [ ] **Step 3: Gate the options-menu Share action**
+
+In `useBoostMenu.tsx`, call lifecycle status only for earned Troop IDs using the second argument (`boostUri`) as the credential-record URI:
+
+```ts
+const isTroopID = isTroopCategory(categoryType as BoostCategoryOptionsEnum);
+const { status, isLoading: statusLoading } = useTroopIDStatus({
+    credential: boost as VC,
+    credentialUri: boostUri,
+    enabled: menuType === BoostMenuType.earned && isTroopID,
+});
+const canShare = !isTroopID || (!statusLoading && !isCredentialActionRestricted(status));
+```
+
+Pass `showShareButton={menuType === BoostMenuType.earned && canShare}` to `BoostOptionsMenu`, guard `handleShareBoost` with `if (!canShare) return false`, and return `canShare` from the hook.
+
+In `BoostOptionsMenu.tsx`, add `showShareButton?: boolean` and change the menu condition to:
+
+```ts
+if (menuType === BoostMenuType.earned && showShareButton) {
+    boostMenuOptions.push({
+        id: 2,
+        title: 'Share',
+        icon: <ReplyIcon version="2" className="text-grayscale-900" />,
+        onClick: handleShare,
+    });
+}
+```
+
+-   [ ] **Step 4: Pass the earned credential-record URI through card and detail views**
+
+Add `credentialUri?: string` and `canShare?: boolean` to `IdDisplayContainerProps`, with `canShare = true` in the component destructuring so non-Troop call sites keep their existing behavior. In `BoostEarnedIDCard.tsx`:
+
+```tsx
+const { handlePresentBoostMenuModal, canShare } = useBoostMenu(
+    credential as VC,
+    uri ?? '',
+    credential as Boost,
+    credentialCategoryType,
+    BoostMenuType.earned
+);
+
+const presentShareBoostLink = () => {
+    if (!credential || !canShare) return;
+    newPreviewModal(
+        <ShareTroopIdModal
+            credential={(credential as VC & { boostCredential?: VC }).boostCredential ?? credential}
+            uri={(credential as VC & { boostId?: string }).boostId ?? uri ?? ''}
+        />,
+        { sectionClassName: '!bg-transparent !shadow-none !max-w-[355px]' },
+        { desktop: ModalTypes.Cancel, mobile: ModalTypes.Cancel }
+    );
+};
+
+// Add these props to the existing IdDisplayContainer call:
+credentialUri = { uri };
+canShare = { canShare };
+```
+
+Pass this guarded callback to `BoostPreview`:
+
+```tsx
+qrCodeOnClick={
+    canShare
+        ? () => {
+              closePreviewModal();
+              presentShareBoostLink();
+          }
+        : undefined
+}
+```
+
+-   [ ] **Step 5: Gate card QR actions and pass the URI into `TroopPage`**
+
+In `IdDisplayContainer.tsx`:
+
+```tsx
+<TroopIdStatusButton credential={cred?.boostCredential ?? cred} credentialUri={credentialUri} />;
+
+{
+    !loading && canShare && (
+        <button
+            onClick={event => {
+                event.stopPropagation();
+                handleQRCodeClick();
+            }}
+            className="absolute top-[10px] right-[10px] flex items-center justify-center bg-white rounded-full p-[10px] z-50 shadow-3xl"
+        >
+            <QRCodeScanner className="h-[30px] w-[30px] text-grayscale-900" />
+        </button>
+    );
+}
+
+<TroopPage
+    credential={cred.boostCredential ?? cred}
+    credentialUri={credentialUri}
+    handleShare={handleQRCodeClick}
+/>;
+```
+
+Managed cards pass neither `credentialUri` nor `canShare`; their Boost URI must not reach the holder lifecycle hook.
+
+-   [ ] **Step 6: Distinguish held record URI from managed Boost URI in `TroopPage`**
+
+Add `credentialUri?: string` to `TroopPageProps`. Keep `_boostUri` for Boost queries, request both accepted and pending recipient metadata, and derive holder state separately:
+
+```ts
+const { data: recipients } = useGetBoostRecipients(_boostUri, true, true);
+const holderCredentialUri = credentialUri ?? currentUserRecipient?.uri;
+const ownsCurrentId = Boolean(credentialUri) || (recipients ? Boolean(currentUserRecipient) : true);
+const holderIssuanceState = currentUserRecipient
+    ? currentUserRecipient.received
+        ? 'accepted'
+        : 'pending'
+    : 'accepted';
+const { status, isLoading: lifecycleLoading } = useTroopIDStatus({
+    credential: _credential,
+    credentialUri: holderCredentialUri,
+    issuanceState: holderIssuanceState,
+    enabled: ownsCurrentId && Boolean(holderCredentialUri),
+});
+const isRestricted =
+    !hasParentAdminAccess && (lifecycleLoading || isCredentialActionRestricted(status));
+```
+
+Pass `holderCredentialUri` and `holderIssuanceState` to `TroopPageIdAndTroopBox`, hide `TroopChildrenBox` and `TroopPageMembersBox` when `isRestricted`, and pass `isRestricted` to the footer. Parent-admin managed views retain their explicit access bypass without manufacturing holder status.
+
+-   [ ] **Step 7: Use the same status in the ID box and footer**
+
+Add `credentialUri?: string` and `issuanceState?: TroopIdIssuanceState` to `TroopPageIdAndTroopBoxProps`, pass both to the hook and `TroopIdStatusButton`, and compute:
+
+```ts
+const isRestricted = lifecycleLoading || isCredentialActionRestricted(status);
+```
+
+The QR button must be disabled and have `disabled:opacity-40 disabled:cursor-not-allowed` when restricted. Rename the footer prop from `isRevoked` to `isRestricted`, suppress its protected options for all restricted states, and change its edit guard to `const showEditButton = !isRestricted && role !== ScoutsRoleEnum.scout && canEdit`.
+
+-   [ ] **Step 8: Gate sharing in the full-screen member ID view**
+
+Add `credentialUri?: string` and `issuanceState?: TroopIdIssuanceState` to `ViewTroopIdModalProps` and `ViewTroopIdTemplateProps`. In `ViewTroopIdModal.tsx`, derive:
+
+```ts
+const { status, isLoading: statusLoading } = useTroopIDStatus({
+    credential,
+    credentialUri,
+    issuanceState,
+    enabled: Boolean(credentialUri),
+});
+const canShare = !statusLoading && !isCredentialActionRestricted(status);
+```
+
+Resolve the exact issuance instead of overwriting it with the Boost template:
+
+```ts
+const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
+credential = resolvedCredential?.boostCredential ?? resolvedCredential ?? credential;
+```
+
+Pass `credentialUri` and `issuanceState` to `ViewTroopIdTemplate`. Render its divet QR button and footer Share button only when `handleShare && canShare`. In `ViewTroopIdTemplate.tsx`, change status visibility to `isHidden={isClaimMode && !isAlreadyClaimed}` and replace `otherUserProfileID` on the status button with:
+
+```tsx
+credentialUri={credentialUri}
+issuanceState={issuanceState}
+lifecycleEnabled={Boolean(credentialUri)}
+```
+
+-   [ ] **Step 9: Build ScoutPass and inspect every lifecycle call site**
+
+Run:
+
+```bash
+bunx nx build scouts
+rg -n "useTroopIDStatus\(" apps/scouts/src
+rg -n "credentialUri=|showShareButton|canShare" \
+  apps/scouts/src/components/boost \
+  apps/scouts/src/pages/ids \
+  apps/scouts/src/pages/troop
+```
+
+Expected: build passes; earned flows supply record URIs; managed flows omit them; every direct share entry point is guarded.
+
+-   [ ] **Step 10: Commit URI propagation and action gating**
+
+```bash
+git add apps/scouts/src/components/boost/hooks/useBoostMenu.tsx \
+  apps/scouts/src/components/boost/boost-options-menu/BoostOptionsMenu.tsx \
+  apps/scouts/src/components/boost/boost-earned-card/BoostEarnedIDCard.tsx \
+  apps/scouts/src/pages/ids/IdDisplayContainer.tsx \
+  apps/scouts/src/pages/troop/TroopPage.tsx \
+  apps/scouts/src/pages/troop/TroopPageIdAndTroopBox.tsx \
+  apps/scouts/src/pages/troop/TroopPageFooter.tsx \
+  apps/scouts/src/pages/troop/ViewTroopIdModal.tsx \
+  apps/scouts/src/pages/troop/ViewTroopIdTemplate.tsx \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts
+git commit -m "fix: gate ScoutPass actions by credential lifecycle"
+```
+
+### Task 6: Use group revocation for every administrator removal role
+
+**Files:**
+
+-   Modify: `apps/scouts/src/hooks/useTroopMembers.tsx`
+-   Modify: `apps/scouts/src/pages/troop/TroopPageMembersBox.tsx`
+-   Create: `apps/scouts/src/pages/troop/groupRemoval.helpers.ts`
+-   Create: `apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts`
+-   Modify: `apps/scouts/src/pages/troop/IdOptionsModal.tsx`
+
+**Interfaces:**
+
+-   Consumes: `useRevokeBoostRecipientGroup()` and `RevokeBoostRecipientGroupResult`.
+-   Produces: member rows with `credentialUri`/`issuanceState` and one removal handler for Scout, Member, and Administrator rows.
+
+-   [ ] **Step 1: Write full/partial response interpretation tests**
+
+Create `groupRemoval.helpers.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import { getGroupRemovalOutcome } from '../groupRemoval.helpers';
+
+describe('getGroupRemovalOutcome', () => {
+    it('accepts new and already-revoked complete outcomes', () => {
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: ['credential:1'],
+                alreadyRevokedCredentialUris: [],
+                failedCredentialUris: [],
+            })
+        ).toBe('complete');
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: [],
+                alreadyRevokedCredentialUris: ['credential:1'],
+                failedCredentialUris: [],
+            })
+        ).toBe('complete');
+    });
+
+    it('reports a retryable partial outcome when any URI failed', () => {
+        expect(
+            getGroupRemovalOutcome({
+                revokedCredentialUris: ['credential:1'],
+                alreadyRevokedCredentialUris: [],
+                failedCredentialUris: ['credential:2'],
+            })
+        ).toBe('partial');
+    });
+});
+```
+
+-   [ ] **Step 2: Run the helper test and verify it fails**
+
+Run:
+
+```bash
+bun test apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
+```
+
+Expected: FAIL because the outcome helper does not exist.
+
+-   [ ] **Step 3: Implement exact outcome interpretation**
+
+Create `groupRemoval.helpers.ts`:
+
+```ts
+import type { RevokeBoostRecipientGroupResult } from '@learncard/types';
+
+export type GroupRemovalOutcome = 'complete' | 'partial';
+
+export const getGroupRemovalOutcome = (
+    result: RevokeBoostRecipientGroupResult
+): GroupRemovalOutcome => (result.failedCredentialUris.length === 0 ? 'complete' : 'partial');
+```
+
+-   [ ] **Step 4: Retain recipient issuance metadata in member rows**
+
+Export or update `MemberRow` in `useTroopMembers.tsx`:
+
+```ts
+type MemberRow = {
+    name: string;
+    image: string;
+    profileId: string;
+    type: 'Scout' | 'Leader' | 'Admin';
+    boostUri: string;
+    credentialUri?: string;
+    issuanceState: 'accepted' | 'pending';
+    isPersonalId: boolean;
+    canManageId: boolean;
+};
+```
+
+Request accepted and pending issuances in all three recipient queries:
+
+```ts
+const { data: scoutRecipients } = useGetBoostRecipients(scoutBoostUri, !skipMembers, true);
+const { data: leaderRecipients } = useGetBoostRecipients(troopBoostUri, !skipMembers, true);
+const { data: currentBoostRecipients } = useGetBoostRecipients(uri, !skipMembers, true);
+```
+
+For every recipient mapping, preserve:
+
+```ts
+credentialUri: recipient.uri,
+issuanceState: recipient.received ? 'accepted' : 'pending',
+```
+
+Keep deduplication by profile ID because the UI row represents a person and server-side removal now owns all-instance enumeration.
+
+-   [ ] **Step 5: Pass issuance metadata to the options modal**
+
+In `TroopPageMembersBox.tsx`, add:
+
+```tsx
+credentialUri={member.credentialUri}
+issuanceState={member.issuanceState}
+```
+
+Place those two props on the existing `IdOptionsModal` element next to `boostUri={member.boostUri}` and `type={member.type}`.
+
+Add both optional fields to `IdOptionsModalProps`:
+
+```ts
+credentialUri?: string;
+issuanceState?: TroopIdIssuanceState;
+```
+
+Resolve the exact displayed issuance without changing the removal target:
+
+```ts
+const { data: resolvedCredential } = useResolveBoost(credentialUri ?? boostUri);
+const displayCredential = resolvedCredential?.boostCredential ?? resolvedCredential ?? credential;
+```
+
+Pass `displayCredential`, `credentialUri`, and `issuanceState` into `ViewTroopIdModal` from `handleViewId`. Use `credentialUri ?? boostUri` only for resolving the exact credential shown; keep `boostUri` as the group-removal target.
+
+-   [ ] **Step 6: Replace role-specific client orchestration with one group mutation**
+
+In `IdOptionsModal.tsx`:
+
+-   Remove `useWallet`, `useRevokeBoostRecipient`, `PermissionsByRole`, `removeBoostAdmin`, and `updateBoostPermissions` from administrator removal.
+-   Keep the personal `Leave` branch unchanged.
+-   Use one mutation for every non-personal removable row:
+
+```ts
+const { mutateAsync: revokeGroup, isPending: isRevoking } = useRevokeBoostRecipientGroup();
+
+const handleRemoveFromGroup = async (): Promise<void> => {
+    await confirm({
+        text: `Are you sure you want to remove ${ownerName} from ${credential?.name}?`,
+        onConfirm: async () => {
+            try {
+                const result = await revokeGroup({
+                    boostUri,
+                    recipientProfileId: ownerProfileId,
+                });
+
+                if (getGroupRemovalOutcome(result) === 'partial') {
+                    presentToast(
+                        `Some IDs could not be revoked. Please try removing ${ownerName} again.`,
+                        { type: ToastTypeEnum.Error, hasDismissButton: true }
+                    );
+                    return;
+                }
+
+                presentToast(`${ownerName} has been removed from ${credential?.name}`, {
+                    type: ToastTypeEnum.Success,
+                    hasDismissButton: true,
+                });
+                closeAllModals();
+            } catch (error) {
+                log.error('Failed to remove group member', error);
+                presentToast(`Failed to remove ${ownerName}. Please try again.`, {
+                    type: ToastTypeEnum.Error,
+                    hasDismissButton: true,
+                });
+            }
+        },
+        cancelButtonClassName:
+            'cancel-btn text-grayscale-900 bg-grayscale-200 py-2 rounded-[40px] font-bold px-2 w-[100px]',
+        confirmButtonClassName:
+            'confirm-btn bg-grayscale-900 text-white py-2 rounded-[40px] font-bold px-2 w-[100px]',
+    });
+};
+```
+
+Both the Administrator row and Scout/Member row call `handleRemoveFromGroup`.
+
+-   [ ] **Step 7: Add a visible async state to the remove row**
+
+Extend `IdOptionRow` with `disabled?: boolean` and render contextual copy:
+
+```tsx
+<IdOptionRow
+    text={isRevoking ? 'Removing...' : `Remove from ${troopOrNetwork}`}
+    icon={isRevoking ? <LoadingSpinner /> : <PeaceIcon />}
+    onClick={handleRemoveFromGroup}
+    disabled={isRevoking}
+/>
+```
+
+Set the button's `disabled` attribute and add `disabled:opacity-40 disabled:cursor-not-allowed` to its existing classes.
+
+-   [ ] **Step 8: Run outcome tests and build ScoutPass**
+
+Run:
+
+```bash
+bun test apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
+bunx nx build scouts
+```
+
+Expected: response interpretation tests pass and all role paths compile against the group mutation.
+
+-   [ ] **Step 9: Prove the old removal APIs are absent from the modal**
+
+Run:
+
+```bash
+rg -n "useRevokeBoostRecipient|removeBoostAdmin|updateBoostPermissions|PermissionsByRole" \
+  apps/scouts/src/pages/troop/IdOptionsModal.tsx
+```
+
+Expected: no matches.
+
+-   [ ] **Step 10: Commit the unified removal flow**
+
+```bash
+git add apps/scouts/src/hooks/useTroopMembers.tsx \
+  apps/scouts/src/pages/troop/TroopPageMembersBox.tsx \
+  apps/scouts/src/pages/troop/groupRemoval.helpers.ts \
+  apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts \
+  apps/scouts/src/pages/troop/IdOptionsModal.tsx
+git commit -m "fix: revoke every ID when removing ScoutPass members"
+```
+
+### Task 7: Retain revoked records, update documentation, and verify the runtime slice
+
+**Files:**
+
+-   Modify: `apps/scouts/src/AppRouter.tsx`
+-   Modify: `docs/apps/scouts/credential-revocation.md`
+-   Modify: `apps/scouts/AGENTS.md`
+-   Verify: all files changed by Tasks 1–6
+
+**Interfaces:**
+
+-   Consumes: completed runtime behavior from Tasks 1–6.
+-   Produces: ScoutPass no longer deletes revoked records during app startup and project guidance describes the authoritative model.
+
+-   [ ] **Step 1: Remove deletion-based synchronization from ScoutPass**
+
+Delete `useSyncRevokedCredentials` from the `learn-card-base` import in `AppRouter.tsx` and remove:
+
+```ts
+useSyncRevokedCredentials(enablePrefetch);
+```
+
+Do not remove the shared hook implementation or LearnCard App usage in this runtime cycle.
+
+-   [ ] **Step 2: Update the ScoutPass revocation documentation**
+
+Rewrite `docs/apps/scouts/credential-revocation.md` around these exact sections:
+
+```md
+# ScoutPass credential revocation
+
+## Lifecycle source of truth
+
+ScoutPass reads the issuer-controlled lifecycle recorded by LearnCard Network for the specific credential URI. If that record is unavailable, it verifies the credential's Bitstring Status List entry. A loading state, missing list entry, or request failure is never treated as proof of revocation.
+
+## Removing a member
+
+Removing a member revokes every active, pending, or suspended credential issued from that group ID to the profile. LearnCard also removes permissions, administrator grants, and connections created by those credentials. Repeating the operation is safe; a partial result remains visible so the administrator can retry.
+
+## Holder experience
+
+Revoked IDs remain in the holder's credential list and display **ID Revoked**. Suspended and unaccepted IDs display **ID Suspended** and **Pending Acceptance**. Sharing and membership-protected actions are unavailable in all three states.
+
+## Legacy credentials
+
+Credentials issued before Bitstring Status List support still receive authoritative LearnCard Network revocation, but their old signed copies cannot be changed. External cryptographic revocation for those IDs requires controlled reissuance, retirement or blocklisting of old identifiers, and verifier cutover in a separate migration cycle.
+```
+
+Use user-facing language in headings and explanatory prose; reserve graph and Bitstring terms for the technical lifecycle section.
+
+-   [ ] **Step 3: Replace outdated agent guidance**
+
+In `apps/scouts/AGENTS.md`, replace the recipient-list status table and parent-admin workaround text with:
+
+```md
+## Troop credential lifecycle
+
+-   `learn-card-base/useCredentialStatus` is the shared authoritative holder lifecycle hook.
+-   `TroopIdStatusButton.tsx` adapts lifecycle plus explicit acceptance metadata for ScoutPass presentation.
+-   Earned views must pass a credential-record URI; managed views must not pass a Boost URI as a credential URI.
+-   Missing/query-error recipient data must never be interpreted as revocation.
+-   Administrator group removal uses `useRevokeBoostRecipientGroup`; the existing singular mutation remains per-instance.
+-   Revoked credentials remain visible. Do not mount deletion-based revoked-credential synchronization in ScoutPass.
+```
+
+Keep the still-correct hierarchy and issuance guidance.
+
+-   [ ] **Step 4: Run focused unit and integration verification**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-base test -- \
+  src/hooks/__tests__/deriveLifecycleStatus.test.ts \
+  src/hooks/__tests__/useCredentialStatus.test.tsx \
+  src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+bun run --cwd apps/learn-card-app test:unit -- \
+  src/hooks/__tests__/useCredentialStatus.test.ts
+bun test \
+  apps/scouts/src/pages/troop/__tests__/troopIdStatus.helpers.test.ts \
+  apps/scouts/src/pages/troop/__tests__/groupRemoval.helpers.test.ts
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  test/revoke-boost-recipient-group.spec.ts \
+  test/revoke-suspend-per-instance.spec.ts \
+  test/revoke-credential.spec.ts \
+  test/scouts-hierarchy.spec.ts
+```
+
+Expected: every listed suite passes. DIDKit native fallback warnings and deliberate missing-entry migration-gap warnings are acceptable; test failures are not.
+
+-   [ ] **Step 5: Run package builds**
+
+Run:
+
+```bash
+bun run --cwd packages/learn-card-types build
+bun run --cwd packages/plugins/learn-card-network build
+bunx nx build scouts
+```
+
+Expected: all builds exit zero.
+
+-   [ ] **Step 6: Run static acceptance searches**
+
+Run:
+
+```bash
+rg -n "useSyncRevokedCredentials" apps/scouts/src
+rg -n "isClaimedError|isAllError|useIsTroopIDRevokedFake" apps/scouts/src
+rg -n "removeBoostAdmin|updateBoostPermissions" apps/scouts/src/pages/troop/IdOptionsModal.tsx
+git diff --check
+```
+
+Expected: the three `rg` commands return no matches and `git diff --check` emits no errors.
+
+-   [ ] **Step 7: Perform OrbStack-backed manual acceptance checks**
+
+With the existing OrbStack Docker runtime, start the local services and ScoutPass in separate terminals:
+
+```bash
+orbctl start
+bun run --cwd apps/scouts dev:services
+```
+
+```bash
+bun run --cwd apps/scouts docker-start
+```
+
+Then verify:
+
+1. Issue the same Scout ID twice to one profile and leave another issuance pending.
+2. Suspend one accepted instance.
+3. Remove the profile once and confirm the UI reports complete success.
+4. Confirm member counts/list refresh and no membership-protected content remains for the holder.
+5. Confirm each held record remains visible with `ID Revoked` and no Share/QR action.
+6. Verify a status-enabled credential against its status-list endpoint and confirm the revocation bit is set.
+7. Repeat removal and confirm it succeeds as an already-revoked no-op without duplicate notification.
+8. Simulate an offline lifecycle request and confirm ScoutPass shows neither `ID Revoked` nor a false successful removal.
+
+-   [ ] **Step 8: Commit retention and documentation**
+
+```bash
+git add apps/scouts/src/AppRouter.tsx \
+  docs/apps/scouts/credential-revocation.md \
+  apps/scouts/AGENTS.md
+git commit -m "docs: describe ScoutPass authoritative revocation"
+```
+
+-   [ ] **Step 9: Confirm the branch is ready for review**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate origin/main..HEAD
+```
+
+Expected: clean worktree and one focused commit per task, plus the approved design and implementation-plan commits.
+
+## Final Acceptance Matrix
+
+| Requirement                                   | Primary implementation    | Verification                                      |
+| --------------------------------------------- | ------------------------- | ------------------------------------------------- |
+| Authoritative holder lifecycle                | Task 1, Task 4            | Shared hook tests; Scout helper tests             |
+| No error/list-absence false revocation        | Task 1, Task 4            | Fail-open hook cases; static search               |
+| Revoke all active/pending/suspended instances | Task 2                    | Group integration suite                           |
+| Bitstring revocation for capable credentials  | Task 2                    | Status-list bit assertions                        |
+| Legacy gap visible without blocking runtime   | Task 2                    | Migration-gap log assertion                       |
+| Idempotent retry repairs partial work         | Task 2                    | Partial-cleanup retry test                        |
+| Existing per-instance API unchanged           | Task 2                    | Existing per-instance regression suite            |
+| Typed plugin/client path                      | Task 3                    | Mutation test; plugin build                       |
+| Retained revoked IDs                          | Task 7                    | Static search; manual holder check                |
+| Share/protected actions disabled              | Task 5                    | Pure restriction tests; Scout build; manual check |
+| Scout/Member/Admin removal unified            | Task 6                    | Outcome tests; static search; manual check        |
+| Self-service Leave excluded                   | Global constraint, Task 6 | Review diff for unchanged personal branch         |
+| Documentation current                         | Task 7                    | Documentation review                              |

--- a/docs/superpowers/specs/2026-08-09-lc-1950-scoutpass-real-revocation-design.md
+++ b/docs/superpowers/specs/2026-08-09-lc-1950-scoutpass-real-revocation-design.md
@@ -1,0 +1,346 @@
+# LC-1950: ScoutPass Real Revocation Design
+
+**Date:** 2026-08-09
+
+**Status:** Approved for implementation planning
+
+**Jira:** https://welibrary.atlassian.net/browse/LC-1950
+
+## Summary
+
+ScoutPass currently infers whether a Troop ID is revoked from recipient-list membership. That is not an authoritative lifecycle check: request failures can appear as revocation, revoked IDs disappear from the holder's view, and group removal does not reliably revoke every credential instance.
+
+This design makes the existing LearnCard lifecycle system the source of truth in ScoutPass. Removing a person from a group will revoke every credential issued from that group Boost to that profile, including active, pending, and suspended instances. Holder-facing ScoutPass screens will keep the credential visible, show its authoritative state, and disable sharing and protected actions when it is not active.
+
+Delivery is intentionally split into two cycles:
+
+1. **Runtime revocation:** authoritative status, cryptographic Bitstring Status List revocation where the credential supports it, group-level removal, cleanup hooks, retained revoked IDs, and tests.
+2. **Legacy migration and compatibility:** inventory pre-Bitstring credentials, reissue active credentials where needed, retire or blocklist old identifiers, and cut external verifiers over to the replacement credentials.
+
+The runtime cycle is the first priority and is the scope of the implementation plan that follows this design.
+
+## Goals
+
+-   Replace ScoutPass's recipient-list-based "fake revocation" with the lifecycle system already used by LearnCard App.
+-   Revoke all credential instances that grant a profile membership in a group when an authorized administrator removes that profile.
+-   Set the Bitstring Status List revocation bit for every affected credential that contains a revocation status-list entry.
+-   Remove permissions, administrator grants, and auto-created connections that were derived from the revoked credentials.
+-   Keep revoked credential records visible to holders as `ID Revoked` instead of deleting them.
+-   Disable sharing and membership-protected actions for pending, suspended, and revoked IDs.
+-   Preserve the existing single-instance revoke API and its current targeting behavior.
+-   Make bulk removal idempotent and expose partial failures so administrators can retry safely.
+
+## Non-goals for the Runtime Cycle
+
+-   Migrating or rewriting old signed credentials in place. A previously signed credential cannot be modified without invalidating its proof.
+-   Completing the controlled reissuance and verifier-cutover program for pre-Bitstring active IDs.
+-   Implementing self-service `Leave` behavior. Holder-initiated departure requires a separate product and authorization design.
+-   Deleting revoked credential records from LearnCloud or the network index.
+-   Changing the existing `revokeBoostRecipient` semantics. When a credential URI is provided it continues to revoke only that instance; without one it continues to target the most recent non-revoked instance.
+
+## Approved Product Decisions
+
+1. Removing a member from a group revokes **every** issuance for that group and profile, not only the latest issuance.
+2. The bulk operation includes active, pending, and suspended credentials. A suspended credential must not be able to regain membership later through unsuspension.
+3. Revoked IDs remain visible to the holder and are labeled `ID Revoked`.
+4. External cryptographic revocation is required for active IDs issued before Bitstring Status List support. Because old signed copies cannot be changed, that requirement will be met in the follow-up migration cycle through controlled reissuance plus retirement/blocklist and verifier cutover.
+5. Self-service `Leave` is separate from administrator removal and is not part of LC-1950's runtime cycle.
+
+## Current State
+
+### Authoritative lifecycle support
+
+LearnCard Network already stores issuer-controlled lifecycle state on `CREDENTIAL_SENT` and can set a credential's Bitstring Status List revocation or suspension bit. LearnCard App's `useCredentialStatus` first queries `getMyCredentialLifecycleStatuses`, then falls back to credential verification, and fails open to `active` when status cannot be established. Its pure `deriveLifecycleStatus` helper gives structured lifecycle results and verification errors precedence over incidental list state.
+
+### ScoutPass status inference
+
+ScoutPass's `useTroopIDStatus` checks whether the current profile appears in claimed or all-recipient queries. It reports:
+
+-   `valid` when present in claimed recipients;
+-   `pending` when present only in all recipients;
+-   `revoked` when absent from both lists.
+
+This means an API failure or stale list can be rendered as revocation. The check is also tied to a Boost/profile pair rather than the credential record URI held by the user.
+
+### Removal behavior
+
+The existing `revokeBoostRecipient` API is deliberately per-instance. It revokes an explicitly supplied credential URI or, when no URI is supplied, the most recent non-revoked instance. ScoutPass currently calls it without a credential URI for Scout and Member removal. Administrator removal separately mutates permissions. Those paths do not express the group-level invariant that no issuance may remain usable after removal.
+
+### Holder cleanup
+
+ScoutPass mounts `useSyncRevokedCredentials`, which deletes revoked credentials from the holder's personal index. That conflicts with the approved requirement to retain and visibly label revoked IDs.
+
+## Architecture
+
+### 1. Shared lifecycle hook in `learn-card-base`
+
+Move the lifecycle derivation and query behavior currently local to LearnCard App into `packages/learn-card-base` as a shared public hook. Both LearnCard App and ScoutPass will consume the same implementation.
+
+The shared contract is:
+
+```ts
+import type { VC } from '@learncard/types';
+
+export type CredentialLifecycleStatus = 'active' | 'revoked' | 'suspended';
+
+export interface UseCredentialStatusOptions {
+    uri?: string;
+    credential?: VC;
+    enabled?: boolean;
+}
+
+export interface CredentialStatusResult {
+    status: CredentialLifecycleStatus;
+    isLoading: boolean;
+    isError: boolean;
+}
+
+export const useCredentialStatus = (
+    options: UseCredentialStatusOptions
+): CredentialStatusResult;
+```
+
+Behavior:
+
+1. If there is no credential URI or the hook is disabled, return `active` with no request. Callers that require lifecycle gating must provide the held credential-record URI.
+2. Query the authenticated holder's authoritative lifecycle endpoint using that URI.
+3. If the backend returns a lifecycle status, use it.
+4. If no backend status is available, verify the supplied credential, or read it by URI when necessary, so Bitstring Status List results can derive `revoked` or `suspended`.
+5. If the status request or verification fails for an unrelated reason, expose `isError` and fail open to `active`; request failure must never imply revocation.
+6. Preserve the existing query key prefix, `['credentialStatus', credentialUri]`, so lifecycle invalidation remains compatible.
+
+Pending is issuance state rather than a cryptographic credential lifecycle state. ScoutPass will continue to derive `pending` from explicit issuance metadata for credentials that have been sent but not accepted; it will not infer pending from a failed request.
+
+LearnCard App's local hook becomes a compatibility re-export during this cycle so existing imports do not need a flag-day change.
+
+### 2. Dedicated group-removal API
+
+Add a new `revokeBoostRecipientGroup` mutation through the full network type flow: brain-service route, network plugin type and implementation, and `learn-card-base` React Query mutation.
+
+Input:
+
+```ts
+export interface RevokeBoostRecipientGroupInput {
+    boostUri: string;
+    recipientProfileId: string;
+}
+```
+
+Result:
+
+```ts
+export interface RevokeBoostRecipientGroupResult {
+    revokedCredentialUris: string[];
+    alreadyRevokedCredentialUris: string[];
+    failedCredentialUris: string[];
+}
+```
+
+The group route is distinct from `revokeBoostRecipient`; it represents a different business invariant and avoids silently changing a public per-instance API.
+
+The server will:
+
+1. Resolve the recipient profile and Boost.
+2. Check `canRevoke` before returning or mutating credential data.
+3. Load every credential instance connected to that Boost and recipient, including already-revoked instances, with the effective issuer-controlled state from `CREDENTIAL_SENT` and any legacy `CREDENTIAL_RECEIVED` status.
+4. Partition already-revoked instances from active, pending, and suspended instances for result reporting.
+5. Mark each non-revoked instance revoked on `CREDENTIAL_SENT`.
+6. For every instance, including one whose relationship was already revoked, ensure its Bitstring Status List revocation bit is set when a revocation entry exists and run the idempotent revoke hooks. Reprocessing already-revoked instances allows a retry to repair a prior partial failure instead of skipping required cleanup.
+7. Collect per-instance outcomes rather than abandoning the batch after the first failure.
+8. Queue one consolidated holder notification containing the successfully revoked credential URIs. Notification failure is logged but does not turn a completed revocation into a failure.
+9. Return all three URI groups to the authorized caller.
+
+The supporting access-layer query must return all matching credential instances in deterministic newest-first order and must not reuse the existing latest-only accessor.
+
+The status-list helper must distinguish three internal outcomes: `updated`, `missing-entry`, and `failed`. `missing-entry` identifies a pre-Bitstring credential: authoritative revocation succeeds and a structured migration-gap log is emitted. `failed` means a credential that has a revocation entry could not be updated; the URI is returned in `failedCredentialUris` so the operation can repair it on retry. The existing external per-instance API remains boolean and keeps its targeting semantics.
+
+### 3. ScoutPass credential URI wiring
+
+The credential-record URI returned by recipient and earned-ID queries must be preserved through ScoutPass view models and component props. In particular:
+
+-   `useTroopMembers` must retain each recipient issuance URI rather than reducing a profile to only Boost and profile data.
+-   Earned-ID card flows must pass their record URI through `IdDisplayContainer`, `TroopPage`, status controls, and the options menu.
+-   Managed-group views must distinguish the managed Boost URI from a credential-record URI; a Boost URI must never be passed to the lifecycle hook as though it were a held credential.
+-   Where multiple issuances exist, holder views operate on the concrete record being displayed. Administrator group removal intentionally operates on the Boost/profile pair and revokes them all.
+
+### 4. ScoutPass status and presentation
+
+Replace list-membership status inference with a small ScoutPass presentation adapter over:
+
+-   the shared credential lifecycle status for a concrete credential URI; and
+-   explicit accepted/pending issuance metadata.
+
+Presentation states are:
+
+| State       | Source                                   | UI behavior                                                       |
+| ----------- | ---------------------------------------- | ----------------------------------------------------------------- |
+| `valid`     | lifecycle `active` and issuance accepted | Show `Valid ID`; sharing and protected actions enabled            |
+| `pending`   | issuance explicitly not accepted         | Show `Pending Acceptance`; sharing and protected actions disabled |
+| `suspended` | lifecycle `suspended`                    | Show `ID Suspended`; sharing and protected actions disabled       |
+| `revoked`   | lifecycle `revoked`                      | Show `ID Revoked`; sharing and protected actions disabled         |
+
+Loading remains visibly neutral until status is known. An error shows a retryable, user-friendly status error where needed but does not render `ID Revoked`.
+
+Revoked ID records remain in holder lists and detail views. ScoutPass must remove its top-level `useSyncRevokedCredentials` call so it does not delete records as a side effect of viewing the app. Existing compatibility behavior elsewhere in LearnCard App remains unchanged during this cycle.
+
+### 5. Administrator removal flow
+
+Scout and Member removal uses the new group mutation. Administrator removal also uses the same group mutation; permissions and administrator grants are cleaned through the normal per-credential revoke hooks rather than separate client-orchestrated mutations.
+
+The UI will:
+
+1. Show an in-progress state while the mutation runs.
+2. Treat a response with no `failedCredentialUris` as success, including a repeat request where every credential is already revoked.
+3. Show a success message only after complete success.
+4. Show a retryable partial-failure message when any URI failed.
+5. Refresh members, recipient counts, activity, and credential lifecycle queries after both full and partial outcomes so the screen reflects server state.
+
+The client must not report a failed administrator cleanup as a successful member removal.
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Scouts as ScoutPass
+    participant API as LearnCard Network
+    participant Graph as Neo4j lifecycle state
+    participant Status as Bitstring Status List
+    participant Hooks as Revoke hooks
+
+    Admin->>Scouts: Remove member
+    Scouts->>API: revokeBoostRecipientGroup(boostUri, profileId)
+    API->>API: Resolve resources and authorize canRevoke
+    API->>Graph: Load all credential instances and statuses
+    loop Each active, pending, or suspended instance
+        API->>Graph: Set CREDENTIAL_SENT.status = revoked
+        API->>Status: Set revocation bit when status entry exists
+        API->>Hooks: Remove grants and derived connections
+    end
+    API-->>Scouts: revoked / already revoked / failed URI lists
+    Scouts->>Scouts: Refresh affected queries and show outcome
+```
+
+## Idempotency and Failure Semantics
+
+-   Authorization and resource resolution happen before batch mutation. Unauthorized callers receive no credential inventory.
+-   Already-revoked credentials do not rewrite lifecycle state, but their status-list bit and idempotent cleanup hooks are checked again. They are returned separately after those checks succeed.
+-   Repeating the same group removal after full success produces no effective state changes and is treated as success.
+-   The batch is best-effort across credential instances because graph state, external status-list updates, hooks, and notifications do not share a database transaction.
+-   One instance failure does not prevent later instances from being attempted.
+-   A URI appears in `revokedCredentialUris` only after the authoritative relationship update, applicable Bitstring update, and revoke hooks complete. A missing legacy Bitstring entry is logged for migration reporting but does not roll back the authoritative relationship revocation.
+-   A URI appears in `alreadyRevokedCredentialUris` only after its applicable Bitstring update and cleanup hooks complete.
+-   A URI appears in `failedCredentialUris` when its authoritative relationship update, applicable Bitstring update, or mandatory cleanup hooks fail. Retrying the group operation reprocesses these side effects even if the relationship was already changed.
+-   Consolidated notification delivery is non-blocking and is not included in `failedCredentialUris`.
+-   Structured server logs include counts and internal credential identifiers but no credential contents or recipient personal data.
+
+## Query Invalidation
+
+The `learn-card-base` group mutation invalidates, at minimum:
+
+-   Boost recipient lists for the affected Boost;
+-   paginated recipient and recipient-count queries;
+-   ScoutPass network/member lists;
+-   activity list and activity statistics;
+-   credential lifecycle queries under `['credentialStatus']`;
+-   cached Boost summaries that derive recipient state.
+
+Invalidation runs from the mutation's settled path for full success, returned partial outcomes, and transport errors. A transport failure can leave the client uncertain whether the server changed any instances, so refreshing is safer than retaining stale membership. Authorization and transport errors still use the existing mutation error feedback path.
+
+## Security and Privacy
+
+-   The server, not the client, determines the full credential set to revoke.
+-   `canRevoke` is checked against the resolved Boost before credential URIs are returned.
+-   A caller cannot submit arbitrary credential URIs to the group route.
+-   The query constrains every credential to both the Boost and the resolved recipient profile.
+-   Existing public per-instance authorization remains unchanged.
+-   Logs and user-facing errors do not include credential contents or raw internal failures.
+
+## Testing Strategy
+
+### Shared lifecycle behavior
+
+-   Move or reproduce the existing lifecycle derivation tests in `learn-card-base`.
+-   Cover authoritative `active`, `revoked`, and `suspended` responses.
+-   Cover Bitstring-verification fallback when authoritative state is absent.
+-   Cover status-query and verification failures and assert they do not derive `revoked`.
+-   Verify LearnCard App's compatibility re-export preserves behavior.
+
+### Brain-service group removal
+
+-   Revokes all active instances for the same Boost/profile.
+-   Revokes pending instances that have no `CREDENTIAL_RECEIVED` relationship.
+-   Revokes suspended instances and prevents later unsuspension from restoring access.
+-   Reports already-revoked instances and succeeds on a duplicate request.
+-   Rejects unauthorized callers before exposing credential URIs.
+-   Sets each available Bitstring revocation bit.
+-   Emits a structured migration-gap log for legacy credentials without a revocation entry while retaining authoritative revocation.
+-   Runs permission, administrator, auto-connect, and connection cleanup hooks for each newly revoked instance.
+-   Sends one consolidated notification for the batch; notification failure does not fail revocation.
+-   Returns partial failures and continues processing remaining instances.
+-   Keeps the existing per-instance revoke and suspend test suite green, including latest-instance fallback semantics.
+
+### ScoutPass
+
+-   A revoked earned ID remains present and displays `ID Revoked`.
+-   Pending and suspended IDs display their distinct states.
+-   Sharing and protected actions are disabled for pending, suspended, and revoked states.
+-   A list-query or lifecycle-query failure never displays `ID Revoked` by inference.
+-   Managed-group Boost URIs are not sent to the holder lifecycle hook.
+-   Group removal uses the group API for Scout, Member, and Administrator roles.
+-   Full success, already-revoked success, partial failure, and transport failure produce the correct feedback and refresh behavior.
+-   ScoutPass no longer mounts deletion-based revoked-credential synchronization.
+
+### Baseline and focused verification
+
+The implementation plan will retain these known-green focused suites and add package-specific commands for the new tests:
+
+```bash
+bun run --cwd apps/learn-card-app test:unit -- src/hooks/__tests__/useCredentialStatus.test.ts
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  test/revoke-suspend-per-instance.spec.ts
+env SEED=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bun run --cwd services/learn-card-network/brain-service test -- run \
+  test/scouts-hierarchy.spec.ts
+```
+
+## Documentation
+
+Update `docs/apps/scouts/credential-revocation.md` in the runtime cycle to describe:
+
+-   authoritative lifecycle state rather than recipient-list inference;
+-   retained revoked IDs;
+-   group removal semantics;
+-   cryptographic status behavior for credentials with Bitstring entries; and
+-   the explicit limitation and planned handling of pre-Bitstring credentials.
+
+The ScoutPass `AGENTS.md` lifecycle section should be updated with the new hook and component landmarks so future changes do not restore list-absence inference.
+
+## Runtime Acceptance Criteria
+
+-   An authorized group removal revokes all active, pending, and suspended credential instances for the Boost/profile pair.
+-   Credentials with revocation status-list entries verify as revoked outside LearnCard/ScoutPass after their published Bitstring list is refreshed.
+-   No old issuance can keep or regain ScoutPass membership after successful group removal.
+-   Permission, administrator, and connection side effects derived from the affected credentials are removed.
+-   Revoked IDs remain visible and display `ID Revoked`.
+-   Pending, suspended, and revoked IDs cannot be shared or used for membership-protected actions.
+-   Network or query failures do not render a credential as revoked.
+-   Repeating removal is safe and successful.
+-   Partial failures are visible and retryable.
+-   Existing single-instance lifecycle behavior remains backward compatible.
+-   Focused frontend, shared-package, and brain-service tests pass.
+
+## Follow-up: Pre-Bitstring Migration and Compatibility
+
+After the runtime cycle is stable, a separate design and implementation cycle will:
+
+1. Inventory ScoutPass credential instances by issuance generation and status-list capability.
+2. Produce an auditable report of active, pending, suspended, and already-revoked legacy IDs.
+3. Reissue active pre-Bitstring IDs with status-list entries under a controlled process.
+4. Preserve group hierarchy, role, display, and permission intent during reissuance.
+5. Retire or blocklist old credential identifiers at LearnCard-controlled verification boundaries.
+6. Cut external verifiers over to replacement identifiers and document the period in which legacy signed copies cannot be cryptographically revoked on their own.
+7. Define rollback, holder communication, and reconciliation procedures before production execution.
+
+That follow-up is required to satisfy cryptographic revocation for pre-Bitstring active IDs outside LearnCard/ScoutPass. It is secondary to shipping correct runtime revocation for current credentials.

--- a/packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts
+++ b/packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { deriveLifecycleStatus } from '../deriveLifecycleStatus';
+
+describe('deriveLifecycleStatus', () => {
+    it('gives a set revocation bit precedence over suspension', () => {
+        expect(
+            deriveLifecycleStatus({
+                status: [
+                    {
+                        entryType: 'BitstringStatusListEntry',
+                        statusPurpose: 'suspension',
+                        isSet: true,
+                    },
+                    {
+                        entryType: 'BitstringStatusListEntry',
+                        statusPurpose: 'revocation',
+                        isSet: true,
+                    },
+                ],
+            })
+        ).toBe('revoked');
+    });
+
+    it.each([
+        ['revoked', 'revocation'],
+        ['suspended', 'suspension'],
+    ] as const)('returns %s for a set %s entry', (expected, purpose) => {
+        expect(
+            deriveLifecycleStatus({
+                status: [
+                    { entryType: 'BitstringStatusListEntry', statusPurpose: purpose, isSet: true },
+                ],
+            })
+        ).toBe(expected);
+    });
+
+    it('fails open for empty checks and unrelated verification errors', () => {
+        expect(deriveLifecycleStatus(undefined)).toBe('active');
+        expect(deriveLifecycleStatus({ errors: ['proof could not be loaded'] })).toBe('active');
+    });
+});

--- a/packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts
+++ b/packages/learn-card-base/src/hooks/__tests__/deriveLifecycleStatus.test.ts
@@ -38,4 +38,11 @@ describe('deriveLifecycleStatus', () => {
         expect(deriveLifecycleStatus(undefined)).toBe('active');
         expect(deriveLifecycleStatus({ errors: ['proof could not be loaded'] })).toBe('active');
     });
+
+    it.each(['credential is revoked', 'credential is suspended'])(
+        'fails open when a verification error says "%s"',
+        error => {
+            expect(deriveLifecycleStatus({ errors: [error] })).toBe('active');
+        }
+    );
 });

--- a/packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx
+++ b/packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VC } from '@learncard/types';
+
+const uri = 'lc:cloud:credential-status-test';
+const credential = { '@context': [], type: [], credentialSubject: {} } as unknown as VC;
+
+const mocks = vi.hoisted(() => ({
+    initWallet: vi.fn(),
+    getMyCredentialLifecycleStatuses: vi.fn(),
+    readCredential: vi.fn(),
+    verifyCredential: vi.fn(),
+}));
+
+vi.mock('../useWallet', () => ({
+    useWallet: () => ({ initWallet: mocks.initWallet }),
+}));
+
+import { useCredentialStatus, type UseCredentialStatusOptions } from '../useCredentialStatus';
+
+const renderStatusHook = (options: UseCredentialStatusOptions) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return renderHook(() => useCredentialStatus(options), { wrapper });
+};
+
+describe('useCredentialStatus', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.initWallet.mockResolvedValue({
+            invoke: {
+                getMyCredentialLifecycleStatuses: mocks.getMyCredentialLifecycleStatuses,
+                verifyCredential: mocks.verifyCredential,
+            },
+            read: { get: mocks.readCredential },
+        });
+    });
+
+    it('uses an authoritative revoked backend status without verification', async () => {
+        mocks.getMyCredentialLifecycleStatuses.mockResolvedValue({ [uri]: 'revoked' });
+
+        const { result } = renderStatusHook({ credential, uri });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.status).toBe('revoked');
+        expect(mocks.verifyCredential).not.toHaveBeenCalled();
+    });
+
+    it('falls back to verification when the backend status request fails', async () => {
+        mocks.getMyCredentialLifecycleStatuses.mockRejectedValue(new Error('network unavailable'));
+        mocks.verifyCredential.mockResolvedValue({
+            status: [
+                {
+                    entryType: 'BitstringStatusListEntry',
+                    statusPurpose: 'suspension',
+                    isSet: true,
+                },
+            ],
+        });
+
+        const { result } = renderStatusHook({ credential, uri });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.status).toBe('suspended');
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('fails open and retains error metadata when both lifecycle sources fail', async () => {
+        mocks.getMyCredentialLifecycleStatuses.mockRejectedValue(new Error('network unavailable'));
+        mocks.verifyCredential.mockRejectedValue(new Error('verification unavailable'));
+
+        const { result } = renderStatusHook({ credential, uri });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.status).toBe('active');
+        expect(result.current.isError).toBe(true);
+    });
+
+    it('does not initialize a wallet or load when disabled or missing a URI', () => {
+        const { result } = renderStatusHook({ credential, enabled: false });
+
+        expect(result.current).toEqual({ status: 'active', isLoading: false, isError: false });
+        expect(mocks.initWallet).not.toHaveBeenCalled();
+    });
+});

--- a/packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx
+++ b/packages/learn-card-base/src/hooks/__tests__/useCredentialStatus.test.tsx
@@ -87,6 +87,18 @@ describe('useCredentialStatus', () => {
         expect(result.current.isError).toBe(true);
     });
 
+    it('fails open and retains error metadata when verification resolves with errors', async () => {
+        mocks.getMyCredentialLifecycleStatuses.mockRejectedValue(new Error('network unavailable'));
+        mocks.verifyCredential.mockResolvedValue({ errors: ['proof could not be verified'] });
+
+        const { result } = renderStatusHook({ credential, uri });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.status).toBe('active');
+        expect(result.current.isError).toBe(true);
+    });
+
     it('does not initialize a wallet or load when disabled or missing a URI', () => {
         const { result } = renderStatusHook({ credential, enabled: false });
 

--- a/packages/learn-card-base/src/hooks/credentialStatus.types.ts
+++ b/packages/learn-card-base/src/hooks/credentialStatus.types.ts
@@ -1,0 +1,15 @@
+import type { VC } from '@learncard/types';
+
+import type { CredentialLifecycleStatus } from './deriveLifecycleStatus';
+
+export interface UseCredentialStatusOptions {
+    uri?: string;
+    credential?: VC;
+    enabled?: boolean;
+}
+
+export interface CredentialStatusResult {
+    status: CredentialLifecycleStatus;
+    isLoading: boolean;
+    isError: boolean;
+}

--- a/packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts
+++ b/packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts
@@ -1,0 +1,21 @@
+import type { VerificationCheck } from '@learncard/types';
+
+export type CredentialLifecycleStatus = 'active' | 'revoked' | 'suspended';
+
+export const deriveLifecycleStatus = (
+    check: Partial<VerificationCheck> | undefined | null
+): CredentialLifecycleStatus => {
+    const entries = check?.status ?? [];
+    if (entries.some(entry => entry.statusPurpose === 'revocation' && entry.isSet)) {
+        return 'revoked';
+    }
+    if (entries.some(entry => entry.statusPurpose === 'suspension' && entry.isSet)) {
+        return 'suspended';
+    }
+
+    const errors = check?.errors ?? [];
+    if (errors.some(error => /revok/i.test(error))) return 'revoked';
+    if (errors.some(error => /suspend/i.test(error))) return 'suspended';
+
+    return 'active';
+};

--- a/packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts
+++ b/packages/learn-card-base/src/hooks/deriveLifecycleStatus.ts
@@ -13,9 +13,5 @@ export const deriveLifecycleStatus = (
         return 'suspended';
     }
 
-    const errors = check?.errors ?? [];
-    if (errors.some(error => /revok/i.test(error))) return 'revoked';
-    if (errors.some(error => /suspend/i.test(error))) return 'suspended';
-
     return 'active';
 };

--- a/packages/learn-card-base/src/hooks/useCredentialStatus.ts
+++ b/packages/learn-card-base/src/hooks/useCredentialStatus.ts
@@ -2,18 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import type { VC, VerificationCheck } from '@learncard/types';
 import { useWallet } from './useWallet';
 import { deriveLifecycleStatus, type CredentialLifecycleStatus } from './deriveLifecycleStatus';
+import type { CredentialStatusResult, UseCredentialStatusOptions } from './credentialStatus.types';
 
-export interface UseCredentialStatusOptions {
-    uri?: string;
-    credential?: VC;
-    enabled?: boolean;
-}
-
-export interface CredentialStatusResult {
-    status: CredentialLifecycleStatus;
-    isLoading: boolean;
-    isError: boolean;
-}
+export type { CredentialStatusResult, UseCredentialStatusOptions } from './credentialStatus.types';
 
 interface CredentialStatusQueryResult {
     status: CredentialLifecycleStatus;
@@ -59,6 +50,9 @@ export const useCredentialStatus = ({
                     prettify: boolean
                 ) => Promise<VerificationCheck>;
                 const check = await verify(resolved, {}, false);
+                if (check.errors?.length) {
+                    return { status: 'active', isError: true };
+                }
                 return { status: deriveLifecycleStatus(check), isError: false };
             } catch {
                 return { status: 'active', isError: true };

--- a/packages/learn-card-base/src/hooks/useCredentialStatus.ts
+++ b/packages/learn-card-base/src/hooks/useCredentialStatus.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import type { VC, VerificationCheck } from '@learncard/types';
+import { useWallet } from './useWallet';
+import { deriveLifecycleStatus, type CredentialLifecycleStatus } from './deriveLifecycleStatus';
+
+export interface UseCredentialStatusOptions {
+    uri?: string;
+    credential?: VC;
+    enabled?: boolean;
+}
+
+export interface CredentialStatusResult {
+    status: CredentialLifecycleStatus;
+    isLoading: boolean;
+    isError: boolean;
+}
+
+interface CredentialStatusQueryResult {
+    status: CredentialLifecycleStatus;
+    isError: boolean;
+}
+
+export const useCredentialStatus = ({
+    uri,
+    credential,
+    enabled = true,
+}: UseCredentialStatusOptions): CredentialStatusResult => {
+    const { initWallet } = useWallet();
+    const shouldQuery = enabled && Boolean(uri);
+
+    const query = useQuery({
+        queryKey: ['credentialStatus', uri],
+        enabled: shouldQuery,
+        staleTime: 5 * 60 * 1000,
+        refetchOnMount: 'always',
+        queryFn: async (): Promise<CredentialStatusQueryResult> => {
+            const wallet = await initWallet();
+
+            try {
+                const statuses = await wallet?.invoke?.getMyCredentialLifecycleStatuses?.({
+                    uris: [uri as string],
+                });
+                const status = statuses?.[uri as string];
+                if (status === 'active' || status === 'revoked' || status === 'suspended') {
+                    return { status, isError: false };
+                }
+            } catch {
+                // The verification fallback below remains authoritative for Bitstring entries.
+            }
+
+            try {
+                const resolved = credential ?? ((await wallet?.read?.get?.(uri as string)) as VC);
+                if (!resolved || !wallet?.invoke?.verifyCredential) {
+                    return { status: 'active', isError: true };
+                }
+                const verify = wallet.invoke.verifyCredential as unknown as (
+                    candidate: VC,
+                    options: Record<string, unknown>,
+                    prettify: boolean
+                ) => Promise<VerificationCheck>;
+                const check = await verify(resolved, {}, false);
+                return { status: deriveLifecycleStatus(check), isError: false };
+            } catch {
+                return { status: 'active', isError: true };
+            }
+        },
+    });
+
+    if (!shouldQuery) return { status: 'active', isLoading: false, isError: false };
+
+    return {
+        status: query.data?.status ?? 'active',
+        isLoading: query.isLoading,
+        isError: query.data?.isError ?? query.isError,
+    };
+};

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -264,6 +264,7 @@ export * from './react-query/queries/vcQueries';
 export * from './react-query/queries/notifications';
 export * from './react-query/queries/aiPassport-queries';
 export * from './react-query/mutations/mutations';
+export * from './react-query/mutations/revokeBoostRecipientGroup';
 export * from './react-query/mutations/notifications';
 export * from './react-query/mutations/boosts';
 export * from './react-query/mutations/mutation.helpers';

--- a/packages/learn-card-base/src/index.ts
+++ b/packages/learn-card-base/src/index.ts
@@ -73,6 +73,8 @@ export * from './constants/LCNWebhookEndpoints';
 export * from './constants/Networks';
 
 export * from './hooks/useWallet';
+export * from './hooks/deriveLifecycleStatus';
+export * from './hooks/useCredentialStatus';
 export * from './hooks/useContract';
 export * from './hooks/useGetContracts';
 export * from './hooks/useGetCredentialsFromContract';

--- a/packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+++ b/packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRevokeBoostRecipientGroup } from '../revokeBoostRecipientGroup';
+
+const mocks = vi.hoisted(() => ({
+    revokeBoostRecipientGroup: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useWallet', () => ({
+    useWallet: () => ({
+        initWallet: async () => ({
+            invoke: {
+                revokeBoostRecipientGroup: mocks.revokeBoostRecipientGroup,
+            },
+        }),
+    }),
+}));
+
+const INVALIDATION_PREFIXES = [
+    ['boostRecipients'],
+    ['getPaginatedBoostRecipients'],
+    ['getBoostRecipientCount'],
+    ['boosts'],
+    ['useNetworkMembers'],
+    ['getMyActivities'],
+    ['getActivityStats'],
+    ['credentialStatus'],
+];
+
+const makeWrapper =
+    (queryClient: QueryClient) =>
+    ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+describe('useRevokeBoostRecipientGroup', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.revokeBoostRecipientGroup.mockResolvedValue({
+            revokedCredentialUris: ['credential-1'],
+            alreadyRevokedCredentialUris: [],
+            failedCredentialUris: [],
+        });
+    });
+
+    it('revokes the recipient group and invalidates related caches after success', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const { result } = renderHook(() => useRevokeBoostRecipientGroup(), {
+            wrapper: makeWrapper(queryClient),
+        });
+
+        await result.current.mutateAsync({
+            boostUri: 'lc:network:test:boost:troop',
+            recipientProfileId: 'scout-1',
+        });
+
+        expect(mocks.revokeBoostRecipientGroup).toHaveBeenCalledWith(
+            'lc:network:test:boost:troop',
+            'scout-1'
+        );
+        for (const queryKey of INVALIDATION_PREFIXES) {
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
+        }
+    });
+
+    it('invalidates related caches after the recipient group revocation fails', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        mocks.revokeBoostRecipientGroup.mockRejectedValueOnce(new Error('offline'));
+        const { result } = renderHook(() => useRevokeBoostRecipientGroup(), {
+            wrapper: makeWrapper(queryClient),
+        });
+
+        await expect(
+            result.current.mutateAsync({
+                boostUri: 'lc:network:test:boost:troop',
+                recipientProfileId: 'scout-1',
+            })
+        ).rejects.toThrow('offline');
+
+        for (const queryKey of INVALIDATION_PREFIXES) {
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
+        }
+    });
+});

--- a/packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
+++ b/packages/learn-card-base/src/react-query/mutations/__tests__/revokeBoostRecipientGroup.test.tsx
@@ -19,16 +19,21 @@ vi.mock('../../../hooks/useWallet', () => ({
     }),
 }));
 
-const INVALIDATION_PREFIXES = [
-    ['boostRecipients'],
-    ['getPaginatedBoostRecipients'],
-    ['getBoostRecipientCount'],
-    ['boosts'],
-    ['useNetworkMembers'],
-    ['getMyActivities'],
-    ['getActivityStats'],
-    ['credentialStatus'],
-];
+const boostUri = 'lc:network:test:boost:troop';
+const consumerQueryKeys = [
+    ['paginatedBoostRecipients', boostUri, { limit: 10 }],
+    ['useCountBoostRecipients', boostUri, false],
+] as const;
+
+const seedConsumerQueries = (queryClient: QueryClient) => {
+    for (const queryKey of consumerQueryKeys) queryClient.setQueryData(queryKey, { seeded: true });
+};
+
+const expectConsumerQueriesInvalidated = (queryClient: QueryClient) => {
+    for (const queryKey of consumerQueryKeys) {
+        expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    }
+};
 
 const makeWrapper =
     (queryClient: QueryClient) =>
@@ -47,28 +52,23 @@ describe('useRevokeBoostRecipientGroup', () => {
 
     it('revokes the recipient group and invalidates related caches after success', async () => {
         const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        seedConsumerQueries(queryClient);
         const { result } = renderHook(() => useRevokeBoostRecipientGroup(), {
             wrapper: makeWrapper(queryClient),
         });
 
         await result.current.mutateAsync({
-            boostUri: 'lc:network:test:boost:troop',
+            boostUri,
             recipientProfileId: 'scout-1',
         });
 
-        expect(mocks.revokeBoostRecipientGroup).toHaveBeenCalledWith(
-            'lc:network:test:boost:troop',
-            'scout-1'
-        );
-        for (const queryKey of INVALIDATION_PREFIXES) {
-            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
-        }
+        expect(mocks.revokeBoostRecipientGroup).toHaveBeenCalledWith(boostUri, 'scout-1');
+        expectConsumerQueriesInvalidated(queryClient);
     });
 
     it('invalidates related caches after the recipient group revocation fails', async () => {
         const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        seedConsumerQueries(queryClient);
         mocks.revokeBoostRecipientGroup.mockRejectedValueOnce(new Error('offline'));
         const { result } = renderHook(() => useRevokeBoostRecipientGroup(), {
             wrapper: makeWrapper(queryClient),
@@ -76,13 +76,11 @@ describe('useRevokeBoostRecipientGroup', () => {
 
         await expect(
             result.current.mutateAsync({
-                boostUri: 'lc:network:test:boost:troop',
+                boostUri,
                 recipientProfileId: 'scout-1',
             })
         ).rejects.toThrow('offline');
 
-        for (const queryKey of INVALIDATION_PREFIXES) {
-            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
-        }
+        expectConsumerQueriesInvalidated(queryClient);
     });
 });

--- a/packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts
+++ b/packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import type { RevokeBoostRecipientGroupResult } from '@learncard/types';
+import { useWallet } from '../../hooks/useWallet';
+
+export interface RevokeBoostRecipientGroupParams {
+    boostUri: string;
+    recipientProfileId: string;
+}
+
+const INVALIDATION_PREFIXES = [
+    ['boostRecipients'],
+    ['getPaginatedBoostRecipients'],
+    ['getBoostRecipientCount'],
+    ['boosts'],
+    ['useNetworkMembers'],
+    ['getMyActivities'],
+    ['getActivityStats'],
+    ['credentialStatus'],
+] as const;
+
+export const useRevokeBoostRecipientGroup = (): UseMutationResult<
+    RevokeBoostRecipientGroupResult,
+    Error,
+    RevokeBoostRecipientGroupParams
+> => {
+    const { initWallet } = useWallet();
+    const queryClient = useQueryClient();
+
+    return useMutation<RevokeBoostRecipientGroupResult, Error, RevokeBoostRecipientGroupParams>({
+        mutationFn: async ({ boostUri, recipientProfileId }) => {
+            const wallet = await initWallet();
+            const method = wallet?.invoke?.revokeBoostRecipientGroup;
+            if (!method) throw new Error('Group removal is unavailable');
+            return method(boostUri, recipientProfileId);
+        },
+        onSettled: async () => {
+            await Promise.all(
+                INVALIDATION_PREFIXES.map(queryKey =>
+                    queryClient.invalidateQueries({ queryKey: [...queryKey] })
+                )
+            );
+        },
+    });
+};

--- a/packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts
+++ b/packages/learn-card-base/src/react-query/mutations/revokeBoostRecipientGroup.ts
@@ -9,8 +9,8 @@ export interface RevokeBoostRecipientGroupParams {
 
 const INVALIDATION_PREFIXES = [
     ['boostRecipients'],
-    ['getPaginatedBoostRecipients'],
-    ['getBoostRecipientCount'],
+    ['paginatedBoostRecipients'],
+    ['useCountBoostRecipients'],
     ['boosts'],
     ['useNetworkMembers'],
     ['getMyActivities'],

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -354,6 +354,16 @@ export const BoostRecipientValidator = z.object({
 });
 export type BoostRecipientInfo = z.infer<typeof BoostRecipientValidator>;
 
+export const RevokeBoostRecipientGroupResultValidator = z.object({
+    revokedCredentialUris: z.array(z.string()),
+    alreadyRevokedCredentialUris: z.array(z.string()),
+    failedCredentialUris: z.array(z.string()),
+});
+
+export type RevokeBoostRecipientGroupResult = z.infer<
+    typeof RevokeBoostRecipientGroupResultValidator
+>;
+
 export const PaginatedBoostRecipientsValidator = PaginationResponseValidator.extend({
     records: BoostRecipientValidator.array(),
 });

--- a/packages/plugins/learn-card-network/src/plugin.ts
+++ b/packages/plugins/learn-card-network/src/plugin.ts
@@ -1362,6 +1362,13 @@ export async function getLearnCardNetworkPlugin(
 
                 return client.boost.revokeBoostRecipient.mutate(input);
             },
+            revokeBoostRecipientGroup: async (_learnCard, boostUri, recipientProfileId) => {
+                await ensureUser();
+                return client.boost.revokeBoostRecipientGroup.mutate({
+                    boostUri,
+                    recipientProfileId,
+                });
+            },
             suspendBoostRecipient: async (
                 _learnCard,
                 boostUri,

--- a/packages/plugins/learn-card-network/src/types.ts
+++ b/packages/plugins/learn-card-network/src/types.ts
@@ -109,6 +109,7 @@ import {
     CredentialActivityStats,
     BitstringCredentialStatusPurpose,
     BitstringCredentialStatusEntry,
+    RevokeBoostRecipientGroupResult,
 } from '@learncard/types';
 import { Plugin } from '@learncard/core';
 import { ProofOptions } from '@learncard/didkit-plugin';
@@ -410,6 +411,10 @@ export type LearnCardNetworkPluginMethods = {
         recipientProfileId: string,
         credentialUri?: string
     ) => Promise<boolean>;
+    revokeBoostRecipientGroup: (
+        boostUri: string,
+        recipientProfileId: string
+    ) => Promise<RevokeBoostRecipientGroupResult>;
     suspendBoostRecipient: (
         boostUri: string,
         recipientProfileId: string,

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
@@ -264,9 +264,7 @@ export const getCredentialStatusesForBoostAndProfile = async (
         })
     );
 
-    return statuses.filter(
-        (status): status is CredentialStatusForBoostAndProfile => status !== null
-    );
+    return statuses.filter((status): status is NonNullable<typeof status> => status !== null);
 };
 
 export const getCredentialStatusForBoostAndProfile = async (

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/read.ts
@@ -213,60 +213,67 @@ export interface CredentialStatusForBoostAndProfile {
     status: 'pending' | 'claimed' | 'revoked' | 'suspended';
 }
 
-export const getCredentialStatusForBoostAndProfile = async (
+export const getCredentialStatusesForBoostAndProfile = async (
     boostId: string,
     profileId: string
-): Promise<CredentialStatusForBoostAndProfile | null> => {
+): Promise<CredentialStatusForBoostAndProfile[]> => {
     const result = await neogma.queryRunner.run(
         `MATCH (boost:Boost {id: $boostId})<-[:INSTANCE_OF]-(credential:Credential)
          MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
          WHERE (sender:Profile OR sender:AppStoreListing)
          OPTIONAL MATCH (credential)-[received:CREDENTIAL_RECEIVED]->(:Profile {profileId: $profileId})
          RETURN credential, sent, received
-         ORDER BY coalesce(received.date, sent.date) DESC
-         LIMIT 1`,
+         ORDER BY coalesce(received.date, sent.date) DESC, credential.id DESC`,
         { boostId, profileId }
     );
 
-    const record = result.records[0];
-    if (!record) {
-        return null;
-    }
+    const statuses = await Promise.all(
+        result.records.map(async record => {
+            const credentialNode = record.get('credential') as {
+                properties?: Record<string, unknown>;
+            };
+            const credentialProps = inflateObject<CredentialType>(
+                (credentialNode?.properties ?? {}) as CredentialType
+            );
+            const credential = await Credential.findOne({ where: { id: credentialProps.id } });
+            if (!credential) return null;
 
-    const credentialProps = inflateObject<CredentialType>(
-        ((record.get('credential') as { properties?: Record<string, unknown> })?.properties ??
-            {}) as CredentialType
+            const sentNode = record.get('sent') as { properties?: Record<string, unknown> };
+            const receivedNode = record.get('received') as {
+                properties?: Record<string, unknown>;
+            } | null;
+            const sentProps = inflateRelationshipProperties(sentNode?.properties ?? {});
+            const receivedProps = receivedNode?.properties
+                ? inflateRelationshipProperties(receivedNode.properties)
+                : undefined;
+            const rawStatus = sentProps.status ?? receivedProps?.status;
+
+            return {
+                credential,
+                sentDate: sentProps.date as string | undefined,
+                receivedDate: receivedProps?.date as string | undefined,
+                status:
+                    rawStatus === 'revoked'
+                        ? ('revoked' as const)
+                        : rawStatus === 'suspended'
+                        ? ('suspended' as const)
+                        : receivedProps
+                        ? ('claimed' as const)
+                        : ('pending' as const),
+            };
+        })
     );
-    const credential = await Credential.findOne({ where: { id: credentialProps.id } });
-    if (!credential) {
-        return null;
-    }
 
-    const sentProps = inflateRelationshipProperties(
-        (record.get('sent') as { properties?: Record<string, unknown> })?.properties ?? {}
+    return statuses.filter(
+        (status): status is CredentialStatusForBoostAndProfile => status !== null
     );
-    const receivedNode = record.get('received') as { properties?: Record<string, unknown> } | null;
-    const receivedProps = receivedNode?.properties
-        ? inflateRelationshipProperties(receivedNode.properties)
-        : undefined;
-
-    const rawStatus = sentProps.status ?? receivedProps?.status;
-    const status =
-        rawStatus === 'revoked'
-            ? 'revoked'
-            : rawStatus === 'suspended'
-            ? 'suspended'
-            : receivedProps
-            ? 'claimed'
-            : 'pending';
-
-    return {
-        credential,
-        sentDate: sentProps.date as string | undefined,
-        receivedDate: receivedProps?.date as string | undefined,
-        status,
-    };
 };
+
+export const getCredentialStatusForBoostAndProfile = async (
+    boostId: string,
+    profileId: string
+): Promise<CredentialStatusForBoostAndProfile | null> =>
+    (await getCredentialStatusesForBoostAndProfile(boostId, profileId))[0] ?? null;
 
 /**
  * Returns the authoritative lifecycle status ('active' | 'revoked' | 'suspended') for a

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
@@ -24,7 +24,11 @@ export const revokeCredentialForProfile = async (
          MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
          WHERE sender:Profile OR sender:AppStoreListing
          WITH sent, sent.status AS previousStatus
-         SET sent.status = "revoked", sent.revokedAt = $revokedAt
+         SET sent.status = "revoked",
+             sent.revokedAt = CASE
+                 WHEN previousStatus = "revoked" THEN sent.revokedAt
+                 ELSE $revokedAt
+             END
          RETURN previousStatus`,
         { credentialId, profileId, revokedAt }
     );

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
@@ -23,13 +23,25 @@ export const revokeCredentialForProfile = async (
         `MATCH (credential:Credential {id: $credentialId})
          MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
          WHERE sender:Profile OR sender:AppStoreListing
-         WITH sent, sent.status AS previousStatus
+         OPTIONAL MATCH (credential)-[received:CREDENTIAL_RECEIVED]->(:Profile {profileId: $profileId})
+         WITH sent,
+              sent.status AS previousSentStatus,
+              sent.revokedAt AS sentRevokedAt,
+              received.status AS previousReceivedStatus,
+              received.revokedAt AS receivedRevokedAt
+         WITH sent,
+              previousSentStatus,
+              previousReceivedStatus,
+              CASE
+                  WHEN previousSentStatus = "revoked"
+                      THEN coalesce(sentRevokedAt, receivedRevokedAt, $revokedAt)
+                  WHEN previousReceivedStatus = "revoked"
+                      THEN coalesce(receivedRevokedAt, sentRevokedAt, $revokedAt)
+                  ELSE $revokedAt
+              END AS effectiveRevokedAt
          SET sent.status = "revoked",
-             sent.revokedAt = CASE
-                 WHEN previousStatus = "revoked" THEN sent.revokedAt
-                 ELSE $revokedAt
-             END
-         RETURN previousStatus`,
+             sent.revokedAt = effectiveRevokedAt
+         RETURN previousSentStatus, previousReceivedStatus`,
         { credentialId, profileId, revokedAt }
     );
 
@@ -49,7 +61,9 @@ export const revokeCredentialForProfile = async (
 
     return {
         found: true,
-        wasAlreadyRevoked: result.records[0]?.get('previousStatus') === 'revoked',
+        wasAlreadyRevoked:
+            result.records[0]?.get('previousSentStatus') === 'revoked' ||
+            result.records[0]?.get('previousReceivedStatus') === 'revoked',
         statusList,
     };
 };
@@ -63,14 +77,18 @@ export const revokeCredentialReceived = async (
     profileId: string
 ): Promise<boolean> => {
     const result = await revokeCredentialForProfile(credentialId, profileId);
-    if (result.found && result.statusList !== 'updated') {
+    if (!result.found) return false;
+    if (result.statusList === 'failed') {
+        throw new Error('Failed to update credential status list');
+    }
+    if (result.statusList === 'missing-entry') {
         console.warn('[revokeCredentialReceived] verifiable revocation unavailable', {
             credentialId,
             reason: result.statusList,
         });
     }
 
-    return result.found;
+    return true;
 };
 
 /**

--- a/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/credential/relationships/update.ts
@@ -2,6 +2,53 @@ import { QueryBuilder, BindParam } from 'neogma';
 
 import { Credential } from '@models';
 import { setCredentialBitstringStatus } from '@helpers/status-list.helpers';
+import { neogma } from '@instance';
+import {
+    setCredentialBitstringStatusWithResult,
+    type CredentialBitstringStatusUpdateResult,
+} from '@helpers/status-list.helpers';
+
+export interface RevokeCredentialForProfileResult {
+    found: boolean;
+    wasAlreadyRevoked: boolean;
+    statusList: CredentialBitstringStatusUpdateResult;
+}
+
+export const revokeCredentialForProfile = async (
+    credentialId: string,
+    profileId: string
+): Promise<RevokeCredentialForProfileResult> => {
+    const revokedAt = new Date().toISOString();
+    const result = await neogma.queryRunner.run(
+        `MATCH (credential:Credential {id: $credentialId})
+         MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
+         WHERE sender:Profile OR sender:AppStoreListing
+         WITH sent, sent.status AS previousStatus
+         SET sent.status = "revoked", sent.revokedAt = $revokedAt
+         RETURN previousStatus`,
+        { credentialId, profileId, revokedAt }
+    );
+
+    if (result.records.length === 0) {
+        return { found: false, wasAlreadyRevoked: false, statusList: 'failed' };
+    }
+
+    let statusList: CredentialBitstringStatusUpdateResult = 'failed';
+    try {
+        statusList = await setCredentialBitstringStatusWithResult(credentialId, 'revocation', true);
+    } catch (error) {
+        console.error('[revokeCredentialForProfile] status-list update failed', {
+            credentialId,
+            error,
+        });
+    }
+
+    return {
+        found: true,
+        wasAlreadyRevoked: result.records[0]?.get('previousStatus') === 'revoked',
+        statusList,
+    };
+};
 
 /**
  * Revoke a credential by setting its issuer-controlled status on the CREDENTIAL_SENT relationship.
@@ -11,33 +58,15 @@ export const revokeCredentialReceived = async (
     credentialId: string,
     profileId: string
 ): Promise<boolean> => {
-    const revokedAt = new Date().toISOString();
-
-    const result = await new QueryBuilder(new BindParam({ profileId, revokedAt }))
-        .match({ identifier: 'credential', model: Credential, where: { id: credentialId } })
-        .raw(
-            `MATCH (sender)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential)
-             WHERE sender:Profile OR sender:AppStoreListing
-             SET sent.status = "revoked",
-                 sent.revokedAt = $revokedAt
-             RETURN sent`
-        )
-        .run();
-
-    if (result.records.length > 0) {
-        const bitSet = await setCredentialBitstringStatus(credentialId, 'revocation', true);
-        if (!bitSet) {
-            // The relationship is marked revoked but the credential has no 'revocation'
-            // status-list entry, so the verifiable bit was NOT set. Holders relying purely
-            // on verifyCredential can't see the revocation. Surface it instead of failing
-            // silently (the authoritative relationship status still drives the UI).
-            console.warn(
-                `[revokeCredentialReceived] credential ${credentialId} has no verifiable 'revocation' status entry; bitstring bit not set`
-            );
-        }
+    const result = await revokeCredentialForProfile(credentialId, profileId);
+    if (result.found && result.statusList !== 'updated') {
+        console.warn('[revokeCredentialReceived] verifiable revocation unavailable', {
+            credentialId,
+            reason: result.statusList,
+        });
     }
 
-    return result.records.length > 0;
+    return result.found;
 };
 
 /**

--- a/services/learn-card-network/brain-service/src/helpers/revoke-hooks.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/revoke-hooks.helpers.ts
@@ -119,9 +119,7 @@ const processAdminRevokeHooks = async (
         })
         .match({ model: Profile, where: { profileId: profile.profileId }, identifier: 'profile' })
         .match({
-            related: [
-                { identifier: 'adminRole', model: Role, where: { role: 'admin' } },
-            ],
+            related: [{ identifier: 'adminRole', model: Role, where: { role: 'admin' } }],
         })
         .match({
             optional: false,
@@ -155,7 +153,7 @@ const processConnectionRevoke = async (
     credential: CredentialInstance
 ): Promise<void> => {
     const { neogma } = await import('@instance');
-    
+
     // Get all boost IDs that could have created connections for this credential
     // This mirrors the logic in ensureConnectionsForCredentialAcceptance
     const boostIdsQuery = `
@@ -169,19 +167,27 @@ const processConnectionRevoke = async (
         RETURN directIds + parentIds + hookIds as boostIds
     `;
 
-    const boostIdsResult = await neogma.queryRunner.run(boostIdsQuery, { 
-        credentialId: credential.id 
+    const boostIdsResult = await neogma.queryRunner.run(boostIdsQuery, {
+        credentialId: credential.id,
     });
-    
+
     const boostIds: string[] = boostIdsResult.records[0]?.get('boostIds') || [];
-    
+
     if (boostIds.length === 0) {
-        console.log('[processConnectionRevoke] No eligible boosts found for credential', credential.id);
+        console.log(
+            '[processConnectionRevoke] No eligible boosts found for credential',
+            credential.id
+        );
         return;
     }
 
     const sourceKeys = boostIds.map(id => getBoostConnectionSourceKey(id));
-    console.log('[processConnectionRevoke] Removing connections for profile', profile.profileId, 'with sourceKeys', sourceKeys);
+    console.log(
+        '[processConnectionRevoke] Removing connections for profile',
+        profile.profileId,
+        'with sourceKeys',
+        sourceKeys
+    );
 
     // First, check what connections exist for this profile with any of these source keys
     const debugQuery = `
@@ -189,13 +195,22 @@ const processConnectionRevoke = async (
         WHERE r.sources IS NOT NULL AND ANY(key IN $sourceKeys WHERE key IN r.sources)
         RETURN other.profileId as otherProfileId, r.sources as sources
     `;
-    const debugResult = await neogma.queryRunner.run(debugQuery, { 
+    const debugResult = await neogma.queryRunner.run(debugQuery, {
         profileId: profile.profileId,
-        sourceKeys 
+        sourceKeys,
     });
-    console.log('[processConnectionRevoke] Found', debugResult.records.length, 'connections with matching sourceKeys');
+    console.log(
+        '[processConnectionRevoke] Found',
+        debugResult.records.length,
+        'connections with matching sourceKeys'
+    );
     debugResult.records.forEach(r => {
-        console.log('[processConnectionRevoke] - Connection to:', r.get('otherProfileId'), 'sources:', r.get('sources'));
+        console.log(
+            '[processConnectionRevoke] - Connection to:',
+            r.get('otherProfileId'),
+            'sources:',
+            r.get('sources')
+        );
     });
 
     // Now remove all matching source keys and delete connections that become empty
@@ -209,13 +224,33 @@ const processConnectionRevoke = async (
         RETURN count(r) as deletedCount
     `;
 
-    const result = await neogma.queryRunner.run(cypher, { 
+    const result = await neogma.queryRunner.run(cypher, {
         profileId: profile.profileId,
-        sourceKeys 
+        sourceKeys,
     });
-    
+
     const deletedCount = result.records[0]?.get('deletedCount');
-    console.log('[processConnectionRevoke] Deleted', deletedCount, 'connection(s) that had only these sources');
+    console.log(
+        '[processConnectionRevoke] Deleted',
+        deletedCount,
+        'connection(s) that had only these sources'
+    );
+};
+
+export const processRevokeHooksStrict = async (
+    profile: ProfileType,
+    credential: CredentialInstance
+): Promise<void> => {
+    await Promise.all([
+        processPermissionsRevokeHooks(profile, credential),
+        processAdminRevokeHooks(profile, credential),
+        processAutoConnectRevokeHooks(profile, credential),
+        processConnectionRevoke(profile, credential),
+    ]);
+
+    const boostId = await getBoostIdForCredentialInstance(credential);
+
+    if (boostId) await clearDidWebCacheForChildProfileManagers(boostId);
 };
 
 export const processRevokeHooks = async (
@@ -226,7 +261,7 @@ export const processRevokeHooks = async (
         processPermissionsRevokeHooks(profile, credential),
         processAdminRevokeHooks(profile, credential),
         processAutoConnectRevokeHooks(profile, credential),
-        processConnectionRevoke(profile, credential)
+        processConnectionRevoke(profile, credential),
     ]);
 
     try {

--- a/services/learn-card-network/brain-service/src/helpers/status-list.helpers.ts
+++ b/services/learn-card-network/brain-service/src/helpers/status-list.helpers.ts
@@ -388,25 +388,33 @@ export const setStatusListEntryBit = async (
     });
 };
 
+export type CredentialBitstringStatusUpdateResult = 'updated' | 'missing-entry' | 'failed';
+
+export const setCredentialBitstringStatusWithResult = async (
+    credentialId: string,
+    statusPurpose: BitstringStatusPurpose,
+    value: boolean
+): Promise<CredentialBitstringStatusUpdateResult> => {
+    const credential = await Credential.findOne({ where: { id: credentialId } });
+    if (!credential) return 'failed';
+
+    const entries = getBitstringStatusListEntries(JSON.parse(credential.credential)).filter(
+        entry => entry.statusPurpose === statusPurpose
+    );
+
+    if (entries.length === 0) return 'missing-entry';
+
+    const results = await Promise.all(entries.map(entry => setStatusListEntryBit(entry, value)));
+    return results.every(Boolean) ? 'updated' : 'failed';
+};
+
 export const setCredentialBitstringStatus = async (
     credentialId: string,
     statusPurpose: BitstringStatusPurpose,
     value: boolean
-): Promise<boolean> => {
-    const credential = await Credential.findOne({ where: { id: credentialId } });
-    if (!credential) return false;
-
-    const parsedCredential = JSON.parse(credential.credential);
-    const entries = getBitstringStatusListEntries(parsedCredential).filter(
-        entry => entry.statusPurpose === statusPurpose
-    );
-
-    if (entries.length === 0) return false;
-
-    await Promise.all(entries.map(entry => setStatusListEntryBit(entry, value)));
-
-    return true;
-};
+): Promise<boolean> =>
+    (await setCredentialBitstringStatusWithResult(credentialId, statusPurpose, value)) ===
+    'updated';
 
 export const getSignedStatusListCredential = async (id: string): Promise<VC | null> => {
     const list = await getStatusListById(id);

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -30,6 +30,8 @@ import {
     SendBoostResponseValidator,
     AllocateCredentialStatusInputValidator,
     AllocatedBitstringStatusListEntryValidator,
+    RevokeBoostRecipientGroupResultValidator,
+    RevokeBoostRecipientGroupResult,
 } from '@learncard/types';
 import { isVC2Format } from '@learncard/helpers';
 import {
@@ -145,6 +147,7 @@ import {
 import { getBlockedAndBlockedByIds, isRelationshipBlocked } from '@helpers/connection.helpers';
 import { getDidWeb, getManagedDidWeb, getProfileIdFromString } from '@helpers/did.helpers';
 import { addNotificationToQueue } from '@helpers/notifications.helpers';
+import * as revokeHooks from '@helpers/revoke-hooks.helpers';
 import { getNotificationMessage } from '@helpers/notificationMessages';
 import { resolveRecipientLocale } from '@helpers/getRecipientLocale.helpers';
 import {
@@ -2029,6 +2032,133 @@ export const boostsRouter = t.router({
             }
 
             return true;
+        }),
+
+    revokeBoostRecipientGroup: profileRoute
+        .meta({
+            openapi: {
+                protect: true,
+                method: 'POST',
+                path: '/boost/recipients/revoke-group',
+                tags: ['Boosts'],
+                summary: 'Revoke every credential for a boost recipient',
+            },
+            requiredScope: 'boosts:write',
+        })
+        .input(z.object({ boostUri: z.string(), recipientProfileId: z.string() }))
+        .output(RevokeBoostRecipientGroupResultValidator)
+        .mutation(async ({ ctx, input }) => {
+            const resolvedRecipientProfileId = await getProfileIdFromString(
+                input.recipientProfileId,
+                ctx.domain
+            );
+            if (!resolvedRecipientProfileId) {
+                throw new TRPCError({ code: 'NOT_FOUND', message: 'Profile not found' });
+            }
+
+            const boost = await getBoostByUri(decodeURIComponent(input.boostUri));
+            if (!boost) {
+                throw new TRPCError({ code: 'NOT_FOUND', message: 'Could not find boost' });
+            }
+
+            const permissions = await getBoostPermissions(boost, ctx.user.profile);
+            if (!permissions.canRevoke) {
+                throw new TRPCError({
+                    code: 'UNAUTHORIZED',
+                    message:
+                        'Profile does not have permission to revoke credentials for this boost',
+                });
+            }
+
+            const recipientProfile = await getProfileByProfileId(resolvedRecipientProfileId);
+            if (!recipientProfile) {
+                throw new TRPCError({ code: 'NOT_FOUND', message: 'Recipient profile not found' });
+            }
+
+            const { getCredentialStatusesForBoostAndProfile } = await import(
+                '@accesslayer/credential/read'
+            );
+            const { revokeCredentialForProfile } = await import(
+                '@accesslayer/credential/relationships/update'
+            );
+            const instances = await getCredentialStatusesForBoostAndProfile(
+                boost.id,
+                resolvedRecipientProfileId
+            );
+            const result: RevokeBoostRecipientGroupResult = {
+                revokedCredentialUris: [],
+                alreadyRevokedCredentialUris: [],
+                failedCredentialUris: [],
+            };
+
+            for (const instance of instances) {
+                const uri = constructUri('credential', instance.credential.id, ctx.domain);
+
+                try {
+                    const revocation = await revokeCredentialForProfile(
+                        instance.credential.id,
+                        resolvedRecipientProfileId
+                    );
+                    const hookResult = await Promise.allSettled([
+                        revokeHooks.processRevokeHooks(recipientProfile, instance.credential),
+                    ]);
+                    const hooksFailed = hookResult.some(item => item.status === 'rejected');
+
+                    if (revocation.statusList === 'missing-entry') {
+                        console.warn('[revokeBoostRecipientGroup] migration-gap', {
+                            credentialId: instance.credential.id,
+                            reason: 'missing-entry',
+                        });
+                    }
+
+                    if (!revocation.found || revocation.statusList === 'failed' || hooksFailed) {
+                        result.failedCredentialUris.push(uri);
+                    } else if (revocation.wasAlreadyRevoked) {
+                        result.alreadyRevokedCredentialUris.push(uri);
+                    } else {
+                        result.revokedCredentialUris.push(uri);
+                    }
+                } catch (error) {
+                    console.error('[revokeBoostRecipientGroup] credential failed', {
+                        credentialId: instance.credential.id,
+                        error,
+                    });
+                    result.failedCredentialUris.push(uri);
+                }
+            }
+
+            if (result.revokedCredentialUris.length > 0) {
+                try {
+                    await addNotificationToQueue({
+                        type: LCNNotificationTypeEnumValidator.enum.CREDENTIAL_REVOKED,
+                        to: {
+                            did: getDidWeb(ctx.domain, resolvedRecipientProfileId),
+                            profileId: resolvedRecipientProfileId,
+                            ...(recipientProfile.notificationsWebhook && {
+                                notificationsWebhook: recipientProfile.notificationsWebhook,
+                            }),
+                        },
+                        from: {
+                            did: getDidWeb(ctx.domain, ctx.user.profile.profileId),
+                            profileId: ctx.user.profile.profileId,
+                            displayName: ctx.user.profile.displayName,
+                        },
+                        message: getNotificationMessage(
+                            boost.name ? 'credentialRevokedNamed' : 'credentialRevokedUnnamed',
+                            resolveRecipientLocale(recipientProfile),
+                            {
+                                credentialName: boost.name ?? undefined,
+                                issuer: ctx.user.profile.displayName ?? ctx.user.profile.profileId,
+                            }
+                        ),
+                        data: { vcUris: result.revokedCredentialUris },
+                    });
+                } catch (error) {
+                    console.error('Failed to queue group CREDENTIAL_REVOKED notification', error);
+                }
+            }
+
+            return result;
         }),
 
     suspendBoostRecipient: profileRoute

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -2090,6 +2090,7 @@ export const boostsRouter = t.router({
                 alreadyRevokedCredentialUris: [],
                 failedCredentialUris: [],
             };
+            const newlyRevokedCredentialUris: string[] = [];
 
             for (const instance of instances) {
                 const uri = constructUri('credential', instance.credential.id, ctx.domain);
@@ -2099,6 +2100,9 @@ export const boostsRouter = t.router({
                         instance.credential.id,
                         resolvedRecipientProfileId
                     );
+                    if (revocation.found && !revocation.wasAlreadyRevoked) {
+                        newlyRevokedCredentialUris.push(uri);
+                    }
                     const hookResult = await Promise.allSettled([
                         revokeHooks.processRevokeHooksStrict(recipientProfile, instance.credential),
                     ]);
@@ -2127,7 +2131,7 @@ export const boostsRouter = t.router({
                 }
             }
 
-            if (result.revokedCredentialUris.length > 0) {
+            if (newlyRevokedCredentialUris.length > 0) {
                 try {
                     await addNotificationToQueue({
                         type: LCNNotificationTypeEnumValidator.enum.CREDENTIAL_REVOKED,
@@ -2151,7 +2155,7 @@ export const boostsRouter = t.router({
                                 issuer: ctx.user.profile.displayName ?? ctx.user.profile.profileId,
                             }
                         ),
-                        data: { vcUris: result.revokedCredentialUris },
+                        data: { vcUris: newlyRevokedCredentialUris },
                     });
                 } catch (error) {
                     console.error('Failed to queue group CREDENTIAL_REVOKED notification', error);

--- a/services/learn-card-network/brain-service/src/routes/boosts.ts
+++ b/services/learn-card-network/brain-service/src/routes/boosts.ts
@@ -2100,7 +2100,7 @@ export const boostsRouter = t.router({
                         resolvedRecipientProfileId
                     );
                     const hookResult = await Promise.allSettled([
-                        revokeHooks.processRevokeHooks(recipientProfile, instance.credential),
+                        revokeHooks.processRevokeHooksStrict(recipientProfile, instance.credential),
                     ]);
                     const hooksFailed = hookResult.some(item => item.status === 'rejected');
 

--- a/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
+++ b/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
@@ -299,11 +299,12 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
             true
         );
         const failingCredentialId = getIdFromUri(failingUri);
-        const realProcessRevokeHooks = revokeHooks.processRevokeHooks;
+        const realProcessRevokeHooks = revokeHooks.processRevokeHooksStrict;
+        let failingCredentialHookCalls = 0;
         const processRevokeHooksSpy = vi
-            .spyOn(revokeHooks, 'processRevokeHooks')
+            .spyOn(revokeHooks, 'processRevokeHooksStrict')
             .mockImplementation(async (profile, credential) => {
-                if (credential.id === failingCredentialId)
+                if (credential.id === failingCredentialId && failingCredentialHookCalls++ === 0)
                     throw new Error('intentional hook failure');
                 return realProcessRevokeHooks(profile, credential);
             });
@@ -313,10 +314,14 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
         expect(firstResult.failedCredentialUris).toEqual([failingUri]);
         expect(firstResult.revokedCredentialUris).toContain(successfulUri);
 
-        processRevokeHooksSpy.mockRestore();
         const secondResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
         expect(secondResult.failedCredentialUris).toEqual([]);
         expect(secondResult.alreadyRevokedCredentialUris).toContain(failingUri);
+        expect(failingCredentialHookCalls).toBe(2);
+        expect(processRevokeHooksSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ profileId: 'userb' }),
+            expect.objectContaining({ id: failingCredentialId })
+        );
     });
 
     it('retries failed status-list updates for already revoked credentials', async () => {

--- a/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
+++ b/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
@@ -1,0 +1,410 @@
+import {
+    Boost,
+    ClaimHook,
+    Credential,
+    CredentialActivity,
+    Profile,
+    Role,
+    StatusList,
+} from '@models';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { app as statusListsApp } from '../src/status-lists';
+import { decodeBitstring } from '../src/helpers/status-list.helpers';
+import * as notifications from '../src/helpers/notifications.helpers';
+import * as revokeHooks from '../src/helpers/revoke-hooks.helpers';
+import * as statusListHelpers from '../src/helpers/status-list.helpers';
+import { getIdFromUri } from '../src/helpers/uri.helpers';
+import { getClient, getUser } from './helpers/getClient';
+import { sendBoost, testUnsignedBoost } from './helpers/send';
+
+const noAuthClient = getClient();
+let userA: Awaited<ReturnType<typeof getUser>>;
+let userB: Awaited<ReturnType<typeof getUser>>;
+let userC: Awaited<ReturnType<typeof getUser>>;
+
+const statusBoostTemplate = {
+    '@context': [
+        'https://www.w3.org/ns/credentials/v2',
+        'https://ctx.learncard.com/boosts/1.0.1.json',
+    ],
+    type: ['VerifiableCredential', 'BoostCredential'],
+    issuer: 'did:example:issuer',
+    validFrom: '2024-01-01T00:00:00.000Z',
+    name: 'Group Revocation Status Boost',
+    credentialSubject: { id: 'did:example:subject' },
+};
+
+const getStatusEntries = (credential: any): any[] => {
+    if (!credential || typeof credential !== 'object') return [];
+
+    const statuses = credential.credentialStatus;
+    const entries = Array.isArray(statuses) ? statuses : statuses ? [statuses] : [];
+    return [...entries, ...getStatusEntries(credential.boostCredential)];
+};
+
+const getEntryForPurpose = (credential: any, statusPurpose: 'revocation' | 'suspension') => {
+    const entry = getStatusEntries(credential).find(
+        (status: any) => status.statusPurpose === statusPurpose
+    );
+    if (!entry) throw new Error(`Missing ${statusPurpose} status entry`);
+    return entry;
+};
+
+const isStatusBitSet = async (entry: any): Promise<boolean> => {
+    const listId = entry.statusListCredential.split('/').pop();
+    const response = await statusListsApp.inject({
+        method: 'GET',
+        url: `/status-lists/${listId}`,
+    });
+    expect(response.statusCode).toBe(200);
+
+    const statusListCredential = JSON.parse(response.body);
+    const bitstring = decodeBitstring(statusListCredential.credentialSubject.encodedList, 131_072);
+    const index = Number(entry.statusListIndex);
+    const byte = bitstring[Math.floor(index / 8)] ?? 0;
+    return (byte & (1 << index % 8)) !== 0;
+};
+
+const issueStatusInstanceToUserB = async (
+    boostUri: string
+): Promise<{ credentialUri: string; credential: any }> => {
+    const signedCredential = await userA.learnCard.invoke.issueCredential({
+        ...statusBoostTemplate,
+        issuer: userA.learnCard.id.did(),
+        validFrom: new Date().toISOString(),
+        credentialSubject: { id: userB.learnCard.id.did() },
+        boostId: boostUri,
+    });
+    const credentialUri = await userA.clients.fullAuth.boost.sendBoost({
+        profileId: 'userb',
+        uri: boostUri,
+        credential: signedCredential,
+    });
+    await userB.clients.fullAuth.credential.acceptCredential({ uri: credentialUri });
+    return {
+        credentialUri,
+        credential: await userB.clients.fullAuth.storage.resolve({ uri: credentialUri }),
+    };
+};
+
+const getConnectionCount = async (fromId: string, toId: string): Promise<number> => {
+    const { neogma } = await import('@instance');
+    const query = await neogma.queryRunner.run(
+        `MATCH (:Profile {profileId: $fromId})-[r:CONNECTED_WITH]-(:Profile {profileId: $toId})
+         RETURN count(r) AS count`,
+        { fromId, toId }
+    );
+    return query.records[0]?.get('count').toNumber() ?? 0;
+};
+
+describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
+    beforeAll(async () => {
+        userA = await getUser();
+        userB = await getUser('b'.repeat(64));
+        userC = await getUser('c'.repeat(64));
+        await statusListsApp.ready();
+    });
+
+    beforeEach(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await StatusList.delete({ detach: true, where: {} });
+        await CredentialActivity.delete({ detach: true, where: {} });
+        await ClaimHook.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+
+        await userA.clients.fullAuth.profile.createProfile({ profileId: 'usera' });
+        await userB.clients.fullAuth.profile.createProfile({ profileId: 'userb' });
+        await userC.clients.fullAuth.profile.createProfile({ profileId: 'userc' });
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    afterAll(async () => {
+        await Profile.delete({ detach: true, where: {} });
+        await Credential.delete({ detach: true, where: {} });
+        await Boost.delete({ detach: true, where: {} });
+        await StatusList.delete({ detach: true, where: {} });
+        await CredentialActivity.delete({ detach: true, where: {} });
+        await ClaimHook.delete({ detach: true, where: {} });
+        await Role.delete({ detach: true, where: {} });
+    });
+
+    it('revokes every active, suspended, and pending instance without allowing unsuspend to revive it', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        const userARef = { profileId: 'usera', user: userA };
+        const userBRef = { profileId: 'userb', user: userB };
+        const activeUri = await sendBoost(userARef, userBRef, boostUri, true);
+        const suspendedUri = await sendBoost(userARef, userBRef, boostUri, true);
+        const pendingUri = await sendBoost(userARef, userBRef, boostUri, false);
+
+        await userA.clients.fullAuth.boost.suspendBoostRecipient({
+            boostUri,
+            recipientProfileId: 'userb',
+            credentialUri: suspendedUri,
+        });
+
+        const result = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri,
+            recipientProfileId: 'userb',
+        });
+        expect(new Set(result.revokedCredentialUris)).toEqual(
+            new Set([activeUri, suspendedUri, pendingUri])
+        );
+        expect(result.alreadyRevokedCredentialUris).toEqual([]);
+        expect(result.failedCredentialUris).toEqual([]);
+
+        const statuses = await userB.clients.fullAuth.activity.getMyCredentialLifecycleStatuses({
+            uris: [activeUri, suspendedUri, pendingUri],
+        });
+        expect(statuses).toEqual({
+            [activeUri]: 'revoked',
+            [suspendedUri]: 'revoked',
+            [pendingUri]: 'revoked',
+        });
+
+        await expect(
+            userA.clients.fullAuth.boost.unsuspendBoostRecipient({
+                boostUri,
+                recipientProfileId: 'userb',
+                credentialUri: suspendedUri,
+            })
+        ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+        expect(
+            await userB.clients.fullAuth.activity.getMyCredentialLifecycleStatuses({
+                uris: [suspendedUri],
+            })
+        ).toEqual({ [suspendedUri]: 'revoked' });
+    }, 15_000);
+
+    it('authorizes before group mutation and rejects unauthenticated access', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+
+        await expect(
+            userC.clients.fullAuth.boost.revokeBoostRecipientGroup({
+                boostUri,
+                recipientProfileId: 'userb',
+            })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        await expect(
+            noAuthClient.boost.revokeBoostRecipientGroup({ boostUri, recipientProfileId: 'userb' })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+
+    it('classifies a retry as already revoked and emits no duplicate notification', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
+
+        const input = { boostUri, recipientProfileId: 'userb' };
+        const first = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(first.revokedCredentialUris).toHaveLength(2);
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
+        expect(notificationSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: { vcUris: expect.arrayContaining(first.revokedCredentialUris) },
+            })
+        );
+
+        notificationSpy.mockClear();
+        const second = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(second.revokedCredentialUris).toEqual([]);
+        expect(new Set(second.alreadyRevokedCredentialUris)).toEqual(
+            new Set(first.revokedCredentialUris)
+        );
+        expect(second.failedCredentialUris).toEqual([]);
+        expect(notificationSpy).not.toHaveBeenCalled();
+    });
+
+    it('sets revocation bits for every status-enabled instance', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: statusBoostTemplate,
+        });
+        const first = await issueStatusInstanceToUserB(boostUri);
+        const second = await issueStatusInstanceToUserB(boostUri);
+        const firstEntry = getEntryForPurpose(first.credential, 'revocation');
+        const secondEntry = getEntryForPurpose(second.credential, 'revocation');
+
+        await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri,
+            recipientProfileId: 'userb',
+        });
+
+        expect(await isStatusBitSet(firstEntry)).toBe(true);
+        expect(await isStatusBitSet(secondEntry)).toBe(true);
+    });
+
+    it('authoritatively revokes legacy credentials while logging a migration gap', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        const uri = await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const result = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri,
+            recipientProfileId: 'userb',
+        });
+        expect(result.revokedCredentialUris).toEqual([uri]);
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[revokeBoostRecipientGroup] migration-gap',
+            expect.objectContaining({ credentialId: expect.any(String), reason: 'missing-entry' })
+        );
+    });
+
+    it('retries cleanup hooks for already revoked credentials after a partial failure', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        const successfulUri = await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        const failingUri = await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        const failingCredentialId = getIdFromUri(failingUri);
+        const realProcessRevokeHooks = revokeHooks.processRevokeHooks;
+        const processRevokeHooksSpy = vi
+            .spyOn(revokeHooks, 'processRevokeHooks')
+            .mockImplementation(async (profile, credential) => {
+                if (credential.id === failingCredentialId)
+                    throw new Error('intentional hook failure');
+                return realProcessRevokeHooks(profile, credential);
+            });
+
+        const input = { boostUri, recipientProfileId: 'userb' };
+        const firstResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(firstResult.failedCredentialUris).toEqual([failingUri]);
+        expect(firstResult.revokedCredentialUris).toContain(successfulUri);
+
+        processRevokeHooksSpy.mockRestore();
+        const secondResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(secondResult.failedCredentialUris).toEqual([]);
+        expect(secondResult.alreadyRevokedCredentialUris).toContain(failingUri);
+    });
+
+    it('retries failed status-list updates for already revoked credentials', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: statusBoostTemplate,
+        });
+        await issueStatusInstanceToUserB(boostUri);
+        const { credentialUri: newestCredentialUri } = await issueStatusInstanceToUserB(boostUri);
+        const realStatusUpdate = statusListHelpers.setCredentialBitstringStatusWithResult;
+        const statusUpdateSpy = vi
+            .spyOn(statusListHelpers, 'setCredentialBitstringStatusWithResult')
+            .mockResolvedValueOnce('failed')
+            .mockImplementation(realStatusUpdate);
+
+        const input = { boostUri, recipientProfileId: 'userb' };
+        const firstResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(firstResult.failedCredentialUris).toContain(newestCredentialUri);
+
+        statusUpdateSpy.mockRestore();
+        const retryResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
+        expect(retryResult.failedCredentialUris).toEqual([]);
+        expect(retryResult.alreadyRevokedCredentialUris).toContain(newestCredentialUri);
+    });
+
+    it('removes permissions and admin roles granted by repeated claim instances', async () => {
+        const claimUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        const targetUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        await userA.clients.fullAuth.claimHook.createClaimHook({
+            hook: {
+                type: 'GRANT_PERMISSIONS',
+                data: { claimUri, targetUri, permissions: { canIssue: true } },
+            },
+        });
+        await userA.clients.fullAuth.claimHook.createClaimHook({
+            hook: { type: 'ADD_ADMIN', data: { claimUri, targetUri } },
+        });
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            claimUri,
+            true
+        );
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            claimUri,
+            true
+        );
+        expect(
+            (await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })).canIssue
+        ).toBe(true);
+        const adminRoleId = (
+            await userB.clients.fullAuth.boost.getBoostPermissions({ uri: targetUri })
+        ).role;
+        expect(adminRoleId).toBeTruthy();
+
+        await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri: claimUri,
+            recipientProfileId: 'userb',
+        });
+        const permissions = await userB.clients.fullAuth.boost.getBoostPermissions({
+            uri: targetUri,
+        });
+        expect(permissions.canIssue).toBeFalsy();
+        expect(permissions.role).not.toBe(adminRoleId);
+    });
+
+    it('removes autoConnectRecipients connections after revoking the group', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+            autoConnectRecipients: true,
+        });
+        await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        expect(await getConnectionCount('usera', 'userb')).toBeGreaterThan(0);
+
+        await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri,
+            recipientProfileId: 'userb',
+        });
+        expect(await getConnectionCount('usera', 'userb')).toBe(0);
+    });
+});

--- a/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
+++ b/services/learn-card-network/brain-service/test/revoke-boost-recipient-group.spec.ts
@@ -259,6 +259,48 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
         expect(await isStatusBitSet(secondEntry)).toBe(true);
     });
 
+    it('rejects singular revocation when the status-list update throws', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: statusBoostTemplate,
+        });
+        const { credentialUri } = await issueStatusInstanceToUserB(boostUri);
+        vi.spyOn(statusListHelpers, 'setCredentialBitstringStatusWithResult').mockRejectedValueOnce(
+            new Error('intentional status-list failure')
+        );
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
+
+        await expect(
+            userA.clients.fullAuth.boost.revokeBoostRecipient({
+                boostUri,
+                recipientProfileId: 'userb',
+                credentialUri,
+            })
+        ).rejects.toThrow('Failed to update credential status list');
+        expect(notificationSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects singular revocation when the status-list update reports failure', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: statusBoostTemplate,
+        });
+        const { credentialUri } = await issueStatusInstanceToUserB(boostUri);
+        vi.spyOn(statusListHelpers, 'setCredentialBitstringStatusWithResult').mockResolvedValueOnce(
+            'failed'
+        );
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
+
+        await expect(
+            userA.clients.fullAuth.boost.revokeBoostRecipient({
+                boostUri,
+                recipientProfileId: 'userb',
+                credentialUri,
+            })
+        ).rejects.toThrow('Failed to update credential status list');
+        expect(notificationSpy).not.toHaveBeenCalled();
+    });
+
     it('authoritatively revokes legacy credentials while logging a migration gap', async () => {
         const boostUri = await userA.clients.fullAuth.boost.createBoost({
             credential: testUnsignedBoost,
@@ -282,6 +324,59 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
         );
     });
 
+    it('repairs legacy received-side revocation without changing its audit time or notifying', async () => {
+        const boostUri = await userA.clients.fullAuth.boost.createBoost({
+            credential: testUnsignedBoost,
+        });
+        const credentialUri = await sendBoost(
+            { profileId: 'usera', user: userA },
+            { profileId: 'userb', user: userB },
+            boostUri,
+            true
+        );
+        const credentialId = getIdFromUri(credentialUri);
+        const legacyRevokedAt = '2025-01-02T03:04:05.000Z';
+        const { neogma } = await import('@instance');
+        await neogma.queryRunner.run(
+            `MATCH (:Profile)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential:Credential {id: $credentialId})
+             MATCH (credential)-[received:CREDENTIAL_RECEIVED]->(:Profile {profileId: $profileId})
+             SET sent.status = null,
+                 received.status = "revoked",
+                 received.revokedAt = $legacyRevokedAt
+             REMOVE sent.revokedAt`,
+            { credentialId, profileId: 'userb', legacyRevokedAt }
+        );
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
+        const hookSpy = vi.spyOn(revokeHooks, 'processRevokeHooksStrict');
+
+        const result = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup({
+            boostUri,
+            recipientProfileId: 'userb',
+        });
+
+        expect(result.revokedCredentialUris).toEqual([]);
+        expect(result.alreadyRevokedCredentialUris).toEqual([credentialUri]);
+        expect(result.failedCredentialUris).toEqual([]);
+        expect(notificationSpy).not.toHaveBeenCalled();
+        expect(hookSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ profileId: 'userb' }),
+            expect.objectContaining({ id: credentialId })
+        );
+
+        const audit = await neogma.queryRunner.run(
+            `MATCH (:Profile)-[sent:CREDENTIAL_SENT {to: $profileId}]->(credential:Credential {id: $credentialId})
+             MATCH (credential)-[received:CREDENTIAL_RECEIVED]->(:Profile {profileId: $profileId})
+             RETURN sent.status AS sentStatus,
+                    sent.revokedAt AS sentRevokedAt,
+                    received.revokedAt AS receivedRevokedAt`,
+            { credentialId, profileId: 'userb' }
+        );
+        expect(audit.records[0]?.get('sentStatus')).toBe('revoked');
+        expect(audit.records[0]?.get('sentRevokedAt')).toBe(legacyRevokedAt);
+        expect(audit.records[0]?.get('receivedRevokedAt')).toBe(legacyRevokedAt);
+    });
+
     it('retries cleanup hooks for already revoked credentials after a partial failure', async () => {
         const boostUri = await userA.clients.fullAuth.boost.createBoost({
             credential: testUnsignedBoost,
@@ -300,6 +395,8 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
         );
         const failingCredentialId = getIdFromUri(failingUri);
         const realProcessRevokeHooks = revokeHooks.processRevokeHooksStrict;
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
         let failingCredentialHookCalls = 0;
         const processRevokeHooksSpy = vi
             .spyOn(revokeHooks, 'processRevokeHooksStrict')
@@ -313,11 +410,18 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
         const firstResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
         expect(firstResult.failedCredentialUris).toEqual([failingUri]);
         expect(firstResult.revokedCredentialUris).toContain(successfulUri);
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
+        expect(notificationSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: { vcUris: expect.arrayContaining([successfulUri, failingUri]) },
+            })
+        );
 
         const secondResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
         expect(secondResult.failedCredentialUris).toEqual([]);
         expect(secondResult.alreadyRevokedCredentialUris).toContain(failingUri);
         expect(failingCredentialHookCalls).toBe(2);
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
         expect(processRevokeHooksSpy).toHaveBeenCalledWith(
             expect.objectContaining({ profileId: 'userb' }),
             expect.objectContaining({ id: failingCredentialId })
@@ -329,21 +433,33 @@ describe('Revoke Boost Recipient Group (LC-1950)', { timeout: 30_000 }, () => {
             credential: statusBoostTemplate,
         });
         await issueStatusInstanceToUserB(boostUri);
-        const { credentialUri: newestCredentialUri } = await issueStatusInstanceToUserB(boostUri);
+        const { credentialUri: newestCredentialUri, credential: newestCredential } =
+            await issueStatusInstanceToUserB(boostUri);
+        const newestRevocationEntry = getEntryForPurpose(newestCredential, 'revocation');
         const realStatusUpdate = statusListHelpers.setCredentialBitstringStatusWithResult;
         const statusUpdateSpy = vi
             .spyOn(statusListHelpers, 'setCredentialBitstringStatusWithResult')
             .mockResolvedValueOnce('failed')
             .mockImplementation(realStatusUpdate);
+        const notificationSpy = vi.spyOn(notifications, 'addNotificationToQueue');
+        notificationSpy.mockClear();
 
         const input = { boostUri, recipientProfileId: 'userb' };
         const firstResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
         expect(firstResult.failedCredentialUris).toContain(newestCredentialUri);
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
+        expect(notificationSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: { vcUris: expect.arrayContaining([newestCredentialUri]) },
+            })
+        );
 
         statusUpdateSpy.mockRestore();
         const retryResult = await userA.clients.fullAuth.boost.revokeBoostRecipientGroup(input);
         expect(retryResult.failedCredentialUris).toEqual([]);
         expect(retryResult.alreadyRevokedCredentialUris).toContain(newestCredentialUri);
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
+        expect(await isStatusBitSet(newestRevocationEntry)).toBe(true);
     });
 
     it('removes permissions and admin roles granted by repeated claim instances', async () => {


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Fixes: [LC-1950](https://welibrary.atlassian.net/browse/LC-1950)

#### 📚 What is the context and goal of this PR?

ScoutPass inferred revocation from recipient-list absence and removed revoked credentials from the holder's local index. That could present network/query failures as revocation, leave duplicate issuances active after group removal, and diverge from the authoritative lifecycle behavior used by LearnCard App.

This PR moves the shared credential lifecycle logic into `learn-card-base`, adds an authenticated server-side group revocation operation, and updates ScoutPass to use exact credential URIs and authoritative lifecycle state. Revoked credentials remain visible for audit, while Share, QR, and protected actions fail closed when an issuance is revoked, suspended, pending, or unavailable.

Migration or reissuance of existing credentials is intentionally outside this PR.

#### 💡 Feature Breakdown

- Shared lifecycle hook with backend-status precedence and Bitstring verification fallback.
- Typed network-plugin and React Query group-revocation API.
- Server-side revocation of every accepted, pending, or suspended issuance for a Boost/profile pair.
- Idempotent Bitstring update, graph transition, permission/admin/connection cleanup, credential-refresh invalidation, and consolidated notification.
- Exact issuance matching in ScoutPass so sibling credentials cannot supply the wrong status.
- Unified Scout, Leader, and Admin removal flow; holder-controlled Leave remains separate.
- Pending-only member rows remain reachable for administration.
- Revoked IDs remain visible with Share, QR, and protected actions suppressed.
- Automatic revoked-record deletion removed from ScoutPass.

#### 🛠 Important tradeoffs

- Group removal revokes every issuance for the selected Boost/profile pair rather than exposing per-issuance selection, preventing an older duplicate from retaining access.
- Verification transport/status-list errors do not become false revocation states. Protected ScoutPass actions remain unavailable while lifecycle status is uncertain.
- Revoked records and original audit timestamps are retained instead of deleted or rewritten.
- Existing-data migration, reissuance, and external-verifier cutover are separate work.

#### 🔍 Types of Changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Chore/documentation

# Testing

Focused validation after rebasing onto current `main`:

- 46 backend integration tests passed across group revocation and existing revoke/suspend suites.
- 25 ScoutPass lifecycle/group-removal helper tests passed.
- 13 shared lifecycle and React Query tests passed.
- 5 LearnCard App compatibility-hook tests passed.
- `@learncard/types`, network plugin, brain service, and ScoutPass builds passed (ScoutPass used a non-secret placeholder Web3Auth client ID required by production config validation).
- Scout lifecycle TypeScript target, i18n AST guard, scoped lint/pre-commit checks, Prettier, and `git diff --check` passed.

Manual rendered UI and native/offline end-to-end QA remain unverified.

# Documentation

Updated `docs/apps/scouts/credential-revocation.md` and ScoutPass `AGENTS.md` for the authoritative runtime lifecycle. Migration planning documents were removed from this PR to keep LC-1950 focused.

# ✅ PR Checklist

- [x] Related to LC-1950
- [x] Follows style and localization guidelines
- [ ] Manually tested common end-to-end cases
- [x] Focused unit/integration tests pass locally
- [x] Relevant package/app builds pass locally
- [x] Security implications reviewed
- [x] New endpoint is authenticated and permission-gated

### 🚀 Ready to squash-and-merge?

- [x] Backward-compatible runtime behavior
- [x] No "Do Not Merge" label
- [ ] Manual rendered/native QA complete


[LC-1950]: https://welibrary.atlassian.net/browse/LC-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ