### PR TITLE
fix(ci): pin release E2E runner to main

### DIFF
--- a/.github/tests/test-workflow-contract.test.sh
+++ b/.github/tests/test-workflow-contract.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+ruby - "$REPO_ROOT/.github/workflows/test.yml" <<'RUBY'
+require 'yaml'
+
+workflow = YAML.load_file(ARGV.fetch(0), aliases: true)
+steps = workflow.fetch('jobs').fetch('e2e-tests').fetch('steps')
+run_ssh = steps.find { |step| step['name'] == 'Run E2E tests on EC2' }
+abort 'Run E2E tests on EC2 step missing' unless run_ssh
+
+script_lines = run_ssh.fetch('with').fetch('script').lines.map(&:strip).reject(&:empty?)
+fetch_index = script_lines.index('git fetch --no-tags origin main')
+reset_index = script_lines.index('git reset --hard FETCH_HEAD')
+sync_index = script_lines.index do |line|
+    line.start_with?('./scripts/sync-repo.sh ')
+end
+
+# Break caught: a persistent EC2 checkout remains on an experimental runner branch.
+abort 'runner main fetch missing' unless fetch_index
+abort 'runner checkout reset missing' unless reset_index
+abort 'LearnCard sync command missing' unless sync_index
+abort 'runner reset must follow fetch' unless fetch_index < reset_index
+abort 'runner reset must precede LearnCard sync' unless reset_index < sync_index
+abort 'stateful git pull must not select the runner revision' if script_lines.include?('git pull origin main')
+RUBY
+
+echo 'LearnCard E2E workflow contract passed'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,9 @@ jobs:
                   command_timeout: 50m
                   script: |
                       cd ~/learncard-e2e-runner
-                      git pull origin main
+                      git fetch --no-tags origin main
+                      git reset --hard FETCH_HEAD
+                      echo "Runner repository resolved to: $(git rev-parse HEAD)"
                       ./scripts/sync-repo.sh ${{ github.head_ref || github.event.inputs.branch }}
                       ./scripts/run-tests.sh
 


### PR DESCRIPTION
## What changed

- replace the stateful `git pull origin main` in the release E2E SSH step with an explicit fetch and hard reset to `FETCH_HEAD`
- print the resolved runner revision before syncing LearnCard
- add a parsed-YAML workflow contract that enforces fetch → reset → LearnCard sync ordering and rejects the old pull behavior

## Root cause

Release run [31525740657](https://github.com/learningeconomy/LearnCard/actions/runs/31525740657) executed `cache-policy.sh` even though that file is not present on runner `main`. The persistent EC2 checkout was still attached to the LC-2073 Phase 2B feature branch. `git pull origin main` fetched/merged main into the current branch but did not select main, allowing experimental runner code to leak into the release run.

Runner PR [WeLibraryOS/learncard-e2e-runner#15](https://github.com/WeLibraryOS/learncard-e2e-runner/pull/15) is also updated so an omitted `E2E_CACHE_MODE` resolves safely to `cold`, while invalid non-empty values remain rejected.

## Validation

- `bash .github/tests/test-workflow-contract.test.sh`
- Ruby YAML parse of `.github/workflows/test.yml`
- `bunx prettier --check .github/workflows/test.yml`
- `git diff --check`
- Husky/lint-staged pre-commit validation
