### PR TITLE
fix: [LC-2102] restore Chromatic story contexts

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,10 @@
 name: 'Chromatic'
 
 on:
+    # Keep a current baseline build for every main commit. Without this, Chromatic
+    # cannot compare a PR once its merge base advances past the last published build.
+    push:
+        branches: [main]
     pull_request:
         types: [opened, synchronize, reopened]
 
@@ -21,6 +25,7 @@ env:
 
 jobs:
     chromatic-deployment:
+        if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
@@ -64,7 +69,7 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v7
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
                   # Chromatic needs full git history to compare against the baseline.
                   fetch-depth: 0
 
@@ -88,14 +93,14 @@ jobs:
             # from the nx graph at runtime (rather than hardcoded) so new dependencies are covered
             # automatically. run-many skips any project in the closure that has no build target.
             - name: Build workspace dependencies
-              if: contains(env.AFFECTED, 'learn-card-app')
+              if: github.event_name == 'push' || contains(env.AFFECTED, 'learn-card-app')
               run: |
                   bunx nx graph --focus=learn-card-app --file=dep-graph.json
                   PROJECTS=$(bun -e "const g=require('./dep-graph.json');const deps=g.graph.dependencies;const seen=new Set();const q=['learn-card-app'];while(q.length){const n=q.pop();for(const d of (deps[n]||[])){if(d.target.startsWith('npm:'))continue;if(!seen.has(d.target)){seen.add(d.target);q.push(d.target);}}}process.stdout.write([...seen].join(','));")
                   bunx nx run-many -t build --projects="$PROJECTS"
 
             - name: Publish to Chromatic
-              if: contains(env.AFFECTED, 'learn-card-app')
+              if: github.event_name == 'push' || contains(env.AFFECTED, 'learn-card-app')
               uses: chromaui/action@latest
               with:
                   projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_LCA }}

--- a/apps/learn-card-app/.storybook/preview.tsx
+++ b/apps/learn-card-app/.storybook/preview.tsx
@@ -8,6 +8,8 @@ import {
     TenantConfigProvider,
     DEFAULT_LEARNCARD_TENANT_CONFIG,
 } from 'learn-card-base';
+import { AnalyticsContextProvider } from '../src/analytics';
+import { LocaleProvider } from '../src/i18n';
 import { Buffer } from 'buffer';
 
 (window as any).Buffer = (window as any).Buffer ?? Buffer;
@@ -50,35 +52,25 @@ const preview: Preview = {
         },
     },
     decorators: [
-        Story =>
-            React.createElement(
-                IonApp,
-                null,
-                React.createElement(
-                    TenantConfigProvider,
-                    { config: DEFAULT_LEARNCARD_TENANT_CONFIG },
-                    React.createElement(
-                        QueryClientProvider,
-                        { client: queryClient },
-                        React.createElement(
-                            MemoryRouter,
-                            null,
-                            React.createElement(
-                                ModalsProvider,
-                                null,
-                                React.createElement(
-                                    'div',
-                                    {
-                                        className:
-                                            'font-poppins bg-grayscale-100 h-screen overflow-y-auto',
-                                    },
-                                    React.createElement(Story)
-                                )
-                            )
-                        )
-                    )
-                )
-            ),
+        Story => (
+            <IonApp>
+                <TenantConfigProvider config={DEFAULT_LEARNCARD_TENANT_CONFIG}>
+                    <LocaleProvider>
+                        <AnalyticsContextProvider>
+                            <QueryClientProvider client={queryClient}>
+                                <MemoryRouter>
+                                    <ModalsProvider>
+                                        <div className="font-poppins bg-grayscale-100 h-screen overflow-y-auto">
+                                            <Story />
+                                        </div>
+                                    </ModalsProvider>
+                                </MemoryRouter>
+                            </QueryClientProvider>
+                        </AnalyticsContextProvider>
+                    </LocaleProvider>
+                </TenantConfigProvider>
+            </IonApp>
+        ),
     ],
 };
 


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Fixes: [LC-2102](https://welibrary.atlassian.net/browse/LC-2102)

#### 📚 What is the context and goal of this PR?

Eight LearnCard app stories were crashing during Chromatic rendering because Storybook's global decorator didn't include the locale and analytics contexts their components now consume. The Chromatic workflow also only ran for pull requests, so `main` could advance without publishing the baseline builds Chromatic needs for later comparisons.

This adds the missing app-level providers and publishes the LearnCard app Storybook after every push to `main`. Pull-request behavior stays affected-project-only.

#### 🥴 TL; RL:

- Three `IssueSuccess` stories threw from `useAnalyticsContext` and five `DataSharingCenterView` stories threw from `useLocale`; both contexts are now provided globally.
- `main` now publishes a Chromatic baseline on every commit so PR comparisons don't become detached from their merge base again.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Chore (CI workflow update)

#### 💳 Does This Create Any New Technical Debt?

-   [x] No

# Testing

#### 🔬 How Can Someone QA This?

1. Build the `learn-card-app` workspace dependency closure using the commands in `.github/workflows/chromatic.yml`.
2. Run `NODE_OPTIONS=--max_old_space_size=8192 bun run build-storybook` from `apps/learn-card-app`.
3. Run `bun run test-storybook:ci` and confirm all 9 suites and 36 story smoke tests pass.
4. Confirm the Chromatic workflow publishes the LearnCard app job for pushes to `main` and keeps the React-package job pull-request-only.

I reproduced the eight missing-context failures before the provider change. Afterward, the local Storybook build and all 36 smoke tests passed. I also published the requested `main` build and forced a fresh branch build; [Chromatic build 1061](https://www.chromatic.com/build?appId=6a2b06791b5c97ab43dcdd4d&number=1061) passed all 36 stories with no unreviewed changes or stale merge-base warning.

#### 🧪 Code Coverage

No new component test was needed: the existing Storybook runner already exercises the broken render path. The workflow file passes Prettier's parser/format check.

# Documentation

#### 💭 Documentation Notes

Internal Storybook and CI repair; no user-facing flow or public API changed.

— OMP

[LC-2102]: https://welibrary.atlassian.net/browse/LC-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Restore missing context providers to Storybook stories and fix Chromatic CI workflow to maintain baseline builds and proper context propagation.

Main changes:
- Added AnalyticsContextProvider and LocaleProvider imports and wrapped story decorator with full context hierarchy (IonApp, TenantConfig, Locale, Analytics, QueryClient, MemoryRouter, Modals)
- Enabled Chromatic builds on main branch pushes to maintain baseline; adjusted job conditions to run on both push and PR events with affected filtering
- Fixed checkout ref to support both PR and push events using fallback syntax for baseline comparison

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
