### PR TITLE
[LC-1839] Show Learning Commons grounding debug data

### DIFF
--- a/apps/learn-card-app/src/components/new-ai-session/LearnCardAiChatBot/AiSessionPlan.tsx
+++ b/apps/learn-card-app/src/components/new-ai-session/LearnCardAiChatBot/AiSessionPlan.tsx
@@ -11,6 +11,7 @@ import {
     planStreamActive,
     planSections,
     isLoading,
+    learningCommonsDebug,
 } from 'learn-card-base/stores/nanoStores/chatStore';
 
 const containerVariants = {
@@ -35,6 +36,7 @@ export const AiSessionPlan: React.FC = () => {
     const loading = useStore(isLoading);
     const isStreaming = useStore(planStreamActive);
     const plan = useStore(planSections);
+    const groundingDebug = useStore(learningCommonsDebug);
 
     const hasPlan =
         loading ||
@@ -80,6 +82,112 @@ export const AiSessionPlan: React.FC = () => {
                     </div>
                 )}
             </motion.section>
+
+            {import.meta.env.DEV && groundingDebug.status !== 'idle' && (
+                <motion.section
+                    variants={sectionVariants}
+                    className="rounded-2xl border border-amber-200 bg-amber-50 p-4"
+                    data-testid="learning-commons-debug"
+                >
+                    <div className="mb-2 flex items-center gap-2">
+                        <span className="rounded-full bg-amber-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900">
+                            Debug
+                        </span>
+                        <h2 className="text-sm font-semibold text-grayscale-900">
+                            Learning Commons grounding
+                        </h2>
+                    </div>
+
+                    {groundingDebug.status === 'unavailable' ? (
+                        <p className="text-sm leading-relaxed text-red-700">
+                            No matching standard was used. This plan used the generic prompt.
+                        </p>
+                    ) : groundingDebug.status === 'grounded' ? (
+                        <div className="space-y-3">
+                            <div>
+                                <p className="text-xs font-medium text-grayscale-700">
+                                    Standard used
+                                </p>
+                                <p className="font-mono text-sm font-semibold text-grayscale-900">
+                                    {groundingDebug.grounding.target.statementCode}
+                                </p>
+                                <p className="mt-1 text-sm leading-relaxed text-grayscale-700">
+                                    {groundingDebug.grounding.target.description}
+                                </p>
+                            </div>
+
+                            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                                <div>
+                                    <dt className="text-grayscale-500">Subject</dt>
+                                    <dd className="font-medium text-grayscale-800">
+                                        {groundingDebug.grounding.target.academicSubject}
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt className="text-grayscale-500">Grade</dt>
+                                    <dd className="font-medium text-grayscale-800">
+                                        {groundingDebug.grounding.target.gradeLevel.join(', ')}
+                                    </dd>
+                                </div>
+                                {groundingDebug.grounding.source.searchScore !== undefined && (
+                                    <div>
+                                        <dt className="text-grayscale-500">Search relevance</dt>
+                                        <dd className="font-medium text-grayscale-800">
+                                            {(
+                                                groundingDebug.grounding.source.searchScore * 100
+                                            ).toFixed(1)}
+                                            %
+                                        </dd>
+                                    </div>
+                                )}
+                                <div>
+                                    <dt className="text-grayscale-500">Jurisdiction</dt>
+                                    <dd className="font-medium text-grayscale-800">
+                                        {groundingDebug.grounding.target.jurisdiction}
+                                    </dd>
+                                </div>
+                            </dl>
+
+                            {groundingDebug.grounding.prerequisite && (
+                                <div>
+                                    <p className="text-xs font-medium text-grayscale-700">
+                                        Supporting standard
+                                    </p>
+                                    <p className="font-mono text-xs font-semibold text-grayscale-900">
+                                        {groundingDebug.grounding.prerequisite.statementCode}
+                                    </p>
+                                    <p className="mt-1 text-xs leading-relaxed text-grayscale-600">
+                                        {groundingDebug.grounding.prerequisite.description}
+                                    </p>
+                                </div>
+                            )}
+
+                            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                                <a
+                                    href={groundingDebug.grounding.target.caseIdentifierURI}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="font-medium text-grayscale-700 underline hover:text-grayscale-900"
+                                >
+                                    Open CASE identifier
+                                </a>
+                                <a
+                                    href={groundingDebug.grounding.source.targetUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="font-medium text-grayscale-700 underline hover:text-grayscale-900"
+                                >
+                                    Open API source
+                                </a>
+                            </div>
+
+                            <p className="text-[11px] leading-relaxed text-grayscale-500">
+                                {groundingDebug.grounding.target.attributionStatement}
+                            </p>
+                        </div>
+                    ) : null}
+                </motion.section>
+            )}
 
             {/* ================= SKILLS ================= */}
             <motion.section variants={sectionVariants} className="flex flex-col gap-8 mt-4">

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
@@ -89,6 +89,7 @@ const {
     disconnectWebSocket,
     isLoading,
     lastAiError,
+    learningCommonsDebug,
     isTyping,
     messages,
     planReady,
@@ -166,6 +167,67 @@ describe('chat session startup', () => {
             skills: [],
             roadmap: [],
         });
+    });
+
+    it('captures the standard used to ground the current session plan', async () => {
+        const start = startTopic('Teach me fractions');
+        const socket = await openLatestSocket();
+        await start;
+        socket.receive({ event: 'session_start_accepted', requestId: 'request-grounding' });
+        socket.receive({
+            event: 'learning_commons_grounding',
+            requestId: 'request-grounding',
+            grounding: {
+                source: {
+                    provider: 'Learning Commons',
+                    searchScore: 0.86,
+                    targetUrl: 'https://api.learningcommons.org/standard',
+                    retrievedAt: '2026-08-12T00:00:00.000Z',
+                },
+                target: {
+                    statementCode: '3.NF.A.1',
+                    description: 'Understand unit fractions as equal parts of a whole.',
+                    caseIdentifierURI: 'https://example.com/case/3.NF.A.1',
+                    jurisdiction: 'Multi-State',
+                    academicSubject: 'Mathematics',
+                    gradeLevel: ['3'],
+                    author: 'Standards Author',
+                    license: 'https://creativecommons.org/licenses/by/4.0/',
+                    attributionStatement: 'Standards attribution.',
+                },
+            },
+        });
+
+        expect(learningCommonsDebug.get()).toEqual({
+            status: 'grounded',
+            grounding: {
+                source: {
+                    provider: 'Learning Commons',
+                    searchScore: 0.86,
+                    targetUrl: 'https://api.learningcommons.org/standard',
+                    retrievedAt: '2026-08-12T00:00:00.000Z',
+                },
+                target: {
+                    statementCode: '3.NF.A.1',
+                    description: 'Understand unit fractions as equal parts of a whole.',
+                    caseIdentifierURI: 'https://example.com/case/3.NF.A.1',
+                    jurisdiction: 'Multi-State',
+                    academicSubject: 'Mathematics',
+                    gradeLevel: ['3'],
+                    author: 'Standards Author',
+                    license: 'https://creativecommons.org/licenses/by/4.0/',
+                    attributionStatement: 'Standards attribution.',
+                },
+            },
+        });
+
+        socket.receive({
+            event: 'learning_commons_grounding',
+            requestId: 'request-grounding',
+            grounding: null,
+        });
+
+        expect(learningCommonsDebug.get()).toEqual({ status: 'unavailable' });
     });
 
     it('keeps ended threads read-only while preserving legacy threads with omitted state', async () => {

--- a/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
+++ b/packages/learn-card-base/src/stores/nanoStores/chatStore.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores';
 import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
 
 import { auth } from './authStore';
 import { resetArtifactsStore } from './artifactsStore';
@@ -14,6 +15,7 @@ import type {
     ThreadCredentialContext,
     LearningPathway,
     ActiveSessionStatus,
+    LearningCommonsDebugState,
 } from '../../types/ai-chat';
 import { parseAiErrorPayload, type AiClientError } from '../../helpers/aiErrors';
 
@@ -28,6 +30,7 @@ export const showEndingSessionLoader = atom(false);
 export const activeQuestions = atom<string[]>([]);
 export const suggestedTopics = atom<string[]>([]);
 export const topicCredentials = atom<ThreadCredentialContext[]>([]);
+export const learningCommonsDebug = atom<LearningCommonsDebugState>({ status: 'idle' });
 export const sessionEnded = atom(false);
 export const planReady = atom(false);
 export const planReadyThread = atom<string | null>(null);
@@ -138,6 +141,35 @@ const CREDENTIAL_INGESTION_PHASES = {
     error: true,
 } satisfies Record<NonNullable<CredentialContextReadiness['ingestionPhase']>, true>;
 
+const LearningCommonsDebugStandardValidator = z.object({
+    statementCode: z.string(),
+    description: z.string(),
+    caseIdentifierURI: z.string(),
+    jurisdiction: z.string(),
+    academicSubject: z.string(),
+    gradeLevel: z.array(z.string()),
+    author: z.string(),
+    license: z.string(),
+    attributionStatement: z.string(),
+});
+
+const LearningCommonsDebugGroundingValidator = z.object({
+    source: z.object({
+        provider: z.literal('Learning Commons'),
+        searchScore: z.number().optional(),
+        targetUrl: z.string(),
+        retrievedAt: z.string(),
+    }),
+    target: LearningCommonsDebugStandardValidator,
+    prerequisite: LearningCommonsDebugStandardValidator.optional(),
+    relationship: z
+        .object({
+            relationshipType: z.literal('buildsTowards'),
+            description: z.string(),
+        })
+        .optional(),
+});
+
 /** Returns whether a thread has explicit lifecycle or legacy summary evidence of ending. */
 export const hasThreadEnded = (thread: Thread | undefined): boolean =>
     Boolean(thread?.ended_at || thread?.active === false || thread?.summaries?.length);
@@ -171,6 +203,7 @@ export function resetChatSessionStores() {
     planReady.set(false);
     planReadyThread.set(null);
     credentialContextReadiness.set({ status: 'idle', count: 0 });
+    learningCommonsDebug.set({ status: 'idle' });
     currentTopicUri.set(null);
     currentAiPathwayUri.set(null);
     sessionStartedAt.set(null);
@@ -496,6 +529,22 @@ export function connectWebSocket() {
                 if (typeof data.requestId === 'string') {
                     currentSessionStartRequestId = data.requestId;
                 }
+
+                return;
+            }
+
+            if (data.event === 'learning_commons_grounding') {
+                if (!isCurrentSessionStartFrame(data.requestId)) return;
+
+                if (data.grounding === null) {
+                    learningCommonsDebug.set({ status: 'unavailable' });
+                    return;
+                }
+
+                const result = LearningCommonsDebugGroundingValidator.safeParse(data.grounding);
+
+                if (result.success)
+                    learningCommonsDebug.set({ status: 'grounded', grounding: result.data });
 
                 return;
             }

--- a/packages/learn-card-base/src/types/ai-chat.ts
+++ b/packages/learn-card-base/src/types/ai-chat.ts
@@ -42,6 +42,37 @@ export type ThreadCredentialContext = {
     title?: string;
 };
 
+export type LearningCommonsDebugStandard = {
+    statementCode: string;
+    description: string;
+    caseIdentifierURI: string;
+    jurisdiction: string;
+    academicSubject: string;
+    gradeLevel: string[];
+    author: string;
+    license: string;
+    attributionStatement: string;
+};
+
+export type LearningCommonsDebugGrounding = {
+    source: {
+        provider: 'Learning Commons';
+        searchScore?: number;
+        targetUrl: string;
+        retrievedAt: string;
+    };
+    target: LearningCommonsDebugStandard;
+    prerequisite?: LearningCommonsDebugStandard;
+    relationship?: {
+        relationshipType: 'buildsTowards';
+        description: string;
+    };
+};
+
+export type LearningCommonsDebugState =
+    | { status: 'idle' | 'pending' | 'unavailable'; grounding?: never }
+    | { status: 'grounded'; grounding: LearningCommonsDebugGrounding };
+
 export type Thread = {
     id: string;
     did: string;


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Related to: [LC-1839](https://welibrary.atlassian.net/browse/LC-1839)

Production follow-up: [LC-2103](https://welibrary.atlassian.net/browse/LC-2103), [LC-2104](https://welibrary.atlassian.net/browse/LC-2104), [LC-2105](https://welibrary.atlassian.net/browse/LC-2105), [LC-2106](https://welibrary.atlassian.net/browse/LC-2106), [LC-2107](https://welibrary.atlassian.net/browse/LC-2107)

Companion backend spike: https://github.com/WeLibraryOS/AI-Passport/pull/63

#### 📚 What is the context and goal of this PR?

This is the development-only UI used to verify that an AI tutor plan was grounded by the server-selected Learning Commons standard rather than inferred from generated prose. It consumes the correlated provenance event from the AI Passport spike and keeps the detail behind `import.meta.env.DEV`.

This is intentionally a **draft**. The production experience should use persisted provenance and a learner-safe “Aligned to” disclosure, not this raw diagnostic panel.

#### 🥴 TL; RL:

The session plan now shows the exact statement code, description, grade, subject, jurisdiction, search relevance, optional supporting standard, CASE identifier, API record, and attribution during development. It explicitly says when the generic prompt was used instead.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Validates the backend payload before storing it.
- Ignores stale startup frames by `requestId`.
- Resets provenance when the active session resets.
- Renders only in development builds.
- Uses direct links to the authoritative CASE identifier and API record.

OMP browser-verified the panel through the live `Teach me fractions` flow and confirmed that both source links resolved. A separate manual session for `Prepositional Phrases` displayed `L.4.1.e`.

#### 🛠 Important tradeoffs made:

This deliberately mirrors the experimental backend event instead of introducing a production persistence contract in LearnCard. That keeps the spike small, but reloading cannot reconstruct provenance and the raw score is not learner-facing copy. The production follow-up tickets linked above replace this transient contract.

#### 🔍 Types of Changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

-   [ ] No
-   [x] Yes

The panel depends on transient WebSocket provenance and is suitable only for development verification. LC-2103 covers durable storage and safe status; LC-2106 covers the eventual learner-facing disclosure and controlled pilot.

# Testing

#### 🔬 How Can Someone QA This?

1. Run the companion AI Passport branch with `LEARNING_COMMONS_API_KEY` configured.
2. Run LearnCard in development and start LearnCard AI with `Teach me fractions`.
3. Confirm the plan shows a `Learning Commons grounding` card with the exact standard and working CASE/API links.
4. Remove the key or force the resolver to return no match. Confirm the session still starts and the card says the generic prompt was used.
5. Start a second session and confirm the first session's grounding does not leak into it.

#### 📱 🖥 Which devices would you like help testing on?

Chromium is sufficient for this development-only spike.

#### 🧪 Code Coverage

The chat-store regression covers accepted grounding, explicit unavailable state, request correlation, and session reset behavior. OMP ran the focused test after applying the change to current `main`: **30 passed, 0 failed**.

```bash
bunx vitest run packages/learn-card-base/src/stores/nanoStores/chatStore.test.ts
```

# Documentation

#### 📝 Documentation Checklist

No user-facing documentation yet. This is a development diagnostic for a draft integration; the companion backend PR contains the experiment report and production recommendation.

# ✅ PR Checklist

-   [x] Related to a Jira issue
-   [x] Code follows the repository formatting conventions
-   [x] OMP manually exercised the end-to-end development flow
-   [x] OMP reviewed the scoped diff
-   [x] Focused unit tests pass locally
-   [x] Documentation requirements are explained above
-   [x] Product analytics are not applicable to development-only UI

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [ ] There is not a “Do Not Merge” label on this PR
-   [x] Security implications were considered; the panel is development-only and exposes no API key
-   [x] This change does not expose a new public endpoint

— OMP

[LC-1839]: https://welibrary.atlassian.net/browse/LC-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2103]: https://welibrary.atlassian.net/browse/LC-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2104]: https://welibrary.atlassian.net/browse/LC-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2105]: https://welibrary.atlassian.net/browse/LC-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2106]: https://welibrary.atlassian.net/browse/LC-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2107]: https://welibrary.atlassian.net/browse/LC-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ