### PR TITLE
feat: [LC-1851] - Transcript Upload -> CLR 

### DIFF
--- a/apps/learn-card-app/src/components/clr-transcript/ClrTranscriptTitleDisplay.test.tsx
+++ b/apps/learn-card-app/src/components/clr-transcript/ClrTranscriptTitleDisplay.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { VC } from '@learncard/types';
+
+const mocks = vi.hoisted(() => ({
+    normalize: vi.fn(),
+    inferKind: vi.fn(() => 'transcript'),
+}));
+
+vi.mock('../../helpers/clrRenderer.helpers', () => ({
+    normalizeClrTranscriptDisplayModel: mocks.normalize,
+}));
+
+vi.mock('./clrKind.helpers', () => ({
+    inferClrKindWithTitleFallback: mocks.inferKind,
+}));
+
+vi.mock('learn-card-base/svgs/wallet/SkillsIcon', () => ({ SkillsIcon: () => null }));
+vi.mock('learn-card-base/svgs/wallet/StudiesIcon', () => ({ StudiesIcon: () => null }));
+vi.mock('learn-card-base/components/FlatIcon', () => ({
+    FlatIcon: ({ children }: React.PropsWithChildren) => children,
+}));
+vi.mock('../svgs/PaperClip', () => ({ default: () => null }));
+
+import ClrTranscriptTitleDisplay from './ClrTranscriptTitleDisplay';
+
+const credential = {} as VC;
+
+const createTranscriptModel = (
+    gpa?: number,
+    title: string | null = 'Silverbrook College Transcript'
+) => ({
+    header: { title: title ? { value: title } : undefined },
+    summary: {
+        gpa: gpa === undefined ? undefined : { value: gpa },
+        courseCount: 4,
+        explicitCompetencyCount: 0,
+        evidenceCount: 0,
+    },
+});
+
+describe('ClrTranscriptTitleDisplay', () => {
+    beforeEach(() => {
+        mocks.normalize.mockReset();
+        mocks.inferKind.mockClear();
+    });
+
+    it('shows the credential name when the transcript has no GPA', () => {
+        mocks.normalize.mockReturnValue(createTranscriptModel());
+
+        render(
+            <ClrTranscriptTitleDisplay
+                credential={credential}
+                fallbackTitle="Fallback Transcript"
+            />
+        );
+
+        expect(screen.getByText('Silverbrook College Transcript')).toBeInTheDocument();
+        expect(screen.queryByText(/GPA:/)).not.toBeInTheDocument();
+    });
+
+    it('continues to show GPA when one is available', () => {
+        mocks.normalize.mockReturnValue(createTranscriptModel(3.48));
+
+        render(
+            <ClrTranscriptTitleDisplay
+                credential={credential}
+                fallbackTitle="Fallback Transcript"
+            />
+        );
+
+        expect(screen.getByText('GPA: 3.48')).toBeInTheDocument();
+        expect(screen.queryByText('Silverbrook College Transcript')).not.toBeInTheDocument();
+    });
+
+    it('uses the fallback title when the CLR credential has no name or GPA', () => {
+        mocks.normalize.mockReturnValue(createTranscriptModel(undefined, null));
+
+        render(
+            <ClrTranscriptTitleDisplay
+                credential={credential}
+                fallbackTitle="Fallback Transcript"
+            />
+        );
+
+        expect(screen.getByText('Fallback Transcript')).toBeInTheDocument();
+        expect(screen.queryByText(/GPA:/)).not.toBeInTheDocument();
+    });
+});

--- a/apps/learn-card-app/src/components/clr-transcript/ClrTranscriptTitleDisplay.tsx
+++ b/apps/learn-card-app/src/components/clr-transcript/ClrTranscriptTitleDisplay.tsx
@@ -84,11 +84,17 @@ const ClrTranscriptTitleDisplay: React.FC<{ credential: VC; fallbackTitle: strin
     }
 
     if (inferredKind === 'transcript') {
+        const transcriptName = model.header.title?.value || fallbackTitle;
+
         return (
             <div className="flex w-full min-w-0 flex-col items-center justify-start mt-[0px] px-2">
-                {model.summary.gpa && (
+                {model.summary.gpa ? (
                     <p className="mt-2 text-[14px] font-semibold text-grayscale-900 text-center">
                         GPA: {formatClrGpa(model.summary.gpa.value)}
+                    </p>
+                ) : (
+                    <p className="mt-1 w-full max-w-full break-words text-center text-grayscale-900 text-[14px] font-notoSans font-semibold leading-[125%] line-clamp-2">
+                        {transcriptName}
                     </p>
                 )}
                 <div className="mt-2 flex items-center justify-center gap-3 flex-wrap">


### PR DESCRIPTION
# Overview

[USE THIS BACKEND PR](https://github.com/WeLibraryOS/AI-Passport/pull/64)

#### 🎟 Relevant Jira Issues

<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?

#### 🥴 TL; RL:

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

https://www.loom.com/share/6ca033af65ad4b89a6d5984478a5778f

#### 🛠 Important tradeoffs made:

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [X] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

# Testing Transcript Upload

## Prerequisites

1. Check out and run the backend changes from [AI Passport PR #64](https://github.com/WeLibraryOS/AI-Passport/pull/64).
2. Confirm the AI Passport backend is available at:

   ```text
   http://localhost:3001
   ```

3. Configure LearnCard to use the local backend:

   ```json
   {
       "apis": {
           "aiService": "http://localhost:3001"
       }
   }
   ```

4. Download the test transcript attached to [LC-1851](https://welibrary.atlassian.net/browse/LC-1851).

## Test Steps

1. Start the AI Passport backend from PR #64.
2. Start the LearnCard app.
3. Sign in to LearnCard.
4. Open **Build My LearnCard**.
5. Select **Add Transcripts**.
6. Upload the transcript downloaded from LC-1851.
7. Wait for transcript parsing to complete.
8. Confirm that:

   - The request is sent to `http://localhost:3001/credentials/parse-file`.
   - The request returns `200 OK`.
   - A transcript credential is generated.
   - The parsed transcript information and courses are correct.
   - No parsing or extraction error is displayed.

9. Select the generated credential.
10. Save the credential.
11. Confirm that the save completes successfully.
12. Open the saved credential from **Studies**.
13. Confirm that:

   - The credential includes `ClrCredential` in its `type` array.
   - Courses are stored under `credentialSubject.verifiableCredential`.
   - The GPA is displayed when one exists.
   - The credential name is displayed when no GPA exists.

## Expected Result

The transcript is parsed into a single CLR v2 credential, saved successfully, and displayed in the Studies section with the correct transcript information.


<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [X] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [X] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [X] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [X] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [X] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [X] My code follows **style guidelines** (eslint / prettier)
-   [X] I have **manually tested** common end-2-end cases
-   [X] I have **reviewed** my code
-   [X] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [X] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [X] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [X] Code is backwards compatible
-   [X] There is **not** a "Do Not Merge" label on this PR
-   [ ] I have thoughtfully considered the security implications of this change.
-   [X] This change does not expose new public facing endpoints that do not have authentication


[LC-1851]: https://welibrary.atlassian.net/browse/LC-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to AI for the associated Atlassian organization.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhance CLR transcript display to show credential name when GPA is unavailable and add comprehensive test coverage.

Main changes:
- Modified transcript rendering logic to conditionally display either GPA or transcript title based on GPA availability
- Added fallback to transcript name with proper text formatting when GPA is absent
- Created test suite validating GPA presence/absence scenarios and fallback title handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
