### PR TITLE
fix[LC-2114]: Scoutpass BoostCMS contact picker selection not working

### DIFF
--- a/apps/scouts/package.json
+++ b/apps/scouts/package.json
@@ -120,7 +120,7 @@
         "docker-build": "VITE_DOCKER_SOURCE=true LCN_URL=http://localhost:4000/trpc CLOUD_URL=http://localhost:4100/trpc API_URL=http://localhost:5100/trpc NODE_OPTIONS=\"--max-old-space-size=8192\" vite build -d",
         "test-playwright": "playwright test",
         "test-ui": "playwright test --ui",
-        "test": "bun test tests/vite-config.test.ts tests/boost-cms-date-picker.test.ts",
+        "test": "bun test tests/vite-config.test.ts tests/boost-cms-date-picker.test.ts && NODE_OPTIONS=--no-experimental-webstorage vitest run --config vitest.config.ts",
         "test-debug": "PLAYWRIGHT_SLOW_MO=1000 playwright test --headed --debug",
         "test-report": "playwright show-report",
         "write-test": "playwright codegen --ignore-https-errors --load-storage=demoState.json https://localhost:3000",

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
@@ -10,7 +10,7 @@ import {
     BoostAddressBookViewMode,
 } from './BoostAddressBook';
 
-const { contact, emptyPages, emptyScouts } = vi.hoisted(() => ({
+const { contact, emptyPages, emptyScouts, newModal } = vi.hoisted(() => ({
     contact: {
         profileId: 'test-contact',
         displayName: 'Test Contact',
@@ -18,6 +18,7 @@ const { contact, emptyPages, emptyScouts } = vi.hoisted(() => ({
     },
     emptyPages: [] as never[],
     emptyScouts: [] as never[],
+    newModal: vi.fn(),
 }));
 
 vi.mock('@ionic/react', () => {
@@ -48,7 +49,7 @@ vi.mock('learn-card-base', () => ({
     getLogger: () => ({ debug: vi.fn() }),
     useGetBoostParents: () => ({ data: { records: [] } }),
     useGetCurrentLCNUser: () => ({ currentLCNUser: undefined, currentLCNUserLoading: false }),
-    useModal: () => ({ newModal: vi.fn(), closeModal: vi.fn() }),
+    useModal: () => ({ newModal, closeModal: vi.fn() }),
     useResolveBoost: () => ({ data: undefined }),
     useWallet: () => ({
         initWallet: async () => ({
@@ -95,7 +96,10 @@ vi.mock('./BoostAddressBookContactOptions', () => ({ default: () => null }));
 vi.mock('./BoostShareableCode', () => ({ default: () => null }));
 
 describe('BoostAddressBook contact selection', () => {
-    afterEach(cleanup);
+    afterEach(() => {
+        cleanup();
+        newModal.mockClear();
+    });
 
     it('keeps a selected contact live until the selection is saved', async () => {
         let cmsState = { issueTo: [] as (typeof contact)[] };
@@ -173,14 +177,14 @@ describe('BoostAddressBook contact selection', () => {
         expect(await screen.findByRole('button', { name: 'Add contact' })).toBeTruthy();
     });
 
-    it('syncs committed empty selections without discarding a supplied modal selection', async () => {
+    it('does not discard a local selection when outer CMS state changes', async () => {
         const renderPicker = (pickerState: Record<string, unknown>) => (
             <BoostAddressBook
                 state={pickerState as never}
                 setState={vi.fn()}
                 viewMode={BoostAddressBookViewMode.full}
                 mode={BoostAddressBookEditMode.edit}
-                _issueTo={[contact]}
+                _issueTo={[]}
                 _setIssueTo={vi.fn()}
                 search=""
                 setSearch={vi.fn()}
@@ -192,15 +196,43 @@ describe('BoostAddressBook contact selection', () => {
             />
         );
 
-        const { rerender } = render(renderPicker({ issueTo: [contact] }));
-        expect(await screen.findByRole('button', { name: 'Selected contact' })).toBeTruthy();
-
-        rerender(renderPicker({ issueTo: [] }));
+        const { rerender } = render(renderPicker({ issueTo: [] }));
         expect(await screen.findByRole('button', { name: 'Add contact' })).toBeTruthy();
 
-        cleanup();
-        render(renderPicker({}));
+        fireEvent.click(screen.getByRole('button', { name: 'Add contact' }));
+        expect(screen.getByRole('button', { name: 'Selected contact' })).toBeTruthy();
+
+        rerender(renderPicker({ issueTo: [], unrelatedField: 'changed' }));
 
         expect(await screen.findByRole('button', { name: 'Selected contact' })).toBeTruthy();
+    });
+
+    it('syncs a committed empty selection into the list view', () => {
+        const renderList = (issueTo: (typeof contact)[]) => (
+            <BoostAddressBook
+                state={{ issueTo } as never}
+                setState={vi.fn()}
+                viewMode={BoostAddressBookViewMode.list}
+                mode={BoostAddressBookEditMode.edit}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="urn:boost:test"
+                showContactOptions={false}
+            />
+        );
+
+        const { rerender } = render(renderList([contact]));
+        rerender(renderList([]));
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Add contact' })[0]);
+
+        const openedPicker = newModal.mock.calls.at(-1)?.[0] as React.ReactElement<{
+            _issueTo: (typeof contact)[];
+        }>;
+        expect(openedPicker.props._issueTo).toEqual([]);
     });
 });

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    BoostAddressBook,
+    BoostAddressBookEditMode,
+    BoostAddressBookViewMode,
+} from './BoostAddressBook';
+
+const { contact, emptyPages, emptyScouts } = vi.hoisted(() => ({
+    contact: {
+        profileId: 'test-contact',
+        displayName: 'Test Contact',
+        did: 'did:example:test-contact',
+    },
+    emptyPages: [] as never[],
+    emptyScouts: [] as never[],
+}));
+
+vi.mock('@ionic/react', () => {
+    const Container = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+
+    return {
+        IonCol: Container,
+        IonContent: Container,
+        IonFooter: Container,
+        IonGrid: Container,
+        IonHeader: Container,
+        IonInput: ({ placeholder }: { placeholder?: string }) => (
+            <input placeholder={placeholder} />
+        ),
+        IonItem: Container,
+        IonList: Container,
+        IonPage: Container,
+        IonRow: Container,
+        IonSpinner: () => null,
+        IonToolbar: Container,
+    };
+});
+
+vi.mock('learn-card-base', () => ({
+    BoostUserTypeEnum: { someone: 'someone' },
+    ModalTypes: { Cancel: 'cancel', FullScreen: 'full-screen' },
+    UserProfilePicture: () => null,
+    getLogger: () => ({ debug: vi.fn() }),
+    useGetBoostParents: () => ({ data: { records: [] } }),
+    useGetCurrentLCNUser: () => ({ currentLCNUser: undefined, currentLCNUserLoading: false }),
+    useModal: () => ({ newModal: vi.fn(), closeModal: vi.fn() }),
+    useResolveBoost: () => ({ data: undefined }),
+    useWallet: () => ({
+        initWallet: async () => ({
+            invoke: { getConnections: async () => [contact] },
+        }),
+    }),
+}));
+
+vi.mock('learn-card-base/svgs/CaretLeft', () => ({ default: () => null }));
+vi.mock('learn-card-base/svgs/Checkmark', () => ({
+    default: () => <span>Selected contact</span>,
+}));
+vi.mock('learn-card-base/svgs/Plus', () => ({ default: () => <span>Add contact</span> }));
+
+vi.mock('react-lottie-player', () => ({ default: () => null }));
+vi.mock('../../../../../hooks/useTroopMembers', () => ({
+    default: () => ({ scoutRecipients: emptyScouts, isLoading: false }),
+}));
+vi.mock('../../../../../hooks/useNetworkMembers', () => ({
+    default: () => ({ data: { pages: emptyPages }, isLoading: false }),
+}));
+vi.mock('../../../../../stores/boostSearchStore', () => ({
+    default: {
+        set: { boostUri: vi.fn(), contextCredential: vi.fn() },
+        use: {
+            boostUri: () => undefined,
+            contextCredential: () => undefined,
+            role: () => undefined,
+        },
+    },
+}));
+vi.mock('../../../../../stores/troopPageStore', () => ({
+    ScoutsRoleEnum: { leader: 'leader', national: 'national' },
+}));
+vi.mock('../../../../../pages/troop/TroopPageMembersBox', () => ({
+    MemberTabsEnum: { Scouts: 'scouts' },
+}));
+vi.mock('../../../../../i18n/formatters', () => ({
+    formatLocaleCount: (count: number) => `${count} Contacts`,
+    formatLocaleDate: vi.fn(),
+    formatLocaleTime: vi.fn(),
+}));
+vi.mock('./BoostAddressBookContactOptions', () => ({ default: () => null }));
+vi.mock('./BoostShareableCode', () => ({ default: () => null }));
+
+describe('BoostAddressBook contact selection', () => {
+    afterEach(cleanup);
+
+    it('keeps a selected contact live until the selection is saved', async () => {
+        let cmsState = { issueTo: [] as (typeof contact)[] };
+        const setState = vi.fn((update: React.SetStateAction<typeof cmsState>) => {
+            cmsState = typeof update === 'function' ? update(cmsState) : update;
+        });
+
+        render(
+            <BoostAddressBook
+                state={cmsState as never}
+                setState={setState as never}
+                viewMode={BoostAddressBookViewMode.full}
+                mode={BoostAddressBookEditMode.edit}
+                _issueTo={[]}
+                _setIssueTo={vi.fn()}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="urn:boost:test"
+            />
+        );
+
+        expect(await screen.findByText('Test Contact')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add contact' }));
+
+        expect(screen.getByRole('button', { name: 'Selected contact' })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(cmsState.issueTo).toEqual([contact]);
+    });
+});

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
@@ -131,4 +131,76 @@ describe('BoostAddressBook contact selection', () => {
 
         expect(cmsState.issueTo).toEqual([contact]);
     });
+
+    it('does not restore contacts after deselecting all, saving, and reopening', async () => {
+        let cmsState = { issueTo: [contact] };
+        let openerIssueTo = [contact];
+        const setState = vi.fn((update: React.SetStateAction<typeof cmsState>) => {
+            cmsState = typeof update === 'function' ? update(cmsState) : update;
+        });
+        const setOpenerIssueTo = vi.fn((contacts: typeof openerIssueTo) => {
+            openerIssueTo = contacts;
+        });
+
+        const renderPicker = () =>
+            render(
+                <BoostAddressBook
+                    state={cmsState as never}
+                    setState={setState as never}
+                    viewMode={BoostAddressBookViewMode.full}
+                    mode={BoostAddressBookEditMode.edit}
+                    _issueTo={openerIssueTo}
+                    _setIssueTo={setOpenerIssueTo as never}
+                    search=""
+                    setSearch={vi.fn()}
+                    searchResults={[]}
+                    isLoading={false}
+                    recipients={[]}
+                    recipientsLoading={false}
+                    boostUri="urn:boost:test"
+                />
+            );
+
+        renderPicker();
+        expect(await screen.findByRole('button', { name: 'Selected contact' })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Selected contact' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        cleanup();
+        renderPicker();
+
+        expect(await screen.findByRole('button', { name: 'Add contact' })).toBeTruthy();
+    });
+
+    it('syncs committed empty selections without discarding a supplied modal selection', async () => {
+        const renderPicker = (pickerState: Record<string, unknown>) => (
+            <BoostAddressBook
+                state={pickerState as never}
+                setState={vi.fn()}
+                viewMode={BoostAddressBookViewMode.full}
+                mode={BoostAddressBookEditMode.edit}
+                _issueTo={[contact]}
+                _setIssueTo={vi.fn()}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="urn:boost:test"
+            />
+        );
+
+        const { rerender } = render(renderPicker({ issueTo: [contact] }));
+        expect(await screen.findByRole('button', { name: 'Selected contact' })).toBeTruthy();
+
+        rerender(renderPicker({ issueTo: [] }));
+        expect(await screen.findByRole('button', { name: 'Add contact' })).toBeTruthy();
+
+        cleanup();
+        render(renderPicker({}));
+
+        expect(await screen.findByRole('button', { name: 'Selected contact' })).toBeTruthy();
+    });
 });

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
@@ -158,10 +158,12 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     // --- End Limit Search Scope ---
 
     useEffect(() => {
+        if (viewMode !== BoostAddressBookViewMode.list) return;
+
         const stateIssueTo = (state as any)?.[collectionPropName] as BoostCMSIssueTo[] | undefined;
 
         if (stateIssueTo) setLocalIssueTo(stateIssueTo);
-    }, [state, collectionPropName]);
+    }, [state, collectionPropName, viewMode]);
 
     const { newModal: newContactOptionsModal, closeModal: closeContactOptionsModal } = useModal({
         mobile: ModalTypes.Cancel,

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
@@ -158,12 +158,10 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     // --- End Limit Search Scope ---
 
     useEffect(() => {
-        if ((state as any)?.[collectionPropName]?.length > 0) {
-            setLocalIssueTo(((state as any)?.[collectionPropName] as BoostCMSIssueTo[]) || []);
-        } else {
-            return;
-        }
-    }, [state]);
+        const stateIssueTo = (state as any)?.[collectionPropName] as BoostCMSIssueTo[] | undefined;
+
+        if (stateIssueTo) setLocalIssueTo(stateIssueTo);
+    }, [state, collectionPropName]);
 
     const { newModal: newContactOptionsModal, closeModal: closeContactOptionsModal } = useModal({
         mobile: ModalTypes.Cancel,
@@ -256,6 +254,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                 [collectionPropName]: [...localIssueTo],
             };
         });
+        _setIssueTo?.([...localIssueTo]);
         handleCloseModal?.(true);
         setSearch?.('');
     };

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
@@ -118,7 +118,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     const [loading, setLoading] = useState<boolean>(false);
     const [issueMode, setIssueMode] = useState<BoostUserTypeEnum>(BoostUserTypeEnum.someone);
     const [localIssueTo, setLocalIssueTo] = useState<BoostCMSIssueTo[]>(
-        ((state as any)?.[collectionPropName] as BoostCMSIssueTo[]) || []
+        _issueTo ?? ((state as any)?.[collectionPropName] as BoostCMSIssueTo[]) ?? []
     );
 
     // --- Limit Search Scope for Troop Leaders / Admins ---
@@ -253,7 +253,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
         setState(prevState => {
             return {
                 ...prevState,
-                [collectionPropName]: [...(_issueTo || [])],
+                [collectionPropName]: [...localIssueTo],
             };
         });
         handleCloseModal?.(true);
@@ -384,8 +384,8 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                             setState={setState}
                             contacts={connectionsToShow}
                             mode={mode}
-                            _issueTo={_issueTo || []}
-                            _setIssueTo={_setIssueTo as any}
+                            _issueTo={localIssueTo}
+                            _setIssueTo={setLocalIssueTo}
                             collectionPropName={collectionPropName}
                         />
                     )}
@@ -410,8 +410,8 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                             setState={setState}
                             contacts={(searchResults || []) as any}
                             mode={mode}
-                            _issueTo={_issueTo || []}
-                            _setIssueTo={_setIssueTo as any}
+                            _issueTo={localIssueTo}
+                            _setIssueTo={setLocalIssueTo}
                             collectionPropName={collectionPropName}
                         />
                     )}


### PR DESCRIPTION
## Overview

### Context and goal

https://welibrary.atlassian.net/browse/LC-2114

In ScoutPass BoostCMS, opening **Send To**, choosing the fullscreen contact picker, and clicking a contact's **+** button produced no visible change. Saving the picker also omitted that recipient, and no console error was emitted.

Screen recording of broken state on production:
https://github.com/user-attachments/assets/b74d9661-3506-4693-bcc7-77211ccfc80c

The shared modal stack stores an already-created React element. The fullscreen picker was rendering the parent `_issueTo` snapshot while clicks updated state owned by the hidden parent instance, so the mounted picker never received the new selection.

### Regression history

This behavior regressed on **January 14, 2026**, when [PR #918](https://github.com/learningeconomy/LearnCard/pull/918) replaced ScoutPass `useIonModal` usage with the shared `useModal` stack. Ionic's former overlay refreshed the mounted component when `componentProps` changed; the shared stack stores the React element created at modal-open time, leaving the picker with stale selection and search props.

This predates and was **not introduced by** the later LC-1962 modal safe-area work in [PR #1461](https://github.com/learningeconomy/LearnCard/pull/1461). That PR continued modal standardization, but the affected BoostCMS picker had already been migrated in PR #918.

### What changed

- Initialize the fullscreen picker's local selection from the current `_issueTo` value, falling back to CMS state.
- Route contact toggles through the mounted picker's local selection state.
- Save that live local selection back to BoostCMS and synchronize the opener's local copy, including an empty selection.
- Limit committed-state synchronization to the long-lived list view, so the fullscreen picker owns in-progress edits while still accepting explicit empty committed collections.
- Add component regression coverage for:
  - add → selected indicator → save;
  - deselect all → save → reopen;
  - fullscreen selection preservation during unrelated CMS state changes;
  - list-view synchronization when the committed selection becomes empty.
- Wire the full ScoutPass Vitest suite into the package's normal test command.

### Out of scope / follow-up

The sibling frozen-prop network-search regression is handled separately in draft PR #1488.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance

## QA steps

1. Run ScoutPass locally against staging services.
2. Open a BoostCMS credential and choose **Send To**.
3. Open the fullscreen contact picker.
4. Click the **+** button for a contact.
5. Confirm the row immediately shows as selected.
6. Click **Save** and confirm the recipient appears in the BoostCMS send list.
7. Reopen the picker, deselect every recipient, save, and reopen again.
8. Confirm removed contacts remain unselected.

## Verification

- `bun run test` — 3 Bun tests plus 35 Vitest files / 152 tests passed.
- `bun run build` — production build completed.
- `git diff --check`, Prettier, and the pre-commit hook — passed.
- Independent follow-up review — no remaining findings.
- Manual localhost reproduction and after-fix confirmation against staging services.

## Checklist

- [x] I reviewed the scoped diff.
- [x] I added regression coverage for the reported behavior and review follow-up.
- [x] Existing ScoutPass tests pass through the normal package test target.
- [x] The ScoutPass production build passes.
- [x] No documentation update is required for restoring this existing behavior.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix contact picker state management to properly persist user selections and sync between list and full view modes in BoostCMS.

Main changes:
- Initialize local state with `_issueTo` prop as fallback, sync state changes only when not in list mode to prevent unwanted resets
- Update `handleSaveContacts` to persist selections to both `localIssueTo` state and parent `_setIssueTo` callback
- Pass `localIssueTo` and `setLocalIssueTo` to contact list components instead of stale prop values, add comprehensive test suite

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
