### PR TITLE
fix[LC-2114]: Restore ScoutPass BoostCMS network search

### DIFF
--- a/.changeset/calm-scouts-search.md
+++ b/.changeset/calm-scouts-search.md
@@ -1,0 +1,6 @@
+---
+'scoutpass-app': patch
+'learn-card-base': patch
+---
+
+Restore live ScoutPass network search in the BoostCMS recipient picker.

--- a/apps/scouts/package.json
+++ b/apps/scouts/package.json
@@ -120,7 +120,7 @@
         "docker-build": "VITE_DOCKER_SOURCE=true LCN_URL=http://localhost:4000/trpc CLOUD_URL=http://localhost:4100/trpc API_URL=http://localhost:5100/trpc NODE_OPTIONS=\"--max-old-space-size=8192\" vite build -d",
         "test-playwright": "playwright test",
         "test-ui": "playwright test --ui",
-        "test": "bun test tests/vite-config.test.ts tests/boost-cms-date-picker.test.ts",
+        "test": "bun test tests/vite-config.test.ts tests/boost-cms-date-picker.test.ts && NODE_OPTIONS=--no-experimental-webstorage vitest run --config vitest.config.ts",
         "test-debug": "PLAYWRIGHT_SLOW_MO=1000 playwright test --headed --debug",
         "test-report": "playwright show-report",
         "write-test": "playwright codegen --ignore-https-errors --load-storage=demoState.json https://localhost:3000",

--- a/apps/scouts/src/components/boost/boost-search/BoostSearch.test.tsx
+++ b/apps/scouts/src/components/boost/boost-search/BoostSearch.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import BoostSearch from './BoostSearch';
+
+const { roleState, searchProfiles, emptyScoutRecipients, emptyNetworkPages } = vi.hoisted(() => ({
+    roleState: { current: undefined as string | undefined },
+    searchProfiles: vi.fn(() => ({ data: [], isLoading: false })),
+    emptyScoutRecipients: [] as never[],
+    emptyNetworkPages: [] as never[],
+}));
+
+vi.mock('@ionic/react', () => {
+    const Container = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+
+    return {
+        IonCol: Container,
+        IonContent: Container,
+        IonGrid: Container,
+        IonHeader: Container,
+        IonInput: ({ placeholder, onIonInput }: any) => (
+            <input
+                aria-label={placeholder}
+                onChange={event => onIonInput?.({ detail: { value: event.currentTarget.value } })}
+            />
+        ),
+        IonRow: Container,
+        IonToolbar: Container,
+    };
+});
+
+vi.mock('learn-card-base', () => ({
+    getLogger: () => ({ debug: vi.fn() }),
+    useGetSearchProfiles: searchProfiles,
+    useWallet: () => ({
+        initWallet: () => new Promise(() => {}),
+    }),
+}));
+vi.mock('learn-card-base/components/loaders/LoadingSpinner', () => ({
+    LoadingSpinner: () => null,
+}));
+vi.mock('learn-card-base/svgs/CaretLeft', () => ({ default: () => null }));
+vi.mock('react-lottie-player', () => ({ default: () => null }));
+vi.mock('../../../hooks/useTroopMembers', () => ({
+    default: () => ({ scoutRecipients: emptyScoutRecipients, isLoading: false }),
+}));
+vi.mock('../../../hooks/useNetworkMembers', () => ({
+    default: () => ({ data: { pages: emptyNetworkPages }, isLoading: false }),
+}));
+vi.mock('../../../stores/boostSearchStore', () => ({
+    default: {
+        use: {
+            contextCredential: () => undefined,
+            boostUri: () => undefined,
+            role: () => roleState.current,
+        },
+    },
+}));
+vi.mock('../../../stores/troopPageStore', () => ({
+    ScoutsRoleEnum: { leader: 'leader', national: 'national' },
+}));
+vi.mock('../../../pages/troop/TroopPageMembersBox', () => ({
+    MemberTabsEnum: { Scouts: 'scouts' },
+}));
+vi.mock('../../../i18n/formatters', () => ({
+    formatLocaleCount: (count: number) => `${count} contacts`,
+}));
+vi.mock('../../../paraglide/messages.js', () => ({
+    'boost.contactOne': () => 'contact',
+    'boost.contactOther': () => 'contacts',
+    'boost.networkMemberLabelOne': () => 'member',
+    'boost.networkMemberLabelOther': () => 'members',
+    'boost.noConnectionsYet': () => 'No connections',
+    'boost.noNetworkMembers': () => 'No network members',
+    'boost.noSearchResults': () => 'No results',
+    'boost.noTroopMembers': () => 'No troop members',
+    'boost.scoutMemberOne': () => 'scout',
+    'boost.scoutMemberOther': () => 'scouts',
+    'boost.searchNetwork': () => 'Search network',
+    'boost.searchScoutPass': () => 'Search ScoutPass',
+    'boost.searchTroop': () => 'Search troop',
+    'boost.troop': () => 'Troop',
+    'common.save': () => 'Save',
+}));
+vi.mock('../boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook', () => ({
+    BoostAddressBookEditMode: { edit: 'edit' },
+    BoostAddressBookViewMode: { full: 'full' },
+}));
+vi.mock('../boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBookContactList', () => ({
+    default: () => null,
+}));
+
+const renderSearch = (ignoreBoostSearchRestriction = false) =>
+    render(
+        <BoostSearch
+            handleCloseModal={vi.fn()}
+            boostCredential={{} as never}
+            boostUri="boost:example"
+            profileId="issuer"
+            state={{ issueTo: [] }}
+            setState={vi.fn()}
+            history={{}}
+            ignoreBoostSearchRestriction={ignoreBoostSearchRestriction}
+        />
+    );
+
+describe('BoostSearch global profile query scope', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        roleState.current = undefined;
+    });
+
+    it('does not enable global search for a scoped troop leader', () => {
+        roleState.current = 'leader';
+        renderSearch();
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'scout' } });
+
+        expect(searchProfiles).toHaveBeenLastCalledWith('scout', { enabled: false });
+    });
+
+    it('allows global search when restrictions are explicitly ignored', () => {
+        roleState.current = 'leader';
+        renderSearch(true);
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'scout' } });
+
+        expect(searchProfiles).toHaveBeenLastCalledWith('scout', { enabled: true });
+    });
+});

--- a/apps/scouts/src/components/boost/boost-search/BoostSearch.tsx
+++ b/apps/scouts/src/components/boost/boost-search/BoostSearch.tsx
@@ -90,7 +90,11 @@ const BoostSearch: React.FC<BoostSearchProps> = ({
     const rawNetworkMembers = networkMembersData?.pages?.flatMap(page => page.records) ?? [];
     const networkMembers = rawNetworkMembers.map(networkMember => networkMember.to);
 
-    const { data: searchResults, isLoading: searchLoading } = useGetSearchProfiles(search ?? '');
+    const { data: searchResults, isLoading: searchLoading } = useGetSearchProfiles(search ?? '', {
+        enabled:
+            search.length > 0 &&
+            (ignoreBoostSearchRestriction || (!isTroopLeader && !isNetworkAdmin)),
+    });
     const loadConnections = async () => {
         if (!ignoreBoostSearchRestriction) {
             if (isTroopLeader) {

--- a/apps/scouts/src/components/boost/boostCMS/BoostCMS.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/BoostCMS.tsx
@@ -140,7 +140,9 @@ const BoostCMS: React.FC<{
     const [search, setSearch] = useState<string>('');
     const { data: boostAppearanceBadgeList, isLoading: stylePackLoading } =
         useScoutPassStylesPackRegistry();
-    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '');
+    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '', {
+        enabled: false,
+    });
     const { mutate: addCredentialToWallet } = useAddCredentialToWallet();
     const { newModal } = useModal({
         desktop: ModalTypes.Cancel,

--- a/apps/scouts/src/components/boost/boostCMS/UpdateBoostCMS.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/UpdateBoostCMS.tsx
@@ -139,7 +139,9 @@ const UpdateBoostCMS: React.FC<UpdateBoostCMSProps> = ({
     const [search, setSearch] = useState<string>('');
     const { data: boostAppearanceBadgeList, isLoading: stylePackLoading } =
         useScoutPassStylesPackRegistry();
-    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '');
+    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '', {
+        enabled: false,
+    });
 
     const { data: recipients, isLoading: recipientsLoading } = useGetBoostRecipients(_boostUri);
     const { mutate: addCredentialToWallet } = useAddCredentialToWallet();

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.search.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.search.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    BoostAddressBook,
+    BoostAddressBookEditMode,
+    BoostAddressBookViewMode,
+} from './BoostAddressBook';
+
+const { networkProfile } = vi.hoisted(() => ({
+    networkProfile: {
+        profileId: 'network-user',
+        displayName: 'Network Result',
+        did: 'did:example:network-user',
+    },
+}));
+
+vi.mock('@ionic/react', () => {
+    const Container = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+
+    return {
+        IonCol: Container,
+        IonContent: Container,
+        IonFooter: Container,
+        IonGrid: Container,
+        IonHeader: Container,
+        IonInput: ({ placeholder, onIonInput }: any) => (
+            <input
+                aria-label={placeholder}
+                onChange={event => onIonInput?.({ detail: { value: event.currentTarget.value } })}
+            />
+        ),
+        IonItem: Container,
+        IonList: Container,
+        IonPage: Container,
+        IonRow: Container,
+        IonSpinner: () => null,
+        IonToolbar: Container,
+    };
+});
+
+vi.mock('learn-card-base', () => ({
+    BoostUserTypeEnum: { someone: 'someone' },
+    ModalTypes: { Cancel: 'cancel', FullScreen: 'full-screen' },
+    UserProfilePicture: () => null,
+    getLogger: () => ({ debug: vi.fn() }),
+    useGetBoostParents: () => ({ data: { records: [] } }),
+    useGetCurrentLCNUser: () => ({
+        currentLCNUser: undefined,
+        currentLCNUserLoading: false,
+    }),
+    useGetSearchProfiles: (query: string) => ({
+        data: query === networkProfile.profileId ? [networkProfile] : [],
+        isLoading: false,
+    }),
+    useModal: () => ({ newModal: vi.fn(), closeModal: vi.fn() }),
+    useResolveBoost: () => ({ data: undefined }),
+    useWallet: () => ({ initWallet: () => new Promise(() => {}) }),
+}));
+
+vi.mock('learn-card-base/svgs/CaretLeft', () => ({ default: () => null }));
+vi.mock('learn-card-base/svgs/Plus', () => ({ default: () => null }));
+vi.mock('react-lottie-player', () => ({ default: () => null }));
+
+vi.mock('../../../../../hooks/useTroopMembers', () => ({
+    default: () => ({ scoutRecipients: [], isLoading: false }),
+}));
+vi.mock('../../../../../hooks/useNetworkMembers', () => ({
+    default: () => ({ data: { pages: [] }, isLoading: false }),
+}));
+vi.mock('../../../../../stores/boostSearchStore', () => ({
+    default: {
+        use: {
+            contextCredential: () => undefined,
+            boostUri: () => undefined,
+            role: () => undefined,
+        },
+        set: {
+            boostUri: vi.fn(),
+            contextCredential: vi.fn(),
+        },
+    },
+}));
+vi.mock('../../../../../stores/troopPageStore', () => ({
+    ScoutsRoleEnum: { leader: 'leader', national: 'national' },
+}));
+vi.mock('../../../../../pages/troop/TroopPageMembersBox', () => ({
+    MemberTabsEnum: { Scouts: 'scouts' },
+}));
+vi.mock('./BoostAddressBookContactOptions', () => ({ default: () => null }));
+vi.mock('./BoostShareableCode', () => ({ default: () => null }));
+vi.mock('./BoostAddressBookContactList', () => ({
+    default: ({ contacts }: { contacts: Array<{ profileId: string; displayName?: string }> }) => (
+        <div>
+            {contacts.map(contact => (
+                <p key={contact.profileId}>{contact.displayName ?? contact.profileId}</p>
+            ))}
+        </div>
+    ),
+}));
+
+describe('BoostAddressBook network search', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows Scout network results when the user has no contacts', async () => {
+        render(
+            <BoostAddressBook
+                state={{ issueTo: [] } as any}
+                setState={vi.fn()}
+                viewMode={BoostAddressBookViewMode.full}
+                mode={BoostAddressBookEditMode.edit}
+                _issueTo={[]}
+                _setIssueTo={vi.fn()}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="boost:example"
+            />
+        );
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: networkProfile.profileId },
+        });
+
+        expect(await screen.findByText(networkProfile.displayName)).toBeTruthy();
+    });
+});

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.search.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.search.test.tsx
@@ -10,13 +10,37 @@ import {
     BoostAddressBookViewMode,
 } from './BoostAddressBook';
 
-const { networkProfile } = vi.hoisted(() => ({
-    networkProfile: {
-        profileId: 'network-user',
-        displayName: 'Network Result',
-        did: 'did:example:network-user',
-    },
-}));
+const { networkProfile, scoutProfile, roleState, scoutRecipients, searchProfiles } = vi.hoisted(
+    () => ({
+        networkProfile: {
+            profileId: 'network-user',
+            displayName: 'Network Result',
+            did: 'did:example:network-user',
+        },
+        scoutProfile: {
+            profileId: 'troop-user',
+            displayName: 'Troop Member',
+            did: 'did:example:troop-user',
+        },
+        roleState: { current: undefined as string | undefined },
+        scoutRecipients: {
+            current: [] as Array<{ to: { profileId: string; displayName: string; did: string } }>,
+        },
+        searchProfiles: vi.fn((query: string, options: { enabled?: boolean } = {}) => ({
+            data:
+                (options.enabled ?? true) && query === 'network-user'
+                    ? [
+                          {
+                              profileId: 'network-user',
+                              displayName: 'Network Result',
+                              did: 'did:example:network-user',
+                          },
+                      ]
+                    : [],
+            isLoading: false,
+        })),
+    })
+);
 
 vi.mock('@ionic/react', () => {
     const Container = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
@@ -52,10 +76,7 @@ vi.mock('learn-card-base', () => ({
         currentLCNUser: undefined,
         currentLCNUserLoading: false,
     }),
-    useGetSearchProfiles: (query: string) => ({
-        data: query === networkProfile.profileId ? [networkProfile] : [],
-        isLoading: false,
-    }),
+    useGetSearchProfiles: searchProfiles,
     useModal: () => ({ newModal: vi.fn(), closeModal: vi.fn() }),
     useResolveBoost: () => ({ data: undefined }),
     useWallet: () => ({ initWallet: () => new Promise(() => {}) }),
@@ -66,7 +87,7 @@ vi.mock('learn-card-base/svgs/Plus', () => ({ default: () => null }));
 vi.mock('react-lottie-player', () => ({ default: () => null }));
 
 vi.mock('../../../../../hooks/useTroopMembers', () => ({
-    default: () => ({ scoutRecipients: [], isLoading: false }),
+    default: () => ({ scoutRecipients: scoutRecipients.current, isLoading: false }),
 }));
 vi.mock('../../../../../hooks/useNetworkMembers', () => ({
     default: () => ({ data: { pages: [] }, isLoading: false }),
@@ -76,7 +97,7 @@ vi.mock('../../../../../stores/boostSearchStore', () => ({
         use: {
             contextCredential: () => undefined,
             boostUri: () => undefined,
-            role: () => undefined,
+            role: () => roleState.current,
         },
         set: {
             boostUri: vi.fn(),
@@ -105,6 +126,8 @@ vi.mock('./BoostAddressBookContactList', () => ({
 describe('BoostAddressBook network search', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        roleState.current = undefined;
+        scoutRecipients.current = [];
     });
 
     it('shows Scout network results when the user has no contacts', async () => {
@@ -131,5 +154,60 @@ describe('BoostAddressBook network search', () => {
         });
 
         expect(await screen.findByText(networkProfile.displayName)).toBeTruthy();
+    });
+
+    it('does not enable global profile search before the user types', () => {
+        render(
+            <BoostAddressBook
+                state={{ issueTo: [] } as any}
+                setState={vi.fn()}
+                viewMode={BoostAddressBookViewMode.full}
+                mode={BoostAddressBookEditMode.edit}
+                _issueTo={[]}
+                _setIssueTo={vi.fn()}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="boost:example"
+            />
+        );
+
+        expect(searchProfiles).toHaveBeenCalledWith('', { enabled: false });
+    });
+
+    it('keeps troop-leader search scoped to troop members', async () => {
+        roleState.current = 'leader';
+        scoutRecipients.current = [{ to: scoutProfile }];
+
+        render(
+            <BoostAddressBook
+                state={{ issueTo: [] } as any}
+                setState={vi.fn()}
+                viewMode={BoostAddressBookViewMode.full}
+                mode={BoostAddressBookEditMode.edit}
+                _issueTo={[]}
+                _setIssueTo={vi.fn()}
+                search=""
+                setSearch={vi.fn()}
+                searchResults={[networkProfile]}
+                isLoading={false}
+                recipients={[]}
+                recipientsLoading={false}
+                boostUri="boost:example"
+            />
+        );
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: scoutProfile.profileId },
+        });
+
+        expect(await screen.findByText(scoutProfile.displayName)).toBeTruthy();
+        expect(screen.queryByText(networkProfile.displayName)).toBeNull();
+        expect(searchProfiles).toHaveBeenLastCalledWith(scoutProfile.profileId, {
+            enabled: false,
+        });
     });
 });

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.test.tsx
@@ -49,6 +49,7 @@ vi.mock('learn-card-base', () => ({
     getLogger: () => ({ debug: vi.fn() }),
     useGetBoostParents: () => ({ data: { records: [] } }),
     useGetCurrentLCNUser: () => ({ currentLCNUser: undefined, currentLCNUserLoading: false }),
+    useGetSearchProfiles: () => ({ data: [], isLoading: false }),
     useModal: () => ({ newModal, closeModal: vi.fn() }),
     useResolveBoost: () => ({ data: undefined }),
     useWallet: () => ({

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
@@ -130,7 +130,9 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     const [modalSearch, setModalSearch] = useState(searchProp ?? '');
     const { data: modalSearchResults, isLoading: modalSearchLoading } = useGetSearchProfiles(
         modalSearch,
-        isFullView && !isTroopLeader && !isNetworkAdmin
+        {
+            enabled: isFullView && !isTroopLeader && !isNetworkAdmin && modalSearch.length > 0,
+        }
     );
 
     const search = isFullView ? modalSearch : searchProp;
@@ -200,7 +202,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                 }
                 search={search}
                 setSearch={setSearch}
-                searchResults={searchResultsProp}
+                searchResults={searchResults}
                 isLoading={isLoading}
                 collectionPropName={collectionPropName}
             />
@@ -224,7 +226,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                 _setIssueTo={setLocalIssueTo as any}
                 search={search || ''}
                 setSearch={setSearch as any}
-                searchResults={searchResultsProp || []}
+                searchResults={searchResults || []}
                 isLoading={!!isLoading}
                 collectionPropName={collectionPropName}
                 boostUri={boostUri}
@@ -276,7 +278,11 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     }, [isTroopLeader, rawScouts]);
 
     const handleSearch = (profileId: string) => {
-        if (isFullView) setModalSearch(profileId);
+        if (isFullView) {
+            setModalSearch(profileId);
+            return;
+        }
+
         setSearch?.(profileId);
     };
 

--- a/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
+++ b/apps/scouts/src/components/boost/boostCMS/boostCMSForms/boostCMSIssueTo/BoostAddressBook.tsx
@@ -32,6 +32,7 @@ import {
     BoostUserTypeEnum,
     useModal,
     ModalTypes,
+    useGetSearchProfiles,
 } from 'learn-card-base';
 
 import Plus from 'learn-card-base/svgs/Plus';
@@ -97,10 +98,10 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     _issueTo,
     _setIssueTo,
 
-    search,
+    search: searchProp,
     setSearch,
-    searchResults,
-    isLoading,
+    searchResults: searchResultsProp,
+    isLoading: isLoadingProp,
 
     recipients,
     recipientsLoading,
@@ -113,6 +114,12 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     hideBoostShareableCode = false,
 }) => {
     const { initWallet } = useWallet();
+    const contextCredential = boostSearchStore.use.contextCredential();
+    const searchBoostUri = boostSearchStore.use.boostUri();
+    const role = boostSearchStore.use.role();
+    const isTroopLeader = role === ScoutsRoleEnum.leader;
+    const isNetworkAdmin = role === ScoutsRoleEnum.national;
+    const isFullView = viewMode === BoostAddressBookViewMode.full;
 
     const [connections, setConnections] = useState<BoostCMSIssueTo[]>([]);
     const [loading, setLoading] = useState<boolean>(false);
@@ -120,6 +127,15 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     const [localIssueTo, setLocalIssueTo] = useState<BoostCMSIssueTo[]>(
         ((state as any)?.[collectionPropName] as BoostCMSIssueTo[]) || []
     );
+    const [modalSearch, setModalSearch] = useState(searchProp ?? '');
+    const { data: modalSearchResults, isLoading: modalSearchLoading } = useGetSearchProfiles(
+        modalSearch,
+        isFullView && !isTroopLeader && !isNetworkAdmin
+    );
+
+    const search = isFullView ? modalSearch : searchProp;
+    const searchResults = isFullView ? modalSearchResults : searchResultsProp;
+    const isLoading = isFullView ? modalSearchLoading : isLoadingProp;
 
     // --- Limit Search Scope for Troop Leaders / Admins ---
     //   (should really refactor since so much of this code is from BoostSearch)
@@ -127,12 +143,6 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
     const parentBoost = parentBoosts?.records?.[0]; // just default to the first one, guess we're just assuming there's only one
     const parentBoostUri = parentBoost?.uri;
     const { data: resolvedCredential } = useResolveBoost(parentBoostUri);
-
-    const contextCredential = boostSearchStore.use.contextCredential();
-    const searchBoostUri = boostSearchStore.use.boostUri();
-    const role = boostSearchStore.use.role();
-    const isTroopLeader = role === ScoutsRoleEnum.leader;
-    const isNetworkAdmin = role === ScoutsRoleEnum.national;
 
     const { scoutRecipients: rawScouts, isLoading: scoutsLoading } = useTroopMembers(
         contextCredential as any,
@@ -190,7 +200,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                 }
                 search={search}
                 setSearch={setSearch}
-                searchResults={searchResults}
+                searchResults={searchResultsProp}
                 isLoading={isLoading}
                 collectionPropName={collectionPropName}
             />
@@ -214,7 +224,7 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
                 _setIssueTo={setLocalIssueTo as any}
                 search={search || ''}
                 setSearch={setSearch as any}
-                searchResults={searchResults || []}
+                searchResults={searchResultsProp || []}
                 isLoading={!!isLoading}
                 collectionPropName={collectionPropName}
                 boostUri={boostUri}
@@ -264,7 +274,10 @@ export const BoostAddressBook: React.FC<BoostAddressBookProps> = ({
         loadConnections();
     }, [isTroopLeader, rawScouts]);
 
-    const handleSearch = async (profileId: string) => setSearch?.(profileId);
+    const handleSearch = (profileId: string) => {
+        if (isFullView) setModalSearch(profileId);
+        setSearch?.(profileId);
+    };
 
     let contactCount =
         (search?.length ?? 0) > 0 && (searchResults?.length ?? 0) > 0

--- a/apps/scouts/src/components/boost/boostHelpers.test.ts
+++ b/apps/scouts/src/components/boost/boostHelpers.test.ts
@@ -1,9 +1,15 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AchievementTypes } from 'learn-card-base/components/IssueVC/constants';
 import { BoostCategoryOptionsEnum } from 'learn-card-base/types/boostAndCredentialMetadata';
 
 import { setLocale } from '../../paraglide/runtime.js';
+import { CATEGORY_TO_SUBCATEGORY_LIST } from './boost-options/boostOptions';
+import {
+    getDefaultBoostCriteria,
+    getDefaultBoostDescription,
+    getDefaultBoostTitle,
+} from './boostHelpers';
 import { getBoostPresetLocalization, refreshLocalizedPresetFields } from './localizedPresetFields';
 
 vi.mock('../../paraglide/messages.js', async importOriginal => {
@@ -15,11 +21,6 @@ vi.mock('../../paraglide/messages.js', async importOriginal => {
             'Unregistered preset copy',
     };
 });
-
-let getDefaultBoostCriteria: typeof import('./boostHelpers').getDefaultBoostCriteria;
-let getDefaultBoostDescription: typeof import('./boostHelpers').getDefaultBoostDescription;
-let getDefaultBoostTitle: typeof import('./boostHelpers').getDefaultBoostTitle;
-let categoryToSubcategoryList: typeof import('./boost-options/boostOptions').CATEGORY_TO_SUBCATEGORY_LIST;
 
 const englishDefaults = {
     name: 'Archery',
@@ -33,43 +34,15 @@ const spanishDefaults = {
     narrative: 'Completa los requisitos de tiro con arco.',
 };
 
-beforeAll(async () => {
-    const storage = {
-        clear: vi.fn(),
-        getItem: vi.fn(() => null),
-        key: vi.fn(() => null),
-        length: 0,
-        removeItem: vi.fn(),
-        setItem: vi.fn(),
-    };
-
-    vi.stubGlobal('localStorage', storage);
-    vi.stubGlobal('sessionStorage', storage);
-    vi.stubGlobal('window', {
-        localStorage: storage,
-        sessionStorage: storage,
-        location: { hostname: 'localhost' },
-    });
-
-    ({ getDefaultBoostCriteria, getDefaultBoostDescription, getDefaultBoostTitle } = await import(
-        './boostHelpers'
-    ));
-    ({ CATEGORY_TO_SUBCATEGORY_LIST: categoryToSubcategoryList } = await import(
-        './boost-options/boostOptions'
-    ));
-});
-
 afterEach(() => {
     setLocale('en', { reload: false });
 });
 
-afterAll(() => {
-    vi.unstubAllGlobals();
-});
-
 describe('localized Boost preset defaults', () => {
     it('uses bundled images for every Merit Badge preset', () => {
-        const externalImagePresets = categoryToSubcategoryList[BoostCategoryOptionsEnum.meritBadge]
+        const externalImagePresets = CATEGORY_TO_SUBCATEGORY_LIST[
+            BoostCategoryOptionsEnum.meritBadge
+        ]
             .filter(preset => /^https?:\/\//.test(preset.image ?? ''))
             .map(preset => preset.type);
 
@@ -121,7 +94,7 @@ describe('localized Boost preset defaults', () => {
             BoostCategoryOptionsEnum.socialBadge,
             BoostCategoryOptionsEnum.meritBadge,
         ].flatMap(category =>
-            categoryToSubcategoryList[category].map(preset => ({
+            CATEGORY_TO_SUBCATEGORY_LIST[category].map(preset => ({
                 category,
                 type: preset.type,
                 title: preset.presetTitle,

--- a/apps/scouts/src/components/boost/boostHelpers.ts
+++ b/apps/scouts/src/components/boost/boostHelpers.ts
@@ -4,20 +4,20 @@ import type { SupportedLanguage } from '../../i18n';
 import { LCNBoostStatusEnum, VC, VerificationItem } from '@learncard/types';
 import { BespokeLearnCard } from 'learn-card-base/types/learn-card';
 import { RouteComponentProps } from 'react-router-dom';
+import type { BoostCMSState } from 'learn-card-base/components/boost/boost';
+import { defaultCategoryThumbImages } from 'learn-card-base/components/boost/boostOptions/boostOptions';
 import {
-    BoostCategoryOptionsEnum,
-    LCAStylesPackRegistryEntry,
-    defaultCategoryThumbImages,
     getAchievementTypeFromCustomType,
     isCustomBoostType,
     replaceUnderscoresWithWhiteSpace,
-    BoostCMSState,
-} from 'learn-card-base';
+} from 'learn-card-base/helpers/boostCustomTypeHelpers';
+import { getLogger } from 'learn-card-base/logging/logger';
+import { BoostCategoryOptionsEnum } from 'learn-card-base/types/boostAndCredentialMetadata';
+import type { LCAStylesPackRegistryEntry } from 'learn-card-base/types/sync-my-school';
 import { defaultIDCardImage, defaultIssuerThumbnail } from './boost-options/boostOptions';
 import { alignmentsFromSkills, extractSkillIdsFromAlignments } from './alignmentHelpers';
 import { BoostCMSAlignment } from './boost';
 import { CATEGORY_TO_SUBCATEGORY_LIST, boostCategoryOptions } from './boost-options/boostOptions';
-import { getLogger } from 'learn-card-base';
 import * as m from '../../paraglide/messages.js';
 const log = getLogger('boost-helpers');
 

--- a/apps/scouts/src/components/troopsCMS/TroopsIDTypeSelector/TroopIDTypeButton.tsx
+++ b/apps/scouts/src/components/troopsCMS/TroopsIDTypeSelector/TroopIDTypeButton.tsx
@@ -44,7 +44,9 @@ export const TroopIDTypeButton: React.FC<TroopIDTypeButtonProps> = ({
     viewModeSubtype,
 }) => {
     const [search, setSearch] = useState<string>('');
-    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '');
+    const { data: searchResults, isLoading: loading } = useGetSearchProfiles(search ?? '', {
+        enabled: false,
+    });
 
     const scoutsList = members ?? [];
     const leadersList = admins ?? [];

--- a/packages/learn-card-base/src/react-query/queries/queries.ts
+++ b/packages/learn-card-base/src/react-query/queries/queries.ts
@@ -742,13 +742,15 @@ export const useGenerateInvite = () => {
 
 /**
  * Query: Search profiles by profileId.
+ *
+ * @param options.enabled Whether the profile search query should run.
  */
-export const useGetSearchProfiles = (profileId: string, enabled = true) => {
+export const useGetSearchProfiles = (profileId: string, options: { enabled?: boolean } = {}) => {
     const { initWallet } = useWallet();
     const switchedDid = switchedProfileStore.use.switchedDid();
     return useQuery<(LCNVisibleProfile & { connectionStatus?: LCNProfileConnectionStatusEnum })[]>({
         queryKey: ['getSearchProfiles', switchedDid ?? '', profileId],
-        enabled,
+        enabled: options.enabled ?? true,
         queryFn: async () => {
             const wallet = await initWallet();
             const data = await wallet.invoke.searchProfiles(profileId, {

--- a/packages/learn-card-base/src/react-query/queries/queries.ts
+++ b/packages/learn-card-base/src/react-query/queries/queries.ts
@@ -743,11 +743,12 @@ export const useGenerateInvite = () => {
 /**
  * Query: Search profiles by profileId.
  */
-export const useGetSearchProfiles = (profileId: string) => {
+export const useGetSearchProfiles = (profileId: string, enabled = true) => {
     const { initWallet } = useWallet();
     const switchedDid = switchedProfileStore.use.switchedDid();
     return useQuery<(LCNVisibleProfile & { connectionStatus?: LCNProfileConnectionStatusEnum })[]>({
         queryKey: ['getSearchProfiles', switchedDid ?? '', profileId],
+        enabled,
         queryFn: async () => {
             const wallet = await initWallet();
             const data = await wallet.invoke.searchProfiles(profileId, {


### PR DESCRIPTION
## Overview

### Context and goal

https://welibrary.atlassian.net/browse/LC-2114

In ScoutPass BoostCMS, the fullscreen recipient picker could show an empty contact state but fail to display ScoutPass network results after the user typed a profile ID. The network request still ran and no console error was emitted; the mounted picker simply continued rendering the empty, open-time result snapshot.

This is a separate follow-up to the contact-selection fix in #1487.

### Root cause

The shared modal stack stores an already-created React element. The list-view BoostCMS component owned `search`, `searchResults`, and `isLoading`, then passed their current values into the fullscreen picker when opening it.

Typing still updated state in the hidden parent and triggered `useGetSearchProfiles`, but the stored modal element never received the parent's new props. The visible picker therefore remained on `search=""` and `searchResults=[]`.

The same frozen query also affected the existing troop-leader and network-admin scoped filtering paths.

### Regression history

This behavior regressed on **January 14, 2026**, when #918 replaced ScoutPass `useIonModal` usage with the shared `useModal` stack. Ionic's former overlay refreshed mounted component props; the shared modal stack stores the React element created at modal-open time.

This predates and was not introduced by the later LC-1962 modal safe-area work in #1461.

### What changed

- Give the mounted fullscreen picker ownership of its live search query.
- Run global profile search only for non-empty queries in the mounted regular-user picker.
- Preserve troop-leader and network-admin scoped search without enabling a redundant global query.
- Disable global-search observers in the hidden BoostCMS and troop-ID list shells.
- Pass the derived live results consistently between nested picker views.
- Replace the positional query flag with an `{ enabled }` options object.
- Add regression coverage for zero contacts, empty queries, and scoped searches.
- Add the required ScoutPass and `learn-card-base` patch changesets.

### CI follow-up

The initial CI run exposed two test-only issues:

- `BoostAddressBook.test.tsx` fully mocked `learn-card-base` but omitted the newly used `useGetSearchProfiles` export.
- `boostHelpers.test.ts` dynamically imported a large barrel dependency inside `beforeAll`, exceeding Vitest's 10-second hook timeout under CI load.

The mock now includes the hook. The slow async setup was removed rather than given a larger timeout: `boostHelpers` uses direct module imports and the test uses static imports, reducing its 11-test execution time to about 22 ms in the full suite.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance

## QA steps

1. Run ScoutPass locally against staging services.
2. Open a BoostCMS credential and choose **Send To**.
3. Open the fullscreen contact picker with an account that has no contacts.
4. Type a known ScoutPass profile ID.
5. Confirm the matching ScoutPass network profile appears.
6. For troop-leader or network-admin roles, confirm search remains scoped to the troop or network.

## Verification

- `bun run test` — 3 Bun tests plus 37 Vitest files / 157 tests passed.
- `bun run build` — production build completed.
- `git diff --check` and the repository's staged-file Prettier task — passed.
- Manual localhost verification against staging services — confirmed by Donny.

## Related work

- #1487 fixes the sibling stale-modal issue where clicking a contact's **+** button did not update the mounted picker's selection.
- Both symptoms are tracked in LC-2114.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Restore network profile search functionality in BoostCMS recipient picker by adding conditional query enabling based on user role and view mode.

Main changes:
- Added `enabled` option parameter to `useGetSearchProfiles` hook with conditional logic for troop leaders and network admins
- Updated BoostSearch, BoostCMS, BoostAddressBook components to conditionally enable profile search queries based on user restrictions
- Refactored BoostAddressBook to support dual search modes with separate modal and parent search state management

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
