### PR TITLE
fix: bump axios to ^0.33.0 (10 Dependabot alerts)

### DIFF
--- a/.changeset/axios-bump-security.md
+++ b/.changeset/axios-bump-security.md
@@ -1,5 +1,6 @@
 ---
 "@learncard/lca-api-service": patch
+"learn-card-base": patch
 ---
 
 fix: bump axios to ^0.33.0 to resolve Dependabot alerts (formToJSON DoS, NO_PROXY bypass, prototype pollution)

--- a/.changeset/axios-bump-security.md
+++ b/.changeset/axios-bump-security.md
@@ -1,0 +1,5 @@
+---
+"@learncard/lca-api-service": patch
+---
+
+fix: bump axios to ^0.33.0 to resolve Dependabot alerts (formToJSON DoS, NO_PROXY bypass, prototype pollution)

--- a/bun.lock
+++ b/bun.lock
@@ -617,7 +617,7 @@
         "@web3auth/openlogin-adapter": "^8.12.4",
         "@web3auth/single-factor-auth": "^9.5.0",
         "async": "^3.2.6",
-        "axios": "^0.31.0",
+        "axios": "^0.33.0",
         "capacitor-plugin-safe-area": "^5.0.0",
         "class-variance-authority": "0.7.0",
         "clsx": "2.0.0",
@@ -1725,7 +1725,7 @@
         "@types/jsonwebtoken": "^9.0.8",
         "@types/lodash": "^4.14.191",
         "@types/node-forge": "^1.3.11",
-        "axios": "^0.31.0",
+        "axios": "^0.33.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "fastify": "^5.8.5",
@@ -5252,7 +5252,7 @@
 
     "axe-core": ["axe-core@4.13.0", "", {}, "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A=="],
 
-    "axios": ["axios@0.31.1", "", { "dependencies": { "follow-redirects": "^1.15.4", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-Ef8DUZSZQP6igY48mjGaoEjwhely97lserep0IFJifBH4YdKvwH5eMLniy3kig2HQoBNR8EkZpDjowxwTJcmbg=="],
+    "axios": ["axios@0.33.0", "", { "dependencies": { "follow-redirects": "^1.15.4", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 

--- a/packages/learn-card-base/package.json
+++ b/packages/learn-card-base/package.json
@@ -35,7 +35,7 @@
         "@web3auth/openlogin-adapter": "^8.12.4",
         "@web3auth/single-factor-auth": "^9.5.0",
         "async": "^3.2.6",
-        "axios": "^0.31.0",
+        "axios": "^0.33.0",
         "capacitor-plugin-safe-area": "^5.0.0",
         "class-variance-authority": "0.7.0",
         "clsx": "2.0.0",

--- a/services/learn-card-network/lca-api/package.json
+++ b/services/learn-card-network/lca-api/package.json
@@ -53,7 +53,7 @@
         "@types/jsonwebtoken": "^9.0.8",
         "@types/lodash": "^4.14.191",
         "@types/node-forge": "^1.3.11",
-        "axios": "^0.31.0",
+        "axios": "^0.33.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "fastify": "^5.8.5",


### PR DESCRIPTION
## Why
Clears 10 open MODERATE Dependabot alerts (all RUNTIME scope) against `axios ^0.31.0` in `learn-card-base` and `@learncard/lca-api-service`:

- Deep formToJSON key recursion DoS (#948, #949)
- Excessive recursion in formDataToJSON DoS (#950, #951)
- NO_PROXY bypass for 0.0.0.0 local addresses (#962, #963)
- Prototype pollution gadgets altering request construction (#989, #991)
- Nested option objects consuming polluted prototype values (#990, #992)

## What
| package | change |
|---|---|
| learn-card-base | `axios ^0.31.0` → `^0.33.0` |
| @learncard/lca-api-service | `axios ^0.31.0` → `^0.33.0` |

Minor-range bump within 0.x, no API changes affecting our usage. Lockfile resolves to `axios@0.33.0`.

Part of the SOC2 Dependabot cleanup (follows #1496).



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Upgrade axios to ^0.33.0 across packages to resolve 10 Dependabot security alerts including DoS and prototype pollution vulnerabilities.

Main changes:
- Bumped axios from ^0.31.0 to ^0.33.0 in learn-card-base and lca-api package.json dependencies
- Added changeset entry documenting security fixes for formToJSON DoS, NO_PROXY bypass, and prototype pollution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

