### PR TITLE
[LC-2132] Return OAuth presentations in URL fragments

### DIFF
--- a/.changeset/calm-fragments-return.md
+++ b/.changeset/calm-fragments-return.md
@@ -1,0 +1,5 @@
+---
+'learn-card-app': patch
+---
+
+Add opt-in fragment delivery for consent callback presentations while preserving query delivery by default.

--- a/apps/learn-card-app/src/pages/consentFlow/ConsentFlowSyncCard.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/ConsentFlowSyncCard.tsx
@@ -26,6 +26,7 @@ import ConsentFlowEditAccess from '../launchPad/ConsentFlowEditAccess';
 
 import useTheme from '../../theme/hooks/useTheme';
 import * as m from '../../paraglide/messages.js';
+import { createConsentFlowReturnUrl } from './createConsentFlowReturnUrl';
 
 export type ConsentFlowWriteAccessType = {
     [BoostCategoryOptionsEnum.socialBadge]: boolean;
@@ -97,7 +98,7 @@ const ConsentFlowSyncCard: React.FC<ConsentFlowSyncCardProps> = ({
     const location = useLocation();
     const brandingConfig = useBrandingConfig();
 
-    const { returnTo } = queryString.parse(location.search);
+    const { returnTo, response_mode: responseMode } = queryString.parse(location.search);
 
     // state for handling - data share duration
     const [shareDuration, setShareDuration] = useState<{
@@ -221,9 +222,8 @@ const ConsentFlowSyncCard: React.FC<ConsentFlowSyncCardProps> = ({
                                     ) {
                                         const wallet = await initWallet();
 
-                                        // add user's did to returnTo url
-                                        const urlObj = new URL(returnTo);
-                                        urlObj.searchParams.set('did', wallet.id.did());
+                                        let presentation: string | undefined;
+
                                         if (contractDetails.owner.did) {
                                             const unsignedDelegateCredential =
                                                 wallet.invoke.newCredential({
@@ -241,18 +241,22 @@ const ConsentFlowSyncCard: React.FC<ConsentFlowSyncCardProps> = ({
                                                 await wallet.invoke.newPresentation(
                                                     delegateCredential
                                                 );
-                                            const vp = (await wallet.invoke.issuePresentation(
+                                            presentation = (await wallet.invoke.issuePresentation(
                                                 unsignedDidAuthVp,
                                                 {
                                                     proofPurpose: 'authentication',
                                                     proofFormat: 'jwt',
                                                 }
-                                            )) as any as string;
-
-                                            urlObj.searchParams.set('vp', vp);
+                                            )) as unknown as string;
                                         }
 
-                                        window.location.href = urlObj.toString();
+                                        window.location.href = createConsentFlowReturnUrl({
+                                            returnTo,
+                                            did: wallet.id.did(),
+                                            presentation,
+                                            mode:
+                                                responseMode === 'fragment' ? 'fragment' : 'query',
+                                        });
                                     } else history.push(returnTo);
                                 } else history.push(`/launchpad?uri=${contractDetails.uri}`);
                             } finally {

--- a/apps/learn-card-app/src/pages/consentFlow/ConsentFlowSyncData.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/ConsentFlowSyncData.tsx
@@ -14,6 +14,7 @@ import { useConsentedContracts } from 'learn-card-base/hooks/useConsentedContrac
 import PostConsentFlowSyncCard from '../launchPad/PostConsentFlowSyncCard';
 import { useRegistryState } from '../../hooks/useRegistryEntryState';
 import * as m from '../../paraglide/messages.js';
+import { createConsentFlowReturnUrl } from './createConsentFlowReturnUrl';
 
 // Deprecated - ConsentFlow happens on LaunchPad now
 const ConsentFlowSyncData: React.FC = () => {
@@ -25,7 +26,7 @@ const ConsentFlowSyncData: React.FC = () => {
 
     const { newModal } = useModal();
 
-    const { uri, returnTo } = queryString.parse(location.search);
+    const { uri, returnTo, response_mode: responseMode } = queryString.parse(location.search);
 
     const contractUri = Array.isArray(uri) ? uri[0] ?? '' : uri ?? '';
 
@@ -146,9 +147,8 @@ const ConsentFlowSyncData: React.FC = () => {
                             if (returnTo.startsWith('http://') || returnTo.startsWith('https://')) {
                                 const wallet = await initWallet();
 
-                                // add user's did to returnTo url
-                                const urlObj = new URL(returnTo);
-                                urlObj.searchParams.set('did', wallet.id.did());
+                                let presentation: string | undefined;
+
                                 if (contractDetails?.owner?.did) {
                                     const unsignedDelegateCredential = wallet.invoke.newCredential({
                                         type: 'delegate',
@@ -163,18 +163,21 @@ const ConsentFlowSyncData: React.FC = () => {
                                     const unsignedDidAuthVp = await wallet.invoke.newPresentation(
                                         delegateCredential
                                     );
-                                    const vp = (await wallet.invoke.issuePresentation(
+                                    presentation = (await wallet.invoke.issuePresentation(
                                         unsignedDidAuthVp,
                                         {
                                             proofPurpose: 'authentication',
                                             proofFormat: 'jwt',
                                         }
-                                    )) as any as string;
-
-                                    urlObj.searchParams.set('vp', vp);
+                                    )) as unknown as string;
                                 }
 
-                                window.location.href = urlObj.toString();
+                                window.location.href = createConsentFlowReturnUrl({
+                                    returnTo,
+                                    did: wallet.id.did(),
+                                    presentation,
+                                    mode: responseMode === 'fragment' ? 'fragment' : 'query',
+                                });
                             } else history.push(returnTo);
                         } else history.push('/home');
                     }}

--- a/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.test.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.test.tsx
@@ -22,13 +22,18 @@ vi.mock('query-string', () => ({
         parse: vi.fn(() => ({
             uri: 'lc:network:localhost:contract:test-123',
             returnTo: 'https://example.com/callback',
+            response_mode: 'fragment',
             recipientToken: undefined,
         })),
+        stringify: vi.fn(
+            () => 'uri=test&returnTo=https%3A%2F%2Fexample.com%2Fcallback&response_mode=fragment'
+        ),
     },
     parse: vi.fn(() => ({
         uri: 'lc:network:localhost:contract:test-123',
         returnTo: 'https://example.com/callback',
         recipientToken: undefined,
+        response_mode: 'fragment',
     })),
 }));
 
@@ -377,10 +382,12 @@ describe('ExternalConsentFlowDoor', () => {
             const continueButton = screen.getByRole('button', { name: /continue as/i });
             fireEvent.click(continueButton);
 
-            // For non-consented user, SHOULD navigate to sync-data
-            expect(mockPush).toHaveBeenCalledWith(
-                expect.stringContaining('consent-flow-sync-data')
-            );
+            // For non-consented user, preserve fragment mode through sync-data.
+            await waitFor(() => {
+                expect(mockPush).toHaveBeenCalledWith(
+                    expect.stringContaining('response_mode=fragment')
+                );
+            });
         });
     });
 });

--- a/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/ExternalConsentFlowDoor.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { UnsignedVP } from '@learncard/types';
 import { getLogger } from 'learn-card-base';
 const log = getLogger('external-consent-flow-door');
 
@@ -34,6 +35,7 @@ import { useAuthCoordinator } from '../../providers/AuthCoordinatorProvider';
 import { useConsentedContracts } from 'learn-card-base/hooks/useConsentedContracts';
 import { useBrandingConfig } from 'learn-card-base/config/TenantConfigProvider';
 import ConsentFlowError from './ConsentFlowError';
+import { createConsentFlowReturnUrl } from './createConsentFlowReturnUrl';
 import { resumeBuilderStore } from '../../stores/resumeBuilderStore';
 
 import useTheme from '../../theme/hooks/useTheme';
@@ -77,7 +79,12 @@ const ExternalConsentFlowDoor: React.FC<{ login: boolean }> = ({ login = false }
     // Warm up the consented contracts cache
     useConsentedContracts();
 
-    const { uri, returnTo, recipientToken } = queryString.parse(location.search);
+    const {
+        uri,
+        returnTo,
+        response_mode: responseMode,
+        recipientToken,
+    } = queryString.parse(location.search);
 
     const { data: consentedContracts, isLoading: consentedContractLoading } =
         useConsentedContracts();
@@ -138,8 +145,7 @@ const ExternalConsentFlowDoor: React.FC<{ login: boolean }> = ({ login = false }
                 if (returnTo.startsWith('http://') || returnTo.startsWith('https://')) {
                     const wallet = await initWallet();
 
-                    const urlObj = new URL(returnTo);
-                    urlObj.searchParams.set('did', wallet.id.did());
+                    let presentation: string | undefined;
 
                     if (consentedContract?.contract?.owner?.did) {
                         const unsignedDelegateCredential = wallet.invoke.newCredential({
@@ -152,23 +158,25 @@ const ExternalConsentFlowDoor: React.FC<{ login: boolean }> = ({ login = false }
                             unsignedDelegateCredential
                         );
 
-                        const unsignedDidAuthVp: any = await wallet.invoke.newPresentation(
-                            delegateCredential
-                        );
+                        const unsignedDidAuthVp: UnsignedVP & { contractUri?: string } =
+                            await wallet.invoke.newPresentation(delegateCredential);
 
                         if (uri && typeof uri === 'string') {
                             unsignedDidAuthVp.contractUri = uri;
                         }
 
-                        const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
+                        presentation = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
                             proofPurpose: 'authentication',
                             proofFormat: 'jwt',
-                        })) as any as string;
-
-                        urlObj.searchParams.set('vp', vp);
+                        })) as unknown as string;
                     }
 
-                    window.location.href = urlObj.toString();
+                    window.location.href = createConsentFlowReturnUrl({
+                        returnTo,
+                        did: wallet.id.did(),
+                        presentation,
+                        mode: responseMode === 'fragment' ? 'fragment' : 'query',
+                    });
                     return;
                 }
             }
@@ -178,15 +186,16 @@ const ExternalConsentFlowDoor: React.FC<{ login: boolean }> = ({ login = false }
                 setStep(Step.credFrontDoor);
             } else if (returnTo) {
                 history.push(
-                    `/consent-flow-sync-data?uri=${uri}&returnTo=${returnTo}${
-                        recipientToken ? `&recipientToken=${recipientToken}` : ''
-                    }`
+                    `/consent-flow-sync-data?${queryString.stringify({
+                        uri,
+                        returnTo,
+                        response_mode: responseMode,
+                        recipientToken,
+                    })}`
                 );
             } else {
                 history.push(
-                    `/consent-flow-sync-data?uri=${uri}${
-                        recipientToken ? `&recipientToken=${recipientToken}` : ''
-                    }`
+                    `/consent-flow-sync-data?${queryString.stringify({ uri, recipientToken })}`
                 );
             }
         };
@@ -205,6 +214,7 @@ const ExternalConsentFlowDoor: React.FC<{ login: boolean }> = ({ login = false }
         consentedContract,
         login,
         returnTo,
+        responseMode,
         contractDetails,
         uri,
         recipientToken,

--- a/apps/learn-card-app/src/pages/consentFlow/FullScreenConsentFlow.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/FullScreenConsentFlow.tsx
@@ -23,9 +23,15 @@ import { useGuardianGate } from '../../hooks/useGuardianGate';
 import ConsentFlowConnecting from './ConsentFlowConnecting';
 import ConsentFlowConfirmation from './ConsentFlowConfirmation';
 import ConsentFlowGetAnAdultPrompt from './ConsentFlowGetAnAdult';
+import { createConsentFlowReturnUrl } from './createConsentFlowReturnUrl';
 import AiPassportAppProfileConnectedView from '../../components/ai-passport-apps/AiPassportAppProfileConnectedView/AiPassportAppProfileConnectedView';
 
-import { ConsentFlowContractDetails, ConsentFlowTerms, LCNProfile } from '@learncard/types';
+import {
+    ConsentFlowContractDetails,
+    ConsentFlowTerms,
+    LCNProfile,
+    UnsignedVP,
+} from '@learncard/types';
 import * as m from '../../paraglide/messages.js';
 
 enum ConsentFlowStep {
@@ -89,7 +95,11 @@ const FullScreenConsentFlow: React.FC<FullScreenConsentFlowProps> = ({
         !!childInsightsProfile
     );
 
-    const { returnTo: urlReturnTo, recipientToken } = queryString.parse(location.search);
+    const {
+        returnTo: urlReturnTo,
+        response_mode: responseMode,
+        recipientToken,
+    } = queryString.parse(location.search);
     const returnTo = urlReturnTo || contractDetails?.redirectUrl?.trim(); // prefer url param
     const shouldDisableRedirect =
         disableRedirect || Boolean(insightsProfile) || Boolean(childInsightsProfile);
@@ -168,9 +178,7 @@ const FullScreenConsentFlow: React.FC<FullScreenConsentFlowProps> = ({
                     if (returnTo.startsWith('http://') || returnTo.startsWith('https://')) {
                         const wallet = await initWallet();
 
-                        // add user's did to returnTo url
-                        const urlObj = new URL(returnTo);
-                        urlObj.searchParams.set('did', wallet.id.did());
+                        let presentation: string | undefined;
 
                         if (contractDetails?.owner?.did) {
                             const unsignedDelegateCredential = wallet.invoke.newCredential({
@@ -183,24 +191,29 @@ const FullScreenConsentFlow: React.FC<FullScreenConsentFlowProps> = ({
                                 unsignedDelegateCredential
                             );
 
-                            const unsignedDidAuthVp: any = await wallet.invoke.newPresentation(
-                                delegateCredential
-                            );
+                            const unsignedDidAuthVp: UnsignedVP & { contractUri?: string } =
+                                await wallet.invoke.newPresentation(delegateCredential);
 
                             // Add contractUri to VP before signing for xAPI tracking
                             if (contractDetails?.uri) {
                                 unsignedDidAuthVp.contractUri = contractDetails.uri;
                             }
 
-                            const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
-                                proofPurpose: 'authentication',
-                                proofFormat: 'jwt',
-                            })) as any as string;
-
-                            urlObj.searchParams.set('vp', vp);
+                            presentation = (await wallet.invoke.issuePresentation(
+                                unsignedDidAuthVp,
+                                {
+                                    proofPurpose: 'authentication',
+                                    proofFormat: 'jwt',
+                                }
+                            )) as unknown as string;
                         }
 
-                        window.location.href = urlObj.toString();
+                        window.location.href = createConsentFlowReturnUrl({
+                            returnTo,
+                            did: wallet.id.did(),
+                            presentation,
+                            mode: responseMode === 'fragment' ? 'fragment' : 'query',
+                        });
                     } else history.push(returnTo);
                 }
             }

--- a/apps/learn-card-app/src/pages/consentFlow/GameFlow/GameAccessSuccessPrompt.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/GameFlow/GameAccessSuccessPrompt.tsx
@@ -6,6 +6,7 @@ import { useModal, useWallet } from 'learn-card-base';
 import { useBrandingConfig } from 'learn-card-base/config/TenantConfigProvider';
 
 import GamePromptHeader from './GamePromptHeader';
+import { createConsentFlowReturnUrl } from '../createConsentFlowReturnUrl';
 
 import { ConsentFlowContractDetails, LCNProfile } from '@learncard/types';
 import * as m from '../../../paraglide/messages.js';
@@ -32,7 +33,9 @@ export const GameAccessSuccessPrompt: React.FC<GameAccessSuccessPromptProps> = (
     const gameTitle = name ?? '...';
     const gameImage = image ?? '';
 
-    const { returnTo: urlReturnTo } = queryString.parse(location.search);
+    const { returnTo: urlReturnTo, response_mode: responseMode } = queryString.parse(
+        location.search
+    );
 
     const returnTo = urlReturnTo || contractDetails?.redirectUrl; // prefer url param
 
@@ -40,9 +43,8 @@ export const GameAccessSuccessPrompt: React.FC<GameAccessSuccessPromptProps> = (
         closeModal();
         if (returnTo && !Array.isArray(returnTo)) {
             if (returnTo.startsWith('http://') || returnTo.startsWith('https://')) {
-                // add user's did to returnTo url
-                const urlObj = new URL(returnTo);
-                urlObj.searchParams.set('did', user.did);
+                let presentation: string | undefined;
+
                 if (contractDetails?.owner?.did) {
                     const wallet = await initWallet();
 
@@ -59,15 +61,18 @@ export const GameAccessSuccessPrompt: React.FC<GameAccessSuccessPromptProps> = (
                     const unsignedDidAuthVp = await wallet.invoke.newPresentation(
                         delegateCredential
                     );
-                    const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
+                    presentation = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
                         proofPurpose: 'authentication',
                         proofFormat: 'jwt',
-                    })) as any as string;
-
-                    urlObj.searchParams.set('vp', vp);
+                    })) as unknown as string;
                 }
 
-                window.location.href = urlObj.toString();
+                window.location.href = createConsentFlowReturnUrl({
+                    returnTo,
+                    did: user.did,
+                    presentation,
+                    mode: responseMode === 'fragment' ? 'fragment' : 'query',
+                });
             } else history.push(returnTo);
         }
     };

--- a/apps/learn-card-app/src/pages/consentFlow/GameFlow/ReturnToGamePrompt.tsx
+++ b/apps/learn-card-app/src/pages/consentFlow/GameFlow/ReturnToGamePrompt.tsx
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import { useHistory } from 'react-router-dom';
 
 import GamePromptHeader from './GamePromptHeader';
+import { createConsentFlowReturnUrl } from '../createConsentFlowReturnUrl';
 
 import { ConsentFlowContractDetails } from '@learncard/types';
 import { useConsentedContracts } from 'learn-card-base/hooks/useConsentedContracts';
@@ -21,7 +22,9 @@ export const ReturnToGamePrompt: React.FC<ReturnToGamePromptProps> = ({
 }) => {
     const history = useHistory();
     const brandingConfig = useBrandingConfig();
-    const { returnTo: urlReturnTo } = queryString.parse(location.search);
+    const { returnTo: urlReturnTo, response_mode: responseMode } = queryString.parse(
+        location.search
+    );
 
     const { data: consentedContracts } = useConsentedContracts();
     const consentedContract = consentedContracts?.find(
@@ -39,7 +42,7 @@ export const ReturnToGamePrompt: React.FC<ReturnToGamePromptProps> = ({
     const handleBackToGameRdirect = async () => {
         if (returnTo && !Array.isArray(returnTo)) {
             if (returnTo.startsWith('http://') || returnTo.startsWith('https://')) {
-                const urlObj = new URL(returnTo);
+                let presentation: string | undefined;
 
                 if (contractDetails?.owner?.did && consentedContract?.status === 'live') {
                     const wallet = await initWallet();
@@ -57,14 +60,17 @@ export const ReturnToGamePrompt: React.FC<ReturnToGamePromptProps> = ({
                     const unsignedDidAuthVp = await wallet.invoke.newPresentation(
                         delegateCredential
                     );
-                    const vp = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
+                    presentation = (await wallet.invoke.issuePresentation(unsignedDidAuthVp, {
                         proofPurpose: 'authentication',
                         proofFormat: 'jwt',
-                    })) as any as string;
-
-                    urlObj.searchParams.set('vp', vp);
+                    })) as unknown as string;
                 }
-                window.location.href = urlObj.toString();
+
+                window.location.href = createConsentFlowReturnUrl({
+                    returnTo,
+                    presentation,
+                    mode: responseMode === 'fragment' ? 'fragment' : 'query',
+                });
             } else history.push(returnTo);
         }
     };

--- a/apps/learn-card-app/src/pages/consentFlow/createConsentFlowReturnUrl.test.ts
+++ b/apps/learn-card-app/src/pages/consentFlow/createConsentFlowReturnUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { createConsentFlowReturnUrl } from './createConsentFlowReturnUrl';
+
+describe('createConsentFlowReturnUrl', () => {
+    it('preserves query delivery by default', () => {
+        const result = new URL(
+            createConsentFlowReturnUrl({
+                returnTo: 'https://example.com/callback?session=session-id',
+                did: 'did:example:learner',
+                presentation: 'signed-presentation',
+            })
+        );
+
+        expect(result.searchParams.get('session')).toBe('session-id');
+        expect(result.searchParams.get('did')).toBe('did:example:learner');
+        expect(result.searchParams.get('vp')).toBe('signed-presentation');
+    });
+
+    it('keeps presentations out of HTTP request URLs in fragment mode', () => {
+        const result = new URL(
+            createConsentFlowReturnUrl({
+                returnTo: 'https://example.com/callback?challenge=challenge-id&session=session-id',
+                did: 'did:example:learner',
+                presentation: 'signed-presentation',
+                mode: 'fragment',
+            })
+        );
+        const fragment = new URLSearchParams(result.hash.slice(1));
+
+        expect(result.searchParams.get('challenge')).toBe('challenge-id');
+        expect(result.searchParams.get('session')).toBe('session-id');
+        expect(result.searchParams.has('did')).toBe(false);
+        expect(result.searchParams.has('vp')).toBe(false);
+        expect(fragment.get('did')).toBe('did:example:learner');
+        expect(fragment.get('vp')).toBe('signed-presentation');
+    });
+
+    it('preserves existing fragment parameters', () => {
+        const result = new URL(
+            createConsentFlowReturnUrl({
+                returnTo: 'https://example.com/callback#state=existing',
+                presentation: 'signed-presentation',
+                mode: 'fragment',
+            })
+        );
+        const fragment = new URLSearchParams(result.hash.slice(1));
+
+        expect(fragment.get('state')).toBe('existing');
+        expect(fragment.get('vp')).toBe('signed-presentation');
+    });
+});

--- a/apps/learn-card-app/src/pages/consentFlow/createConsentFlowReturnUrl.ts
+++ b/apps/learn-card-app/src/pages/consentFlow/createConsentFlowReturnUrl.ts
@@ -1,0 +1,25 @@
+export type ConsentFlowReturnMode = 'query' | 'fragment';
+
+export interface CreateConsentFlowReturnUrlInput {
+    returnTo: string;
+    did?: string;
+    presentation?: string;
+    mode?: ConsentFlowReturnMode;
+}
+
+export const createConsentFlowReturnUrl = ({
+    returnTo,
+    did,
+    presentation,
+    mode = 'query',
+}: CreateConsentFlowReturnUrlInput): string => {
+    const url = new URL(returnTo);
+    const parameters =
+        mode === 'fragment' ? new URLSearchParams(url.hash.slice(1)) : url.searchParams;
+
+    if (did) parameters.set('did', did);
+    if (presentation) parameters.set('vp', presentation);
+    if (mode === 'fragment') url.hash = parameters.toString();
+
+    return url.toString();
+};


### PR DESCRIPTION
## Why

LearnCard currently returns signed DID Auth presentations in the consumer’s callback query string:

```text
https://consumer.example/callback?session=S&did=D&vp=<signed-presentation>
```

The query is part of the HTTP request URL, so the presentation can end up in proxy, CDN, server, access, and request-monitoring logs. HTTPS protects it in transit, but not from the systems processing the request, and a signed JWT is readable rather than encrypted. Multi-kilobyte presentations can also hit browser or proxy request-line limits.

## What “fragment” means here

The fragment is the part after `#`, sometimes called the hash. It is not a cryptographic hash:

```text
https://consumer.example/callback?session=S#did=D&vp=<signed-presentation>
```

The browser requests only `/callback?session=S`; it does not send the fragment in the HTTP request or `Referer`. The fragment is still visible to the browser, may briefly appear in the address bar, and may be retained in browser-side state. This is not encryption. The benefit is specifically keeping the presentation out of HTTP request URLs and the infrastructure logs that routinely record them.

The consumer is responsible for reading the fragment and moving the presentation into a request body. The paired AI Passport callback does that with a no-store, CSP-protected same-origin POST.

## What changed

- adds an explicit `response_mode=fragment` opt-in for consent return URLs
- keeps the existing query delivery as the default when the opt-in is absent
- centralizes query/fragment URL construction in `createConsentFlowReturnUrl`
- preserves the mode while users move through the different consent paths
- updates each path that can finish consent and return a DID/presentation

The number of touched components is intentional: LearnCard currently completes consent from several paths depending on contract and user state. If one path drops the response mode, fragment delivery would work for some users and silently fall back to query delivery for others.

## Compatibility and rollout

This pairs with [AI Passport #68](https://github.com/WeLibraryOS/AI-Passport/pull/68).

Fragment delivery is opt-in. Existing consumers that do not send `response_mode=fragment` continue receiving `did` and `vp` in the query exactly as before.

Deploy this producer support first, then AI Passport. Producer-first preserves every existing consumer while making fragment mode available. Deploying the AI Passport consumer first would break MCP OAuth login because LearnCard would still send the presentation in the query while the new callback expects the fragment-to-POST flow.

## Tradeoffs

- the browser and destination page can still read the fragment; this is not end-to-end encryption
- the fragment may be visible in the address bar or retained in browser-side state
- fragment consumers need JavaScript or equivalent client-side handling to move the response into a request body
- the eventual POST body remains sensitive and must not be logged
- every consent completion path must preserve the opt-in consistently

## QA

- without `response_mode`, confirm existing query delivery is unchanged
- with `response_mode=fragment`, confirm `did` and `vp` are after `#` and absent from the callback HTTP request URL
- exercise already-consented, new-consent/sync, full-screen, and game return paths
- confirm existing fragment parameters are preserved
- exercise a multi-kilobyte presentation with the paired AI Passport callback

## Verification

The return-URL helper tests cover default query behavior, fragment behavior, and existing fragment preservation. Targeted LearnCard build and consent callback checks pass.

— OMP
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement optional delivery of OAuth presentations via URL fragments to improve security by keeping credentials out of HTTP request logs.

Main changes:
- Created `createConsentFlowReturnUrl` utility to handle both query and fragment response modes
- Updated consent flow components to parse `response_mode` and use the new URL utility
- Added unit tests for URL generation and updated `ExternalConsentFlowDoor` integration tests

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
