### PR TITLE
[LC-2125] Return live AI consent metadata

### DIFF
--- a/.changeset/live-consent-metadata.md
+++ b/.changeset/live-consent-metadata.md
@@ -1,0 +1,6 @@
+---
+'@learncard/types': patch
+'@learncard/network-brain-service': patch
+---
+
+Return live consent metadata required for server-side active-consent enforcement.

--- a/packages/learn-card-types/src/lcn.ts
+++ b/packages/learn-card-types/src/lcn.ts
@@ -653,21 +653,6 @@ export const PaginatedConsentFlowDataValidator = PaginationResponseValidator.ext
 });
 export type PaginatedConsentFlowData = z.infer<typeof PaginatedConsentFlowDataValidator>;
 
-export const ConsentFlowContractDataForDidValidator = z.object({
-    credentials: z.object({ category: z.string(), uri: z.string() }).array(),
-    personal: z.record(z.string(), z.string()).default({}),
-    date: z.string(),
-    contractUri: z.string(),
-});
-export type ConsentFlowContractDataForDid = z.infer<typeof ConsentFlowContractDataForDidValidator>;
-
-export const PaginatedConsentFlowDataForDidValidator = PaginationResponseValidator.extend({
-    records: ConsentFlowContractDataForDidValidator.array(),
-});
-export type PaginatedConsentFlowDataForDid = z.infer<
-    typeof PaginatedConsentFlowDataForDidValidator
->;
-
 export const ConsentFlowTermValidator = z.object({
     sharing: z.boolean().optional(),
     shared: z.string().array().optional(),
@@ -716,6 +701,25 @@ export const PaginatedConsentFlowTermsValidator = PaginationResponseValidator.ex
         .array(),
 });
 export type PaginatedConsentFlowTerms = z.infer<typeof PaginatedConsentFlowTermsValidator>;
+
+export const ConsentFlowContractDataForDidValidator = z.object({
+    credentials: z.object({ category: z.string(), uri: z.string() }).array(),
+    personal: z.record(z.string(), z.string()).default({}),
+    date: z.string(),
+    contractUri: z.string(),
+    termsUri: z.string(),
+    status: ConsentFlowTermsStatusValidator,
+    expiresAt: z.string().optional(),
+    terms: ConsentFlowTermsValidator,
+});
+export type ConsentFlowContractDataForDid = z.infer<typeof ConsentFlowContractDataForDidValidator>;
+
+export const PaginatedConsentFlowDataForDidValidator = PaginationResponseValidator.extend({
+    records: ConsentFlowContractDataForDidValidator.array(),
+});
+export type PaginatedConsentFlowDataForDid = z.infer<
+    typeof PaginatedConsentFlowDataForDidValidator
+>;
 
 export const ConsentFlowContractQueryValidator = z.object({
     read: z

--- a/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
+++ b/services/learn-card-network/brain-service/src/accesslayer/consentflowcontract/relationships/read.ts
@@ -536,12 +536,13 @@ export const getConsentedDataBetweenProfiles = async (
             params: flattenObject({ terms: flattenObject(convertDataQueryToNeo4jQuery(params)) }),
             cursor,
             ...contractQueryParams,
+            now: new Date().toISOString(),
         })
     ).match({
         related: [
             { model: Profile, where: { profileId: consenterProfileId } },
             ConsentFlowTerms.getRelationshipByAlias('createdBy'),
-            { identifier: 'terms', model: ConsentFlowTerms },
+            { identifier: 'terms', model: ConsentFlowTerms, where: { status: 'live' } },
             ConsentFlowTerms.getRelationshipByAlias('consentsTo'),
             { model: ConsentFlowContract, identifier: 'contract' },
             ConsentFlowContract.getRelationshipByAlias('createdBy'),
@@ -559,6 +560,7 @@ all(key IN keys($params) WHERE
     END
 )
 AND ${contractWhereClause}
+AND (terms.expiresAt IS NULL OR terms.expiresAt > $now)
 `);
 
     const dbQuery = cursor ? _dbQuery.raw(' AND terms.updatedAt < $cursor') : _dbQuery;
@@ -582,6 +584,10 @@ AND ${contractWhereClause}
     return inflatedResults.map(({ term, contract }) => ({
         date: term.updatedAt!,
         contractUri: constructUri('contract', contract.id, domain),
+        termsUri: constructUri('terms', term.id, domain),
+        status: term.status,
+        ...(term.expiresAt ? { expiresAt: term.expiresAt } : {}),
+        terms: term.terms,
         credentials: Object.entries(term.terms.read.credentials.categories)
             .flatMap(([category, { shared, sharing, shareUntil }]) => {
                 if (

--- a/services/learn-card-network/brain-service/test/consentflow.spec.ts
+++ b/services/learn-card-network/brain-service/test/consentflow.spec.ts
@@ -954,6 +954,26 @@ describe('Consent Flow Contracts', () => {
             expect(data.records[0]?.credentials).toHaveLength(4);
             expect(data.records[0]?.personal).toEqual(normalFullTerms.read.personal);
             expect(data.records[0]?.contractUri).toEqual(contractUri);
+            expect(data.records[0]?.status).toBe('live');
+            expect(data.records[0]?.termsUri).toMatch(/^lc:network:/);
+            expect(data.records[0]?.terms).toEqual(normalFullTerms);
+        });
+
+        it('should omit withdrawn consent before returning provider-facing data', async () => {
+            const activeData = await userA.clients.fullAuth.contracts.getConsentedDataForDid({
+                did: userBDid,
+            });
+            const termsUri = activeData.records[0]?.termsUri;
+
+            expect(termsUri).toBeDefined();
+            if (!termsUri) throw new Error('Expected active consent terms URI');
+
+            await userB.clients.fullAuth.contracts.withdrawConsent({ uri: termsUri });
+            const withdrawnData = await userA.clients.fullAuth.contracts.getConsentedDataForDid({
+                did: userBDid,
+            });
+
+            expect(withdrawnData.records).toEqual([]);
         });
 
         it('should error for non-existent did', async () => {


### PR DESCRIPTION
## What changed
- returns contract URI, status, terms URI, grant/expiry timestamps, and terms needed for server-side AI consent enforcement
- limits results to live records and omits withdrawn or expired consent
- extends the shared consent response contract without exposing unrelated records

## Stack and rollout
Depends on #1510 and pairs with WeLibraryOS/AI-Passport#71.

Deploy this producer before the AI Passport active-consent consumer.

## Verification
- LearnCard types and brain-service builds pass
- withdrawn-consent omission is covered by the focused integration test; local execution still requires the service SEED fixture

— OMP