### PR TITLE
(e2e)fix: fix e2e wallet test, reconcile stale connection prompts after refresh 

### DIFF
--- a/.changeset/salty-moose-tap.md
+++ b/.changeset/salty-moose-tap.md
@@ -1,0 +1,5 @@
+---
+"learn-card-base": patch
+---
+
+fix: reconcile stale connection prompts after refresh

--- a/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.test.tsx
+++ b/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.test.tsx
@@ -23,14 +23,20 @@ vi.mock('learn-card-base/hooks/useGetCurrentUser', () => ({ default: () => null 
 const state = vi.hoisted(() => ({
     loggedIn: true,
     switchedDid: undefined as string | undefined,
-    prompts: [] as LCNConnectionPrompt[],
+    prompts: [] as LCNConnectionPrompt[] | undefined,
+    promptsQueryIsSuccess: true,
+    promptsQueryIsFetching: false,
     connect: vi.fn<(promptId: string) => Promise<void>>(),
     skip: vi.fn<(promptId: string) => Promise<void>>(),
     dismissToast: vi.fn(),
 }));
 
 vi.mock('../../react-query/connectionPrompts', () => ({
-    usePendingConnectionPrompts: () => ({ data: state.prompts }),
+    usePendingConnectionPrompts: () => ({
+        data: state.prompts,
+        isSuccess: state.promptsQueryIsSuccess,
+        isFetching: state.promptsQueryIsFetching,
+    }),
     useConnectWithConnectionPromptMutation: () => ({ mutateAsync: state.connect }),
     useSkipConnectionPromptMutation: () => ({ mutateAsync: state.skip }),
 }));
@@ -189,6 +195,8 @@ describe('ConnectionPromptCoordinator', () => {
         state.loggedIn = true;
         state.switchedDid = undefined;
         state.prompts = [];
+        state.promptsQueryIsSuccess = true;
+        state.promptsQueryIsFetching = false;
         state.connect.mockReset().mockResolvedValue(undefined);
         state.skip.mockReset().mockResolvedValue(undefined);
         state.dismissToast.mockReset();
@@ -274,7 +282,7 @@ describe('ConnectionPromptCoordinator', () => {
         state.prompts = [alice];
         state.skip.mockImplementation(async promptId => {
             await request.promise;
-            state.prompts = state.prompts.filter(prompt => prompt.promptId !== promptId);
+            state.prompts = (state.prompts ?? []).filter(prompt => prompt.promptId !== promptId);
         });
         renderCoordinator();
         await advance(150);
@@ -337,7 +345,7 @@ describe('ConnectionPromptCoordinator', () => {
     it('does not turn a successful explicit Connect into a Skip', async () => {
         state.prompts = [alice];
         state.connect.mockImplementation(async promptId => {
-            state.prompts = state.prompts.filter(prompt => prompt.promptId !== promptId);
+            state.prompts = (state.prompts ?? []).filter(prompt => prompt.promptId !== promptId);
         });
         renderCoordinator();
         await advance(150);
@@ -375,6 +383,72 @@ describe('ConnectionPromptCoordinator', () => {
 
         expect(screen.getByRole('heading', { name: 'Connect with Bob?' })).toBeTruthy();
         expect(screen.queryByRole('heading', { name: 'Connect with Alice?' })).toBeNull();
+    });
+
+    it('closes a restored prompt when the refreshed pending query no longer includes it', async () => {
+        state.prompts = [alice];
+        const view = renderCoordinator();
+        await advance(150);
+
+        expect(screen.getByRole('heading', { name: 'Connect with Alice?' })).toBeTruthy();
+
+        state.promptsQueryIsFetching = true;
+        view.rerender(
+            <ModalsProvider>
+                <ConnectionPromptCoordinator copy={copy} />
+                <ModalHarness />
+            </ModalsProvider>
+        );
+        await advance(300);
+        expect(screen.getByRole('heading', { name: 'Connect with Alice?' })).toBeTruthy();
+
+        state.prompts = [];
+        state.promptsQueryIsFetching = false;
+        view.rerender(
+            <ModalsProvider>
+                <ConnectionPromptCoordinator copy={copy} />
+                <ModalHarness />
+            </ModalsProvider>
+        );
+        await advance(300);
+
+        expect(screen.queryByRole('heading', { name: 'Connect with Alice?' })).toBeNull();
+        expect(screen.getByTestId('modal-count').textContent).toBe('0');
+        expect(state.connect).not.toHaveBeenCalled();
+        expect(state.skip).not.toHaveBeenCalled();
+    });
+
+    it('keeps an active prompt through reset/loading and a failed refetch', async () => {
+        state.prompts = [alice];
+        const view = renderCoordinator();
+        await advance(150);
+
+        state.prompts = undefined;
+        state.promptsQueryIsSuccess = false;
+        state.promptsQueryIsFetching = true;
+        view.rerender(
+            <ModalsProvider>
+                <ConnectionPromptCoordinator copy={copy} />
+                <ModalHarness />
+            </ModalsProvider>
+        );
+        await advance(300);
+
+        expect(screen.getByRole('heading', { name: 'Connect with Alice?' })).toBeTruthy();
+
+        state.promptsQueryIsFetching = false;
+        view.rerender(
+            <ModalsProvider>
+                <ConnectionPromptCoordinator copy={copy} />
+                <ModalHarness />
+            </ModalsProvider>
+        );
+        await advance(300);
+
+        expect(screen.getByRole('heading', { name: 'Connect with Alice?' })).toBeTruthy();
+        expect(screen.getByTestId('modal-count').textContent).toBe('1');
+        expect(state.connect).not.toHaveBeenCalled();
+        expect(state.skip).not.toHaveBeenCalled();
     });
 
     it('suppresses native dismissal during Connect and resets the guard after failure', async () => {
@@ -546,7 +620,7 @@ describe('ConnectionPromptCoordinator', () => {
     it('queues different counterparts one at a time without reopening the active pair', async () => {
         state.prompts = [bob, alice];
         state.skip.mockImplementation(async promptId => {
-            state.prompts = state.prompts.filter(prompt => prompt.promptId !== promptId);
+            state.prompts = (state.prompts ?? []).filter(prompt => prompt.promptId !== promptId);
         });
         const view = renderCoordinator();
         await advance(150);

--- a/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.tsx
+++ b/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.tsx
@@ -27,7 +27,7 @@ export const ConnectionPromptCoordinator: React.FC<ConnectionPromptCoordinatorPr
 }) => {
     const isLoggedIn = useIsLoggedIn();
     const switchedDid = switchedProfileStore.use.switchedDid();
-    const viewerKey = isLoggedIn ? switchedDid ?? 'primary-profile' : null;
+    const viewerKey = isLoggedIn ? (switchedDid ?? 'primary-profile') : null;
     const copyRef = useRef(copy);
     copyRef.current = copy;
     const previousViewerKeyRef = useRef(viewerKey);
@@ -38,7 +38,12 @@ export const ConnectionPromptCoordinator: React.FC<ConnectionPromptCoordinatorPr
     const ownedModalTokenRef = useRef<ModalInstanceToken | null>(null);
     const resolvedRef = useRef(false);
     const actionInFlightRef = useRef(false);
-    const { data: pendingPrompts = [] } = usePendingConnectionPrompts(isLoggedIn);
+    const {
+        data: pendingPromptsData,
+        isSuccess: pendingPromptsQueryIsSuccess,
+        isFetching: pendingPromptsQueryIsFetching,
+    } = usePendingConnectionPrompts(isLoggedIn);
+    const pendingPrompts = pendingPromptsData ?? [];
     const { mutateAsync: connectPrompt } = useConnectWithConnectionPromptMutation();
     const { mutateAsync: skipPrompt } = useSkipConnectionPromptMutation();
     const { dismissToast } = useToast();
@@ -93,6 +98,32 @@ export const ConnectionPromptCoordinator: React.FC<ConnectionPromptCoordinatorPr
         resolvedRef.current = true;
         actionInFlightRef.current = false;
     }, [modals]);
+
+    useEffect(() => {
+        const activePromptId = activePromptIdRef.current;
+        const ownedModalToken = ownedModalTokenRef.current;
+
+        if (
+            pendingPromptsData === undefined ||
+            !pendingPromptsQueryIsSuccess ||
+            pendingPromptsQueryIsFetching ||
+            activePromptId === null ||
+            ownedModalToken === null ||
+            actionInFlightRef.current ||
+            pendingPromptsData.some(prompt => prompt.promptId === activePromptId)
+        ) {
+            return;
+        }
+
+        resolvedPromptIdsRef.current.add(activePromptId);
+        resolvedRef.current = true;
+        forceCloseModalByToken(ownedModalToken);
+    }, [
+        forceCloseModalByToken,
+        pendingPromptsData,
+        pendingPromptsQueryIsFetching,
+        pendingPromptsQueryIsSuccess,
+    ]);
 
     useEffect(() => {
         if (

--- a/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.tsx
+++ b/packages/learn-card-base/src/components/connection-prompts/ConnectionPromptCoordinator.tsx
@@ -27,7 +27,7 @@ export const ConnectionPromptCoordinator: React.FC<ConnectionPromptCoordinatorPr
 }) => {
     const isLoggedIn = useIsLoggedIn();
     const switchedDid = switchedProfileStore.use.switchedDid();
-    const viewerKey = isLoggedIn ? (switchedDid ?? 'primary-profile') : null;
+    const viewerKey = isLoggedIn ? switchedDid ?? 'primary-profile' : null;
     const copyRef = useRef(copy);
     copyRef.current = copy;
     const previousViewerKeyRef = useRef(viewerKey);


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

N/A — regression found in the [wallet E2E workflow](https://github.com/learningeconomy/LearnCard/actions/runs/33431130551/job/99616465715).

#### 📚 What is the context and goal of this PR?

The wallet E2E can skip a post-claim connection prompt and hard-reload before TanStack Query's persisted cache writes the refreshed empty prompt list. On reload, the stale cached `PENDING` prompt opens the modal again. The server refetch correctly returns no pending prompts, but the coordinator previously left its already-open modal mounted, blocking the test from reaching Badges.

This PR reconciles the active modal with a successful, settled pending-prompts response. If that authoritative response no longer contains the active prompt, the coordinator marks it resolved for the current viewer and closes only the exact modal instance it owns.

#### 🥴 TL; RL:

Close a stale restored connection-prompt modal after the server confirms that prompt is no longer pending.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Reconcile the active post-claim modal after a successful pending-prompts refetch settles.
- Preserve cached prompt presentation while a background refetch is still running.
- Keep the modal open through query reset/loading and failed-refetch states.
- Avoid interrupting explicit Connect/Skip mutations already in flight.
- Prevent a reconciled stale prompt from reopening during the coordinator lifetime.
- Add regression coverage for stale cache → background refetch → confirmed empty response.

#### 🛠 Important tradeoffs made:

The coordinator waits for defined data from a successful query with no fetch in progress before treating prompt absence as authoritative. This can leave a stale modal visible until the refetch settles, but avoids permanently suppressing a legitimate prompt during transient loading, reset, or error states.

#### 🔍 Types of Changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Claim a credential that triggers the post-claim connection prompt.
2. Choose **Skip for Now**.
3. Immediately hard-reload the wallet route.
4. Verify the resolved connection prompt does not remain open or reappear.
5. Verify the wallet navigation, including **Badges**, remains usable.
6. Repeat with a genuinely pending prompt and verify it still appears after the pending query settles.

Automated verification:

- `ConnectionPromptCoordinator.test.tsx`: 19/19 passing.
- Connection-prompt coordinator, modal, notification-card, and query suites: 50/50 passing.
- Prettier and `git diff --check`: passing.
- Full `learn-card-base` run reached 572 passing tests; 8 unrelated suites fail during module setup because the local shared `localStorage` shim lacks required methods.
- The Nx lint target is not runnable in this checkout because the configured `@nrwl/linter` package is unavailable locally.

#### 📱 🖥 Which devices would you like help testing on?

Chromium (the failing Playwright wallet E2E path). Native smoke coverage is welcome but this change is not platform-specific.

#### 🧪 Code Coverage

Added unit regression coverage for:

- a stale cached prompt staying open during a background fetch and closing after a successful empty response;
- reset/loading and failed-refetch states preserving the active prompt;
- reconciliation closing without invoking Connect or Skip.

The existing wallet E2E remains unchanged so CI continues to exercise the original user flow.

# Documentation

#### 📝 Documentation Checklist

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture

#### 💭 Documentation Notes

No documentation changes are needed. This restores existing modal behavior without changing the user flow, API, or SDK surface.

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [ ] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [x] I have **commented** my code, particularly where ambiguous
-   [ ] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app) — no new interaction or analytics event.

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [ ] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

