### PR TITLE
test(a11y): scan against explicit WCAG 2.0/2.1/2.2 A+AA axe tags

### DIFF
--- a/.changeset/quiet-badgers-zoom.md
+++ b/.changeset/quiet-badgers-zoom.md
@@ -1,0 +1,5 @@
+---
+"learn-card-app": patch
+---
+
+Allow users to zoom LearnCard in web browsers while preserving native viewport behavior and one main landmark per page.

--- a/apps/learn-card-app/index.template.html
+++ b/apps/learn-card-app/index.template.html
@@ -7,10 +7,7 @@
         <base href="/" />
 
         <meta name="color-scheme" content="light dark" />
-        <meta
-            name="viewport"
-            content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
-        />
+        <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0" />
         <meta name="format-detection" content="telephone=no" />
         <meta name="msapplication-tap-highlight" content="no" />
 

--- a/apps/learn-card-app/src/AppRouter.tsx
+++ b/apps/learn-card-app/src/AppRouter.tsx
@@ -509,9 +509,9 @@ const AppRouter: React.FC = () => {
                                     {isLoggedIn && !hideSideMenu && (
                                         <SideMenu branding={BrandingEnum.learncard} />
                                     )}
-                                    <main id="main" tabIndex={-1} className="w-full">
+                                    <div id="main" tabIndex={-1} className="w-full">
                                         <MobileNavBar />
-                                    </main>
+                                    </div>
                                 </GenericErrorBoundary>
                             </IonSplitPane>
                         </>

--- a/apps/learn-card-app/src/helpers/applyNativeViewportRestrictions.test.ts
+++ b/apps/learn-card-app/src/helpers/applyNativeViewportRestrictions.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { applyNativeViewportRestrictions } from './applyNativeViewportRestrictions';
+
+const WEB_VIEWPORT_CONTENT = 'viewport-fit=cover, width=device-width, initial-scale=1.0';
+const NATIVE_VIEWPORT_CONTENT = `${WEB_VIEWPORT_CONTENT}, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no`;
+
+describe('applyNativeViewportRestrictions', () => {
+    afterEach(() => {
+        document.head.replaceChildren();
+    });
+
+    it('restores fixed scaling for native builds', () => {
+        const viewport = document.createElement('meta');
+        viewport.name = 'viewport';
+        viewport.content = WEB_VIEWPORT_CONTENT;
+        document.head.append(viewport);
+
+        applyNativeViewportRestrictions(true);
+
+        expect(viewport.content).toBe(NATIVE_VIEWPORT_CONTENT);
+    });
+
+    it('leaves web viewport scaling unrestricted', () => {
+        const viewport = document.createElement('meta');
+        viewport.name = 'viewport';
+        viewport.content = WEB_VIEWPORT_CONTENT;
+        document.head.append(viewport);
+
+        applyNativeViewportRestrictions(false);
+
+        expect(viewport.content).toBe(WEB_VIEWPORT_CONTENT);
+    });
+
+    it('does nothing when the document has no viewport metadata', () => {
+        expect(() => applyNativeViewportRestrictions(true)).not.toThrow();
+    });
+});

--- a/apps/learn-card-app/src/helpers/applyNativeViewportRestrictions.ts
+++ b/apps/learn-card-app/src/helpers/applyNativeViewportRestrictions.ts
@@ -1,0 +1,16 @@
+const NATIVE_VIEWPORT_RESTRICTIONS = 'minimum-scale=1.0, maximum-scale=1.0, user-scalable=no';
+
+/** Keeps Capacitor's in-app viewport fixed without restricting browser zoom. */
+export const applyNativeViewportRestrictions = (isNativePlatform: boolean): void => {
+    if (!isNativePlatform) return;
+
+    const viewport = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    const content = viewport?.getAttribute('content');
+
+    if (viewport) {
+        viewport.setAttribute(
+            'content',
+            [content, NATIVE_VIEWPORT_RESTRICTIONS].filter(Boolean).join(', ')
+        );
+    }
+};

--- a/apps/learn-card-app/src/index.tsx
+++ b/apps/learn-card-app/src/index.tsx
@@ -10,6 +10,7 @@ import { asyncWithLDProvider, basicLogger } from 'launchdarkly-react-client-sdk'
 import { TenantConfigProvider } from 'learn-card-base';
 import { registerExternalUrlOpener } from 'learn-card-base/helpers/externalUrlOpener';
 import { bootstrapTenantConfig } from './config/bootstrapTenantConfig';
+import { applyNativeViewportRestrictions } from './helpers/applyNativeViewportRestrictions';
 import { getLaunchDarklyConfig } from './constants/runtimeLaunchDarkly';
 import App from './App';
 
@@ -20,6 +21,8 @@ import { installInsetSimulator } from 'learn-card-base/dev/simulateInsets';
 import * as Sentry from '@sentry/browser';
 
 (window as any).Buffer = Buffer;
+
+applyNativeViewportRestrictions(Capacitor.isNativePlatform());
 
 // Dev-only: simulate device safe-area insets via ?insets so band bugs are
 // visible on desktop. Must run before React renders (sets CSS vars on <html>).

--- a/apps/learn-card-app/src/pages/hidden/CustomWallet.tsx
+++ b/apps/learn-card-app/src/pages/hidden/CustomWallet.tsx
@@ -30,8 +30,9 @@ const CustomWallet: React.FC = () => {
                 onSubmit={e => e.preventDefault()}
             >
                 <fieldset className="flex flex-col gap-2">
-                    <span>Hello, please enter a seed lol</span>
+                    <label htmlFor="custom-wallet-seed">Hello, please enter a seed lol</label>
                     <input
+                        id="custom-wallet-seed"
                         className="bg-white border"
                         type="text"
                         value={seed}
@@ -41,7 +42,7 @@ const CustomWallet: React.FC = () => {
 
                 <button
                     onClick={createWallet}
-                    className="w-full py-2 rounded border border-solid border-emerald-700 text-emerald-800"
+                    className="w-full py-2 rounded-[20px] border border-solid border-grayscale-300 text-grayscale-900"
                     type="button"
                 >
                     Create Wallet

--- a/apps/learn-card-app/src/pages/legal/LegalPageLayout.tsx
+++ b/apps/learn-card-app/src/pages/legal/LegalPageLayout.tsx
@@ -36,14 +36,10 @@ const LegalPageLayout: React.FC<LegalPageLayoutProps> = ({ title, lastUpdated, c
                     </div>
                 </header>
 
-                <main className="max-w-3xl mx-auto px-6 py-10">
-                    <h1 className="text-2xl font-semibold text-grayscale-900 mb-1">
-                        {title}
-                    </h1>
+                <div className="max-w-3xl mx-auto px-6 py-10">
+                    <h1 className="text-2xl font-semibold text-grayscale-900 mb-1">{title}</h1>
 
-                    <p className="text-xs text-grayscale-500 mb-8">
-                        Last Updated: {lastUpdated}
-                    </p>
+                    <p className="text-xs text-grayscale-600 mb-8">Last Updated: {lastUpdated}</p>
 
                     <div className="legal-content text-sm text-grayscale-700 leading-relaxed space-y-6">
                         {children}
@@ -57,10 +53,16 @@ const LegalPageLayout: React.FC<LegalPageLayoutProps> = ({ title, lastUpdated, c
                         </p>
 
                         <p className="mt-2">
-                            Contact: <a href="mailto:privacy@learningeconomy.io" className="underline hover:text-grayscale-600">privacy@learningeconomy.io</a>
+                            Contact:{' '}
+                            <a
+                                href="mailto:privacy@learningeconomy.io"
+                                className="underline hover:text-grayscale-600"
+                            >
+                                privacy@learningeconomy.io
+                            </a>
                         </p>
                     </footer>
-                </main>
+                </div>
             </IonContent>
         </IonPage>
     );

--- a/apps/learn-card-app/src/pages/pathways/build/BuildMode.tsx
+++ b/apps/learn-card-app/src/pages/pathways/build/BuildMode.tsx
@@ -356,7 +356,7 @@ const BuildMode: React.FC = () => {
                     onReorder={handleReorder}
                 />
 
-                <main className="min-w-0">
+                <div className="min-w-0">
                     {selectedNode ? (
                         <InspectorPane
                             pathway={activePathway}
@@ -374,7 +374,7 @@ const BuildMode: React.FC = () => {
                             </p>
                         </div>
                     )}
-                </main>
+                </div>
 
                 {/*
                     PreviewPane is only rendered on xl+ viewports

--- a/apps/learn-card-app/tests/accessibility.spec.ts
+++ b/apps/learn-card-app/tests/accessibility.spec.ts
@@ -14,7 +14,7 @@ const HIGH_IMPACT_LEVELS = new Set(['serious', 'critical']);
 // Scan explicitly against WCAG 2.0/2.1/2.2 A+AA (plus axe best-practices) so
 // the report surfaces WCAG 2.2-specific rules (e.g. target-size) instead of
 // axe's narrower defaults.
-const WCAG_TAGS = [
+const AXE_SCAN_TAGS = [
     'wcag2a',
     'wcag2aa',
     'wcag21a',

--- a/apps/learn-card-app/tests/accessibility.spec.ts
+++ b/apps/learn-card-app/tests/accessibility.spec.ts
@@ -114,7 +114,7 @@ const assertNoHighImpactViolations = async (
         await Promise.allSettled(transientAnimations.map(animation => animation.finished));
     });
 
-    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    const results = await new AxeBuilder({ page }).withTags(AXE_SCAN_TAGS).analyze();
     const violations = results.violations.filter(
         violation => violation.impact && HIGH_IMPACT_LEVELS.has(violation.impact)
     );

--- a/apps/learn-card-app/tests/accessibility.spec.ts
+++ b/apps/learn-card-app/tests/accessibility.spec.ts
@@ -10,6 +10,19 @@ import { TEST_CREDENTIAL_TITLE, waitForAuthenticatedState } from './test.helpers
 // catch authoring mistakes; axe verifies the composed UI after Ionic, portals,
 // and client-side routing have rendered.
 const HIGH_IMPACT_LEVELS = new Set(['serious', 'critical']);
+
+// Scan explicitly against WCAG 2.0/2.1/2.2 A+AA (plus axe best-practices) so
+// the report surfaces WCAG 2.2-specific rules (e.g. target-size) instead of
+// axe's narrower defaults.
+const WCAG_TAGS = [
+    'wcag2a',
+    'wcag2aa',
+    'wcag21a',
+    'wcag21aa',
+    'wcag22a',
+    'wcag22aa',
+    'best-practice',
+];
 const FOCUS_RESET_SENTINEL_ID = 'playwright-a11y-focus-reset';
 
 /**
@@ -101,20 +114,21 @@ const assertNoHighImpactViolations = async (
         await Promise.allSettled(transientAnimations.map(animation => animation.finished));
     });
 
-    const results = await new AxeBuilder({ page }).analyze();
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
     const violations = results.violations.filter(
         violation => violation.impact && HIGH_IMPACT_LEVELS.has(violation.impact)
     );
 
-    if (violations.length > 0) {
+    if (results.violations.length > 0) {
         await testInfo.attach(axeAttachmentName(checkpoint), {
             body: JSON.stringify(
                 {
                     checkpoint,
                     url: page.url(),
-                    violations: violations.map(violation => ({
+                    violations: results.violations.map(violation => ({
                         id: violation.id,
                         impact: violation.impact,
+                        tags: violation.tags,
                         help: violation.help,
                         description: violation.description,
                         helpUrl: violation.helpUrl,

--- a/apps/learn-card-app/tests/accessibility.spec.ts
+++ b/apps/learn-card-app/tests/accessibility.spec.ts
@@ -10,6 +10,13 @@ import { TEST_CREDENTIAL_TITLE, waitForAuthenticatedState } from './test.helpers
 // catch authoring mistakes; axe verifies the composed UI after Ionic, portals,
 // and client-side routing have rendered.
 const HIGH_IMPACT_LEVELS = new Set(['serious', 'critical']);
+const REQUIRED_RULES: Record<string, true> = {
+    'meta-viewport': true,
+    'landmark-no-duplicate-main': true,
+    'landmark-one-main': true,
+    'landmark-main-is-top-level': true,
+    'landmark-unique': true,
+};
 
 // Scan explicitly against WCAG 2.0/2.1/2.2 A+AA (plus axe best-practices) so
 // the report surfaces WCAG 2.2-specific rules (e.g. target-size) instead of
@@ -78,11 +85,11 @@ const axeAttachmentName = (checkpoint: string): string =>
     `axe-${checkpoint.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.json`;
 
 /**
- * Axe reports all impacts, but this rollout gates only serious and critical
- * violations. On failure, attach the actionable DOM targets to the test report
- * rather than making maintainers reproduce the page state to inspect them.
+ * Axe reports all impacts. The rollout gates serious and critical violations,
+ * plus the viewport and main-landmark rules that LC-2169 must keep at zero.
+ * On failure, attach actionable DOM targets to the test report.
  */
-const assertNoHighImpactViolations = async (
+const assertNoGatedViolations = async (
     page: Page,
     testInfo: TestInfo,
     checkpoint: string
@@ -115,8 +122,26 @@ const assertNoHighImpactViolations = async (
     });
 
     const results = await new AxeBuilder({ page }).withTags(AXE_SCAN_TAGS).analyze();
+    const evaluatedRuleIds = new Set(
+        [
+            ...results.passes,
+            ...results.incomplete,
+            ...results.violations,
+            ...results.inapplicable,
+        ].map(result => result.id)
+    );
+    const missingRequiredRules = Object.keys(REQUIRED_RULES).filter(
+        ruleId => !evaluatedRuleIds.has(ruleId)
+    );
+
+    expect(
+        missingRequiredRules,
+        `Expected every gated axe rule to run at "${checkpoint}" on ${page.url()}.`
+    ).toEqual([]);
     const violations = results.violations.filter(
-        violation => violation.impact && HIGH_IMPACT_LEVELS.has(violation.impact)
+        violation =>
+            Object.hasOwn(REQUIRED_RULES, violation.id) ||
+            (violation.impact && HIGH_IMPACT_LEVELS.has(violation.impact))
     );
 
     if (results.violations.length > 0) {
@@ -164,7 +189,7 @@ const assertNoHighImpactViolations = async (
 
     expect(
         violations.length,
-        `Expected no serious or critical axe violations at "${checkpoint}" on ${page.url()}.${
+        `Expected no gated axe violations at "${checkpoint}" on ${page.url()}.${
             summary ? `\n${summary}` : ''
         }`
     ).toBe(0);
@@ -457,7 +482,7 @@ test.describe('Sign-in and onboarding accessibility', () => {
         const emailInput = page.getByRole('textbox', { name: /email/i });
         const signInButton = page.getByRole('button', { name: /sign in with email/i });
         await expect(emailInput).toBeVisible({ timeout: 30_000 });
-        await assertNoHighImpactViolations(page, testInfo, 'sign-in');
+        await assertNoGatedViolations(page, testInfo, 'sign-in');
 
         await focusWithVisibleIndicator(page, emailInput);
         // The demo shortcut lower-cases its comparison but derives the account
@@ -472,7 +497,7 @@ test.describe('Sign-in and onboarding accessibility', () => {
 
         await expect(welcomeHeading).toBeVisible({ timeout: 30_000 });
 
-        await assertNoHighImpactViolations(page, testInfo, 'onboarding-age-and-country');
+        await assertNoGatedViolations(page, testInfo, 'onboarding-age-and-country');
 
         const monthPicker = page.getByRole('listbox', { name: 'Month' });
         await focusWithVisibleIndicator(page, monthPicker);
@@ -487,7 +512,7 @@ test.describe('Sign-in and onboarding accessibility', () => {
         const countrySearch = page.getByPlaceholder('Search countries');
         await expect(countryDialog).toBeVisible({ timeout: 30_000 });
         await expect(countrySearch).toBeVisible({ timeout: 30_000 });
-        await assertNoHighImpactViolations(page, testInfo, 'onboarding-country-dialog');
+        await assertNoGatedViolations(page, testInfo, 'onboarding-country-dialog');
         await focusWithVisibleIndicator(page, countrySearch);
         await page.keyboard.type('United States');
 
@@ -518,19 +543,19 @@ test.describe('Sign-in and onboarding accessibility', () => {
             name: 'Create my LearnCard',
         });
         await expect(createAccountButton).toBeEnabled({ timeout: 30_000 });
-        await assertNoHighImpactViolations(page, testInfo, 'onboarding-profile');
+        await assertNoGatedViolations(page, testInfo, 'onboarding-profile');
         await activateWithKeyboard(page, createAccountButton, 'Enter');
 
         await expect(page.getByRole('heading', { name: "You're in!" })).toBeVisible({
             timeout: 90_000,
         });
-        await assertNoHighImpactViolations(page, testInfo, 'onboarding-complete');
+        await assertNoGatedViolations(page, testInfo, 'onboarding-complete');
 
         const exploreButton = page.getByRole('button', { name: 'Explore LearnCard' });
         await activateWithKeyboard(page, exploreButton, 'Enter');
         await page.waitForURL(/\/dashboard/, { timeout: 30_000 });
         await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
-        await assertNoHighImpactViolations(page, testInfo, 'post-onboarding-dashboard');
+        await assertNoGatedViolations(page, testInfo, 'post-onboarding-dashboard');
     });
 });
 
@@ -558,7 +583,7 @@ test.describe('Authenticated core-page accessibility', () => {
         await expect(skipLink).toBeVisible();
         await page.keyboard.press('Enter');
         await expect(page.locator('#main')).toBeFocused();
-        await assertNoHighImpactViolations(page, testInfo, 'dashboard-home');
+        await assertNoGatedViolations(page, testInfo, 'dashboard-home');
         await assertTransformMotionIsDisabled(page);
 
         await page.goto('/wallet');
@@ -567,12 +592,12 @@ test.describe('Authenticated core-page accessibility', () => {
         });
         const badgesCategory = page.getByRole('button', { name: /Badges/i });
         await expect(badgesCategory).toBeVisible({ timeout: 30_000 });
-        await assertNoHighImpactViolations(page, testInfo, 'wallet-home');
+        await assertNoGatedViolations(page, testInfo, 'wallet-home');
 
         await activateWithKeyboard(page, badgesCategory, 'Space');
         await page.waitForURL(/\/socialBadges/, { timeout: 30_000 });
         await expect(page.getByText('Earned', { exact: true })).toBeVisible({ timeout: 30_000 });
-        await assertNoHighImpactViolations(page, testInfo, 'wallet-badges-category');
+        await assertNoGatedViolations(page, testInfo, 'wallet-badges-category');
 
         const earnedTab = page.getByRole('tab', { name: 'Earned', exact: true });
         await tabTo(page, earnedTab);
@@ -594,7 +619,7 @@ test.describe('Authenticated core-page accessibility', () => {
         });
         await expect(profileDialog).toBeVisible({ timeout: 30_000 });
         await expect(accountSettingsButton).toBeVisible();
-        await assertNoHighImpactViolations(page, testInfo, 'settings-menu');
+        await assertNoGatedViolations(page, testInfo, 'settings-menu');
 
         await page.keyboard.press('Escape');
         await expect(profileDialog).toBeHidden();
@@ -605,17 +630,54 @@ test.describe('Authenticated core-page accessibility', () => {
         await activateWithKeyboard(page, accountSettingsButton, 'Enter');
         await expect(page.locator('form').last()).toBeVisible({ timeout: 30_000 });
         await expect(page.getByRole('textbox', { name: /full name/i })).toBeVisible();
-        await assertNoHighImpactViolations(page, testInfo, 'account-settings');
+        await assertNoGatedViolations(page, testInfo, 'account-settings');
 
         await page.goto('/privacy-and-data');
         await expect(page.getByText('Your data is yours', { exact: true })).toBeVisible({
             timeout: 30_000,
         });
-        await assertNoHighImpactViolations(page, testInfo, 'privacy-settings');
+        await assertNoGatedViolations(page, testInfo, 'privacy-settings');
 
         const showEmailSwitch = page.getByRole('switch', { name: /show email/i });
         await tabTo(page, showEmailSwitch);
         await expect(showEmailSwitch).toBeFocused();
+    });
+});
+
+test.describe('Public page accessibility', () => {
+    test('legal and hidden utility pages have one main landmark', async ({ page }, testInfo) => {
+        await configureLocalE2EServices(page);
+
+        await page.goto('/legal/terms');
+        await expect(
+            page.getByRole('heading', { name: /Terms of Service$/, level: 1 })
+        ).toBeVisible({ timeout: 30_000 });
+        await assertNoGatedViolations(page, testInfo, 'legal-terms');
+
+        await page.goto('/legal/privacy');
+        await expect(page.getByRole('heading', { name: /Privacy Policy$/, level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        await assertNoGatedViolations(page, testInfo, 'legal-privacy');
+
+        await page.goto('/hidden/custom-wallet');
+        await expect(page.getByText('Hello, please enter a seed lol')).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(page.locator('main')).toHaveCount(1);
+        await assertNoGatedViolations(page, testInfo, 'custom-wallet');
+
+        await page.getByRole('button', { name: 'Create Wallet' }).click();
+        await expect(page.getByText('What would you like to do?', { exact: true })).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(page.locator('main')).toHaveCount(1);
+        await assertNoGatedViolations(page, testInfo, 'custom-wallet-main');
+
+        await page.getByRole('button', { name: 'Manage LCN Account' }).click();
+        await expect(page.getByRole('button', { name: '< Back' })).toBeVisible();
+        await expect(page.locator('main')).toHaveCount(1);
+        await assertNoGatedViolations(page, testInfo, 'custom-wallet-manage-account');
     });
 });
 
@@ -768,18 +830,14 @@ test.describe('Credential lifecycle accessibility', () => {
                 await expect(
                     recipientPage.getByRole('heading', { name: TEST_CREDENTIAL_TITLE, exact: true })
                 ).toBeVisible({ timeout: 30_000 });
-                await assertNoHighImpactViolations(recipientPage, testInfo, 'claim-link');
+                await assertNoGatedViolations(recipientPage, testInfo, 'claim-link');
 
                 const acceptButton = recipientPage.getByRole('button', {
                     name: 'Accept',
                     exact: true,
                 });
                 await expect(acceptButton).toBeVisible({ timeout: 30_000 });
-                await assertNoHighImpactViolations(
-                    recipientPage,
-                    testInfo,
-                    'claim-credential-preview'
-                );
+                await assertNoGatedViolations(recipientPage, testInfo, 'claim-credential-preview');
 
                 // The success toast is intentionally brief and can disappear while
                 // Playwright waits for the post-claim render. The route transition is
@@ -846,7 +904,7 @@ test.describe('Credential lifecycle accessibility', () => {
                             .join('\n')}`
                     );
                 }
-                await assertNoHighImpactViolations(recipientPage, testInfo, 'claim-success');
+                await assertNoGatedViolations(recipientPage, testInfo, 'claim-success');
 
                 await recipientPage.goto('/wallet');
                 const badgesCategory = recipientPage.getByRole('button', { name: /Badges/i });
@@ -866,7 +924,7 @@ test.describe('Credential lifecycle accessibility', () => {
                 await expect(recipientPage.locator('.issued-by').first()).toBeVisible({
                     timeout: 30_000,
                 });
-                await assertNoHighImpactViolations(recipientPage, testInfo, 'credential-detail');
+                await assertNoGatedViolations(recipientPage, testInfo, 'credential-detail');
 
                 const shareButton = recipientPage.getByRole('button', {
                     name: 'Share',
@@ -876,7 +934,7 @@ test.describe('Credential lifecycle accessibility', () => {
 
                 const copyLinkButton = recipientPage.getByRole('button', { name: 'Copy Link' });
                 await expect(copyLinkButton).toBeVisible({ timeout: 60_000 });
-                await assertNoHighImpactViolations(recipientPage, testInfo, 'share-credential');
+                await assertNoGatedViolations(recipientPage, testInfo, 'share-credential');
                 await activateWithKeyboard(recipientPage, copyLinkButton, 'Enter');
                 await expect(recipientPage.getByText(/share link copied/i)).toBeVisible({
                     timeout: 30_000,


### PR DESCRIPTION
## What

Widens the axe scan in the journey-level accessibility suite (`apps/learn-card-app/tests/accessibility.spec.ts`):

- `AxeBuilder` now runs with explicit tags: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22a`, `wcag22aa`, `best-practice` — surfacing WCAG 2.2-specific rules (e.g. `target-size`) instead of axe's narrower defaults.
- The per-checkpoint `axe-*.json` report attachments now include **all** violations (every impact level) plus each violation's WCAG tags, instead of only serious/critical.
- The pass/fail gate is unchanged: tests still fail only on serious/critical violations, so CI policy is not affected.

## Why

We had no explicit WCAG 2.2 coverage and moderate/minor violations were invisible. With this change, one full run (12 checkpoints, Firefox desktop) surfaced:

| Rule | Impact | WCAG | Scope |
|---|---|---|---|
| `meta-viewport` (`user-scalable=no, maximum-scale=1.0`) | moderate | **AA — 1.4.4 Resize Text** | all 12 checkpoints |
| `landmark-no-duplicate-main` / `landmark-main-is-top-level` / `landmark-unique` | moderate | best-practice | 6 pages (Ionic `ion-content role="main"` nested inside `<main id="main">`) |
| `landmark-banner-is-top-level` | moderate | best-practice | badges page |
| `aria-allowed-role` (`role="dialog"` on `<aside>`) | minor | best-practice | 6 modal pages |

Notably, `target-size` (WCAG 2.2 §2.5.8) reported zero violations on the scanned desktop-viewport journeys.

## Test

`bun run test:a11y` — 2 passed, 1 skipped (pre-existing descoped credential-lifecycle test), 3.1m.



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Improve accessibility compliance by implementing explicit WCAG 2.0/2.1/2.2 A+AA scanning and fixing landmark/viewport violations.

Main changes:
- Updated `accessibility.spec.ts` to use explicit WCAG tags and gated landmark rules
- Replaced multiple `<main>` tags with `<div>` to ensure one landmark per page
- Implemented `applyNativeViewportRestrictions` to allow web zoom while restricting native app scaling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

