### PR TITLE
fix(ci): allow pnpm Lambda packaging in Bun workspaces

### DIFF
--- a/.github/tests/test-workflow-contract.test.sh
+++ b/.github/tests/test-workflow-contract.test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-ruby - "$REPO_ROOT/.github/workflows/test.yml" "$REPO_ROOT/.github/workflows/lint.yml" "$REPO_ROOT/scripts/lint-workspace.ts" <<'RUBY'
+ruby - "$REPO_ROOT/.github/workflows/test.yml" "$REPO_ROOT/.github/workflows/lint.yml" "$REPO_ROOT/scripts/lint-workspace.ts" "$REPO_ROOT/.github/workflows/deploy.yml" <<'RUBY'
 require 'yaml'
 
 workflow = YAML.load_file(ARGV.fetch(0), aliases: true)
@@ -59,6 +59,28 @@ abort 'CI must discover every shell contract' unless contract_script.include?(
 abort 'CI must execute each shell contract with Bash' unless contract_script.include?(
     'bash "$contract"'
 )
+
+deploy_workflow = YAML.load_file(ARGV.fetch(3), aliases: true)
+deploy_jobs = deploy_workflow.fetch('jobs')
+
+{
+    'deploy-brain-service' => 'Deploy Brain Service Lambda',
+    'deploy-learn-cloud' => 'Deploy LearnCloud Lambda',
+    'deploy-lca-api' => 'Deploy LCA API Service Lambda',
+}.each do |job_name, step_name|
+    deploy_step = deploy_jobs.fetch(job_name).fetch('steps').find do |step|
+        step['name'] == step_name
+    end
+    abort "#{step_name} step missing" unless deploy_step
+
+    deploy_env = deploy_step.fetch('env')
+    abort "#{step_name} must disable pnpm package-manager strictness" unless deploy_env[
+        'COREPACK_ENABLE_STRICT'
+    ] == '0'
+    abort "#{step_name} uses an unsupported pnpm config environment variable" if deploy_env.key?(
+        'PNPM_CONFIG_PACKAGE_MANAGER_STRICT'
+    )
+end
 RUBY
 
 echo 'LearnCard E2E workflow contract passed'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -439,7 +439,7 @@ jobs:
             - name: Deploy Brain Service Lambda
               run: bunx nx serverless-deploy network-brain-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
-                  PNPM_CONFIG_PACKAGE_MANAGER_STRICT: 'false'
+                  COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_DEFAULT_REGION: us-east-1
@@ -560,7 +560,7 @@ jobs:
             - name: Deploy LearnCloud Lambda
               run: bunx nx serverless-deploy learn-cloud-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
-                  PNPM_CONFIG_PACKAGE_MANAGER_STRICT: 'false'
+                  COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_DEFAULT_REGION: us-east-1
@@ -661,7 +661,7 @@ jobs:
             - name: Deploy LCA API Service Lambda
               run: bunx nx serverless-deploy lca-api-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
-                  PNPM_CONFIG_PACKAGE_MANAGER_STRICT: 'false'
+                  COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -439,6 +439,7 @@ jobs:
             - name: Deploy Brain Service Lambda
               run: bunx nx serverless-deploy network-brain-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
+                  # serverless-esbuild invokes pnpm despite the Bun packageManager; remove once that boundary is gone.
                   COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -560,6 +561,7 @@ jobs:
             - name: Deploy LearnCloud Lambda
               run: bunx nx serverless-deploy learn-cloud-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
+                  # serverless-esbuild invokes pnpm despite the Bun packageManager; remove once that boundary is gone.
                   COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -661,6 +663,7 @@ jobs:
             - name: Deploy LCA API Service Lambda
               run: bunx nx serverless-deploy lca-api-service --stage ${{ vars.SERVERLESS_STAGE }} --region ${{ vars.SERVERLESS_REGION }}
               env:
+                  # serverless-esbuild invokes pnpm despite the Bun packageManager; remove once that boundary is gone.
                   COREPACK_ENABLE_STRICT: '0'
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Overview

#### 🎟 Relevant Jira Issues

Follow-up to #1505 and deployment run #33783040573.

#### 📚 What is the context and goal of this PR?

After #1505 merged, all six staging Lambda jobs failed before reaching AWS. The backend services now correctly declare `packageManager: "bun@1.3.14"`, while `serverless-esbuild` intentionally continues to use pnpm to inspect/package Lambda externals.

The deploy workflow attempted to allow that mixed-tooling boundary with `PNPM_CONFIG_PACKAGE_MANAGER_STRICT=false`, but pnpm 9.12.3 does not recognize that environment-variable name. Once esbuild and the Sentry source-map uploads completed, `serverless-esbuild` ran `pnpm ls --prod --json` from each service directory and pnpm rejected the Bun declaration:

```text
ERROR This project is configured to use bun
at async Pnpm.getProdDependencies (.../serverless-esbuild/dist/packagers/pnpm.js:32:35)
```

This PR uses pnpm's documented `COREPACK_ENABLE_STRICT=0` compatibility override for the three Serverless deploy steps and adds a workflow contract that prevents the ineffective variable from returning.

Failed run: https://github.com/learningeconomy/LearnCard/actions/runs/33783040573

#### 🥴 TL; RL:

Lambda compilation was healthy; pnpm's package-manager guard stopped deployment before AWS. Replace the unrecognized override with the documented one on Brain, LearnCloud, and LCA API deploys.

#### 💡 Feature Breakdown (screenshots & videos encouraged!)

- Replaces `PNPM_CONFIG_PACKAGE_MANAGER_STRICT=false` with `COREPACK_ENABLE_STRICT=0` on all three backend deployment jobs.
- Keeps Bun 1.3.14 as the workspace installer and runner.
- Keeps pnpm 9.12.3 as the `serverless-esbuild` external-module packager.
- Extends the repository workflow contract to require the working override and reject the unsupported one.

#### 🛠 Important tradeoffs made:

The override is scoped only to the deployment commands that intentionally cross from Bun into pnpm. Removing the service-level `packageManager` declarations would hide the intended Bun contract everywhere, while replacing the Serverless packager is a broader migration and is not needed for this incident.

#### 🔍 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt?

- [x] No
- [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?

1. Run `bash .github/tests/test-workflow-contract.test.sh`.
2. With pnpm 9.12.3, run `COREPACK_ENABLE_STRICT=0 pnpm ls --prod --json` from a backend service directory and confirm it succeeds.
3. Dispatch one staging backend deployment and confirm it passes `pnpm ls`, creates the deployment artifacts, and reaches CloudFormation.

Local verification completed:

```text
bash .github/tests/test-workflow-contract.test.sh
LearnCard E2E workflow contract passed

bunx prettier --check .github/workflows/deploy.yml
All matched files use Prettier code style!

COREPACK_ENABLE_STRICT=0 pnpm@9.12.3 ls --prod --json
exit 0

git diff --check
exit 0
```

The contract was first run against the original workflow and failed with:

```text
Deploy Brain Service Lambda must disable pnpm package-manager strictness
```

#### 📱 🖥 Which devices would you like help testing on?

N/A — GitHub Actions deployment configuration only.

#### 🧪 Code Coverage

A repository workflow-contract regression test covers all three affected deployment jobs and rejects the known-bad environment variable.

# Documentation

#### 📝 Documentation Checklist

- [ ] Tutorial
- [ ] How-To Guide
- [ ] Reference
- [ ] Concept
- [ ] App Flows
- [ ] AGENTS.md
- [ ] Code comments/JSDoc
- [ ] Mermaid diagram

#### 💭 Documentation Notes

No user-facing or API documentation is needed; this only repairs internal deployment orchestration. The incident analysis and operational QA are documented in this PR.

# ✅ PR Checklist

- [ ] Related to a Jira issue
- [x] My code follows **style guidelines** (eslint / prettier)
- [ ] I have **manually tested** common end-2-end cases
- [x] I have **reviewed** my code
- [x] I have **commented** my code, particularly where ambiguous
- [x] New and existing **unit tests pass** locally with my changes
- [x] I have completed the **Documentation Checklist** above (or explained why N/A)
- [x] I have considered **product analytics** for user-facing features (N/A)

### 🚀 Ready to squash-and-merge?:

- [x] Code is backwards compatible
- [x] There is **not** a "Do Not Merge" label on this PR
- [x] I have thoughtfully considered the security implications of this change
- [x] This change does not expose new public-facing endpoints




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix pnpm packaging failures in Bun workspaces by disabling Corepack strict mode during Lambda deployments.

Main changes:
- Replaced PNPM_CONFIG_PACKAGE_MANAGER_STRICT with COREPACK_ENABLE_STRICT: '0' in deployment workflow environment
- Updated test-workflow-contract.test.sh to validate COREPACK_ENABLE_STRICT presence across deployment jobs
- Added regression tests to ensure unsupported pnpm config variables are not used

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
