### PR TITLE
[Hotfix] Allow "false" for NOTIFICATIONS_SERVICE_WEBHOOK_URL

### DIFF
--- a/.changeset/full-rivers-sell.md
+++ b/.changeset/full-rivers-sell.md
@@ -1,0 +1,5 @@
+---
+"@learncard/network-brain-service": patch
+---
+
+[Hotfix] Allow "false" for NOTIFICATIONS_SERVICE_WEBHOOK_URL

--- a/services/learn-card-network/brain-service/src/config/environment.ts
+++ b/services/learn-card-network/brain-service/src/config/environment.ts
@@ -32,7 +32,7 @@ export const brainServiceEnvironmentShape = {
     AWS_REGION: optionalEnvironmentString,
     NOTIFICATIONS_QUEUE_URL: optionalEnvironmentUrl,
     NOTIFICATIONS_QUEUE_POLL_URL: optionalEnvironmentUrl,
-    NOTIFICATIONS_SERVICE_WEBHOOK_URL: optionalEnvironmentUrl,
+    NOTIFICATIONS_SERVICE_WEBHOOK_URL: optionalEnvironmentUrl.or(z.literal('false')),
     NOTIFICATIONS_SERVICE_PORT: optionalEnvironmentPort,
     BRAIN_SERVICE_REGISTRY_URL: optionalEnvironmentUrl,
     DCC_KNOWN_REGISTRIES_URL: optionalEnvironmentUrl,


### PR DESCRIPTION
Oh look! A wild 100% human done PR! Haven't seen one of these in a while O.O

# Overview

#### 🎟 Relevant Jira Issues
None
<!--- Example: Fixes: WE-53, Related to: WE-308 -->

#### 📚 What is the context and goal of this PR?
In the [LC-1984] PR (#1505), I made the brain service fail fast if it had invalid config. This broke staging because it was
(correctly) passing `false` for  the `NOTIFICATIONS_WEBHOOK_SERVICE_URL` env variable. This PR lets it do that, because it's a valid value!

#### 🥴 TL; RL:
False is okay

#### 💡 Feature Breakdown (screenshots & videos encouraged!)
Let's false be okay

#### 🛠 Important tradeoffs made:
False is okay now

#### 🔍 Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Chore (refactor, documentation update, etc)

#### 💳 Does This Create Any New Technical Debt? ( If yes, please describe and [add JIRA TODOs](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2) )

-   [x] No
-   [ ] Yes

# Testing

#### 🔬 How Can Someone QA This?
Run the brain service with false as you NOTIFICATIONS_WEBHOOK_SERVICE_URL
<!--- Please add QA steps someone can follow in order to verify this works. -->

#### 📱 🖥 Which devices would you like help testing on?

<!-- iOS Simulator / Android Simulator / iOS Native / Android Native / Chromium / Safari / Firefox / Opera / Brave / Edge / Tablet  -->

#### 🧪 Code Coverage

<!-- What kind of tests did you or did you not write and why (unit, functional, integration, e2e)?-->

# Documentation

<!--
Quick guide: What docs does your change need?
- New API/feature → Tutorial or How-To in docs/
- Complex flow/architecture → Mermaid diagram
- Internal patterns for AI/devs → AGENTS.md
- App UI/UX changes → docs/apps/ (LearnCard App, ScoutPass)
-->

#### 📝 Documentation Checklist

<!-- Check all that apply. If none, explain why in the notes below. -->

**User-Facing Docs** (`docs/` → [docs.learncard.com](https://docs.learncard.com))

-   [ ] **Tutorial** — New capability that users need to learn (`docs/tutorials/`)
-   [ ] **How-To Guide** — New workflow or integration (`docs/how-to-guides/`)
-   [ ] **Reference** — New/changed API, config, or SDK method (`docs/sdks/`)
-   [ ] **Concept** — New mental model or architecture explanation (`docs/core-concepts/`)
-   [ ] **App Flows** — Changes to LearnCard App or ScoutPass user flows (`docs/apps/`)

**Internal/AI Docs**

-   [ ] **AGENTS.md** — New pattern, flow, or context that AI assistants need
-   [ ] **Code comments/JSDoc** — Complex logic that needs inline explanation

**Visual Documentation**

-   [ ] **Mermaid diagram** — Complex flow, state machine, or architecture
<!-- Add diagrams inline in docs or in a dedicated section.-->

#### 💭 Documentation Notes

<!-- If no docs needed, briefly explain why (e.g., "Internal refactor, no API changes") -->

# ✅ PR Checklist

-   [ ] Related to a Jira issue ([create one if not](https://welibrary.atlassian.net/jira/software/projects/WE/boards/2))
-   [x] My code follows **style guidelines** (eslint / prettier)
-   [x] I have **manually tested** common end-2-end cases
-   [x] I have **reviewed** my code
-   [ ] I have **commented** my code, particularly where ambiguous
-   [x] New and existing **unit tests pass** locally with my changes
-   [x] I have completed the **Documentation Checklist** above (or explained why N/A)
-   [x] I have considered **product analytics** for user-facing features (use `@analytics` in learn-card-app)

### 🚀 Ready to squash-and-merge?:

-   [x] Code is backwards compatible
-   [x] There is **not** a "Do Not Merge" label on this PR
-   [x] I have thoughtfully considered the security implications of this change.
-   [x] This change does not expose new public facing endpoints that do not have authentication


[LC-1984]: https://welibrary.atlassian.net/browse/LC-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update environment configuration in brain-service to permit a literal "false" value for the NOTIFICATIONS_SERVICE_WEBHOOK_URL setting.

Main changes:
- Modified brainServiceEnvironmentShape to allow z.literal('false') for NOTIFICATIONS_SERVICE_WEBHOOK_URL
- Added a patch changeset for @learncard/network-brain-service

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
