### PR TITLE
fix: native apps fail to boot with "TenantConfig endpoint /__tenant-config returned invalid JSON"

### DIFF
--- a/.changeset/native-tenant-config-boot.md
+++ b/.changeset/native-tenant-config-boot.md
@@ -1,0 +1,8 @@
+---
+"learn-card-app": patch
+"learn-card-base": patch
+---
+
+fix: native apps no longer fail to boot with "TenantConfig endpoint /__tenant-config returned invalid JSON"
+
+Native builds skip the relative `/__tenant-config` overlay fetch (it only exists as a web edge function; Capacitor SPA-fallbacks it to `index.html` with HTTP 200) and boot from the baked config. As a safety net, `resolveTenantConfig` now treats a non-JSON overlay response as non-fatal whenever a baked config exists.

--- a/apps/learn-card-app/src/config/bootstrapTenantConfig.ts
+++ b/apps/learn-card-app/src/config/bootstrapTenantConfig.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Sentry from '@sentry/browser';
+import { Capacitor } from '@capacitor/core';
 
 import type { TenantConfig } from 'learn-card-base';
 import {
@@ -248,7 +249,14 @@ export const bootstrapTenantConfig = async (): Promise<TenantConfig> => {
     bootstrapState.bootstrapPromise = (async () => {
         const t0 = Date.now();
 
-        const config = bootstrapState.resolvedConfig ?? (await resolveTenantConfig({ onEvent }));
+        // The `/__tenant-config` overlay is a Netlify edge function that only exists on
+        // web origins. Native webviews (capacitor://localhost) have no such route and
+        // SPA-fallback it to index.html, so native boots from the baked config only.
+        const isNative = Capacitor.isNativePlatform();
+
+        const config =
+            bootstrapState.resolvedConfig ??
+            (await resolveTenantConfig({ onEvent, offlineOnly: isNative }));
 
         setResolvedTenantConfig(config);
         initializeTenantSubsystems(config);

--- a/packages/learn-card-base/src/config/__tests__/resolveTenantConfig.test.ts
+++ b/packages/learn-card-base/src/config/__tests__/resolveTenantConfig.test.ts
@@ -128,6 +128,46 @@ describe('resolveTenantConfig – full boot path', () => {
         expect(result.tenantId).toBe('baked');
     });
 
+    it('falls back to baked config when /__tenant-config returns HTTP 200 with non-JSON (native SPA fallback)', async () => {
+        const bakedConfig = buildFullConfig({ tenantId: 'baked' });
+
+        fetchMock.mockImplementation(async (url: string) => {
+            if (typeof url === 'string' && url.includes('tenant-config.json')) {
+                return { ok: true, json: async () => bakedConfig };
+            }
+
+            return {
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new SyntaxError('Unexpected token <');
+                },
+            };
+        });
+
+        const result = await resolveTenantConfig();
+
+        expect(result.tenantId).toBe('baked');
+    });
+
+    it('rejects non-JSON /__tenant-config response when no baked config exists', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (typeof url === 'string' && url.includes('tenant-config.json')) {
+                return { ok: false, status: 404 };
+            }
+
+            return {
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new SyntaxError('Unexpected token <');
+                },
+            };
+        });
+
+        await expect(resolveTenantConfig()).rejects.toThrow(/returned invalid JSON/);
+    });
+
     it('prefers fresh edge-function config over baked config', async () => {
         const bakedConfig = buildFullConfig({ tenantId: 'baked' });
         const freshConfig = buildFullConfig({ tenantId: 'fresh-edge' });

--- a/packages/learn-card-base/src/config/resolveTenantConfig.ts
+++ b/packages/learn-card-base/src/config/resolveTenantConfig.ts
@@ -252,6 +252,19 @@ const fetchFreshConfig = async (
         try {
             raw = await response.json();
         } catch {
+            // A baked config exists (native builds), so a bad response from the
+            // overlay endpoint is non-fatal — e.g. the Capacitor asset server
+            // SPA-fallbacks unknown paths to index.html with HTTP 200.
+            if (mergeBase) {
+                const message = `TenantConfig endpoint ${url} returned invalid JSON`;
+
+                log.warn(`[TenantConfig] ${message} — using baked config`);
+                onEvent?.('config:fetch_error', message, { url, durationMs });
+                _onFetchFailure?.({ endpoint: url, error: message });
+
+                return null;
+            }
+
             throw new TenantConfigResolutionError(
                 `TenantConfig endpoint ${url} returned invalid JSON`
             );


### PR DESCRIPTION
## Problem

Every native cold start on the current production Capgo bundle shows the **Configuration error** screen:

> TenantConfig endpoint /__tenant-config returned invalid JSON

### Root cause

`resolveTenantConfig()` on native does a relative `fetch('/__tenant-config')` against the Capacitor webview origin. That route only exists as a Netlify edge function on web; Capacitor's asset server SPA-fallbacks unknown paths to `index.html` with **HTTP 200**, so `response.ok` is true and `response.json()` fails.

Before #1505 (`c7bbf6e9e`, LC-1984) that parse failure hit the generic `catch → return null` and resolution fell through to the baked `public/tenant-config.json`. #1505 changed it to throw a `TenantConfigResolutionError`, which is explicitly rethrown past the baked/cache fallbacks and lands on `renderConfigurationError`. The first production deploy carrying that change was `chore(release): version packages (#1561)` on Sep 10, which is when the OTA bundle went out.

## Fix

1. **`bootstrapTenantConfig.ts`** — pass `offlineOnly: Capacitor.isNativePlatform()` so native never attempts the relative overlay fetch and boots from the baked config (the behavior it effectively had before).
2. **`resolveTenantConfig.ts`** (safety net) — when a baked `mergeBase` exists, a non-JSON overlay response is non-fatal: `log.warn`, `config:fetch_error` debug event, Sentry `onFetchFailure` breadcrumb, then fall back to baked. Web with no baked config still throws as before.

## Tests

- `resolveTenantConfig.test.ts`: baked config + HTML-200 overlay → resolves to baked
- `resolveTenantConfig.test.ts`: no baked config + HTML-200 overlay → still throws `returned invalid JSON`
- 13/13 passing

## Rollout note

Ships via the next production deploy → Capgo OTA. Users on the broken bundle keep hitting the error on cold start until then; rolling the Capgo prod channel back to the pre-#1561 bundle is the only immediate mitigation.



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Prevent native app boot failures caused by invalid JSON responses from the `/__tenant-config` endpoint.

Main changes:
- Updated `bootstrapTenantConfig` to pass `offlineOnly` flag when `Capacitor.isNativePlatform()` is true
- Modified `resolveTenantConfig` to treat invalid JSON as non-fatal if a baked config exists
- Added test cases for fallback behavior and rejection when no baked config is present

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

